### PR TITLE
docker-quickstart: set NACOS_VERSION before running docker-compose #231

### DIFF
--- a/docs/en-us/quick-start-docker.md
+++ b/docs/en-us/quick-start-docker.md
@@ -15,6 +15,7 @@ Run the following command：
   ```powershell
   git clone https://github.com/nacos-group/nacos-docker.git
   cd nacos-docker
+  export NACOS_VERSION='{the version of nacos}'
   ```
 
 

--- a/docs/zh-cn/quick-start-docker.md
+++ b/docs/zh-cn/quick-start-docker.md
@@ -13,6 +13,7 @@ description: Nacos Docker 快速开始
   ```powershell
   git clone https://github.com/nacos-group/nacos-docker.git
   cd nacos-docker
+  export NACOS_VERSION='{希望运行的 nacos 版本号}'
   ```
 
 


### PR DESCRIPTION
## What is the purpose of the change
Fix #231.

Follow [nacos docker quick start guide](https://nacos.io/zh-cn/docs/quick-start-docker.html) to run nacos at docker, error is raised:
```shell
WARNING: The NACOS_VERSION variable is not set. Defaulting to a blank string.
Creating network "example_default" with the default driver
ERROR: no such image: nacos/nacos-server:: invalid reference format
```
Through the warning from `docker-compose` can help the user find the cause, but I think `NACOS_VERSION` still needs to be noted in doc first.

## Brief changelog

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
