### PR TITLE
Added login authentication configuration

### DIFF
--- a/docs/en-us/sdk.md
+++ b/docs/en-us/sdk.md
@@ -96,6 +96,18 @@ public String getConfig(String dataId, String group, long timeoutMs) throws Naco
 | :--- | :--- |
 | string | configuration value |
 
+#### Added login authentication configuration
+
+By default, no login is required to start following the official document configuration, which can expose the configuration center directly to the outside world.
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=false
+```
+Therefore, to enable authentication, use nacos by configuring the user name and password
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=true
+```
 
 #### Request example
 
@@ -107,6 +119,11 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
+
+        // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
+
 	ConfigService configService = NacosFactory.createConfigService(properties);
     // Actively get the configuration.
 	String content = configService.getConfig(dataId, group, 5000);
@@ -206,6 +223,11 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
+
+// if need username and password to login
+properties.put("username","nacos");
+properties.put("password","nacos");
+
 ConfigService configService = NacosFactory.createConfigService(properties);
 String content = configService.getConfig(dataId, group, 5000);
 System.out.println(content);
@@ -306,6 +328,11 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
+
+// if need username and password to login
+properties.put("username","nacos");
+properties.put("password","nacos");
+
 ConfigService configService = NacosFactory.createConfigService(properties);
 configService.removeListener(dataId, group, yourListener);
 ```
@@ -347,6 +374,11 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
+
+        // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
+
     ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isPublishOk = configService.publishConfig(dataId, group, "content");
 	System.out.println(isPublishOk);
@@ -400,6 +432,10 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
+
+        // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
 
 	ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isRemoveOk = configService.removeConfig(dataId, group);

--- a/docs/en-us/sdk.md
+++ b/docs/en-us/sdk.md
@@ -96,18 +96,6 @@ public String getConfig(String dataId, String group, long timeoutMs) throws Naco
 | :--- | :--- |
 | string | configuration value |
 
-#### Added login authentication configuration
-
-By default, no login is required to start following the official document configuration, which can expose the configuration center directly to the outside world.
-```java
-### If turn on auth system:
-nacos.core.auth.enabled=false
-```
-Therefore, to enable authentication, use nacos by configuring the user name and password
-```java
-### If turn on auth system:
-nacos.core.auth.enabled=true
-```
 
 #### Request example
 
@@ -119,11 +107,6 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
-
-        // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
-
 	ConfigService configService = NacosFactory.createConfigService(properties);
     // Actively get the configuration.
 	String content = configService.getConfig(dataId, group, 5000);
@@ -223,11 +206,6 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
-
-// if need username and password to login
-properties.put("username","nacos");
-properties.put("password","nacos");
-
 ConfigService configService = NacosFactory.createConfigService(properties);
 String content = configService.getConfig(dataId, group, 5000);
 System.out.println(content);
@@ -328,11 +306,6 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
-
-// if need username and password to login
-properties.put("username","nacos");
-properties.put("password","nacos");
-
 ConfigService configService = NacosFactory.createConfigService(properties);
 configService.removeListener(dataId, group, yourListener);
 ```
@@ -374,11 +347,6 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
-
-        // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
-
     ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isPublishOk = configService.publishConfig(dataId, group, "content");
 	System.out.println(isPublishOk);
@@ -432,10 +400,6 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
-
-        // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
 
 	ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isRemoveOk = configService.removeConfig(dataId, group);
@@ -668,4 +632,35 @@ void
 ```java
 NamingService naming = NamingFactory.createNamingService(System.getProperty("serveAddr"));
 naming.unsubscribe("nacos.test.3", event -> {});
+```
+
+### Use Authentication Configuration
+#### Description
+By default, no login is required to start following the official document configuration, which can expose the configuration center directly to the outside world.
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=false
+```
+Therefore, to enable authentication, use nacos by configuring the user name and password.
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=true
+```
+#### Example Code
+```java
+try {
+    // Initialize the configuration service, and the console automatically obtains the following parameters through the sample code.
+	String serverAddr = "{serverAddr}";
+	Properties properties = new Properties();
+	properties.put("serverAddr", serverAddr);
+
+    // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
+
+	ConfigService configService = NacosFactory.createConfigService(properties);
+} catch (NacosException e) {
+    // TODO Auto-generated catch block
+    e.printStackTrace();
+}
 ```

--- a/docs/zh-cn/sdk.md
+++ b/docs/zh-cn/sdk.md
@@ -41,18 +41,6 @@ public String getConfig(String dataId, String group, long timeoutMs) throws Naco
 | :--- | :--- |
 | string | 配置值 |
 
-#### 增加登录验证配置
-
-按照官方文档配置启动,默认是不需要登录的，这样会导致配置中心对外直接暴露。
-```java
-### If turn on auth system:
-nacos.core.auth.enabled=false
-```
-因此要启用鉴权，通过配置用户名和密码的方式来使用nacos
-```java
-### If turn on auth system:
-nacos.core.auth.enabled=true
-```
 
 #### 请求示例
 
@@ -63,11 +51,6 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
-
-        // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
-
 	ConfigService configService = NacosFactory.createConfigService(properties);
 	String content = configService.getConfig(dataId, group, 5000);
 	System.out.println(content);
@@ -165,11 +148,6 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
-
-// if need username and password to login
-properties.put("username","nacos");
-properties.put("password","nacos");
-
 ConfigService configService = NacosFactory.createConfigService(properties);
 String content = configService.getConfig(dataId, group, 5000);
 System.out.println(content);
@@ -220,11 +198,6 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
-
-// if need username and password to login
-properties.put("username","nacos");
-properties.put("password","nacos");
-
 ConfigService configService = NacosFactory.createConfigService(properties);
 configService.removeListener(dataId, group, yourListener);
 ```
@@ -267,11 +240,6 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
-
-        // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
-
     ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isPublishOk = configService.publishConfig(dataId, group, "content");
 	System.out.println(isPublishOk);
@@ -323,10 +291,6 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
-
-        // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
 
 	ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isRemoveOk = configService.removeConfig(dataId, group);
@@ -563,4 +527,36 @@ void unsubscribe(String serviceName, List<String> clusters, EventListener listen
 NamingService naming = NamingFactory.createNamingService(System.getProperty("serveAddr"));
 naming.unsubscribe("nacos.test.3", event -> {});
 
+```
+
+### 使用验证配置
+
+#### 描述
+按照官方文档配置启动,默认是不需要登录的，这样会导致配置中心对外直接暴露。
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=false
+```
+因此要启用鉴权，通过配置用户名和密码的方式来使用nacos
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=true
+```
+#### 示例代码
+```java
+try {
+    // Initialize the configuration service, and the console automatically obtains the following parameters through the sample code.
+	String serverAddr = "{serverAddr}";
+	Properties properties = new Properties();
+	properties.put("serverAddr", serverAddr);
+
+    // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
+
+	ConfigService configService = NacosFactory.createConfigService(properties);
+} catch (NacosException e) {
+    // TODO Auto-generated catch block
+    e.printStackTrace();
+}
 ```

--- a/docs/zh-cn/sdk.md
+++ b/docs/zh-cn/sdk.md
@@ -41,6 +41,18 @@ public String getConfig(String dataId, String group, long timeoutMs) throws Naco
 | :--- | :--- |
 | string | 配置值 |
 
+#### 增加登录验证配置
+
+按照官方文档配置启动,默认是不需要登录的，这样会导致配置中心对外直接暴露。
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=false
+```
+因此要启用鉴权，通过配置用户名和密码的方式来使用nacos
+```java
+### If turn on auth system:
+nacos.core.auth.enabled=true
+```
 
 #### 请求示例
 
@@ -51,6 +63,11 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
+
+        // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
+
 	ConfigService configService = NacosFactory.createConfigService(properties);
 	String content = configService.getConfig(dataId, group, 5000);
 	System.out.println(content);
@@ -148,6 +165,11 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
+
+// if need username and password to login
+properties.put("username","nacos");
+properties.put("password","nacos");
+
 ConfigService configService = NacosFactory.createConfigService(properties);
 String content = configService.getConfig(dataId, group, 5000);
 System.out.println(content);
@@ -198,6 +220,11 @@ String dataId = "{dataId}";
 String group = "{group}";
 Properties properties = new Properties();
 properties.put("serverAddr", serverAddr);
+
+// if need username and password to login
+properties.put("username","nacos");
+properties.put("password","nacos");
+
 ConfigService configService = NacosFactory.createConfigService(properties);
 configService.removeListener(dataId, group, yourListener);
 ```
@@ -240,6 +267,11 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
+
+        // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
+
     ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isPublishOk = configService.publishConfig(dataId, group, "content");
 	System.out.println(isPublishOk);
@@ -291,6 +323,10 @@ try {
 	String group = "{group}";
 	Properties properties = new Properties();
 	properties.put("serverAddr", serverAddr);
+
+        // if need username and password to login
+        properties.put("username","nacos");
+        properties.put("password","nacos");
 
 	ConfigService configService = NacosFactory.createConfigService(properties);
 	boolean isRemoveOk = configService.removeConfig(dataId, group);


### PR DESCRIPTION
## What is the purpose of the change

By default, no login is required to start following the official document configuration, which can expose the configuration center directly to the outside world. Therefore, to enable authentication, use nacos by configuring the user name and password

## Brief changelog

### If turn on auth system:
nacos.core.auth.enabled=true

// if need username and password to login
properties.put("username","nacos");
properties.put("password","nacos");

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `docsite start`, and make sure it works as expected.
- [ ] Make sure no files under build directory is added.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
