### PR TITLE
Fixed missing startup parameters causing startup failure

### DIFF
--- a/src/content/docs/latest/en/guide/user/auth.md
+++ b/src/content/docs/latest/en/guide/user/auth.md
@@ -90,7 +90,11 @@ NACOS_AUTH_ENABLE=true
 For example, you can run this command to run a docker container with Authentication:
 
 ```powershell
-docker run --env PREFER_HOST_MODE=hostname --env MODE=standalone --env NACOS_AUTH_ENABLE=true -p 8848:8848 nacos/nacos-server
+docker run --env PREFER_HOST_MODE=hostname \
+  --env MODE=standalone \
+  --env NACOS_AUTH_ENABLE=true \
+  -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -p 8848:8848 nacos/nacos-server
 ```
 
 Besides, you can also add the other related enviroment parameters:

--- a/src/content/docs/latest/en/guide/user/auth.md
+++ b/src/content/docs/latest/en/guide/user/auth.md
@@ -94,6 +94,8 @@ docker run --env PREFER_HOST_MODE=hostname \
   --env MODE=standalone \
   --env NACOS_AUTH_ENABLE=true \
   -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -e NACOS_AUTH_IDENTITY_KEY=mpYGXyu7 \
+  -e NACOS_AUTH_IDENTITY_VALUE=mpYGXyu7 \
   -p 8848:8848 nacos/nacos-server
 ```
 

--- a/src/content/docs/latest/zh-cn/guide/user/auth.md
+++ b/src/content/docs/latest/zh-cn/guide/user/auth.md
@@ -92,7 +92,11 @@ NACOS_AUTH_ENABLE=true
 例如，可以通过如下命令运行开启了鉴权的容器:
 
 ```powershell
-docker run --env PREFER_HOST_MODE=hostname --env MODE=standalone --env NACOS_AUTH_ENABLE=true -p 8848:8848 nacos/nacos-server
+docker run --env PREFER_HOST_MODE=hostname \
+  --env MODE=standalone \
+  --env NACOS_AUTH_ENABLE=true \
+  -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -p 8848:8848 nacos/nacos-server
 ```
 
 除此之外，还可以添加其他鉴权相关的环境变量信息：

--- a/src/content/docs/latest/zh-cn/guide/user/auth.md
+++ b/src/content/docs/latest/zh-cn/guide/user/auth.md
@@ -96,6 +96,8 @@ docker run --env PREFER_HOST_MODE=hostname \
   --env MODE=standalone \
   --env NACOS_AUTH_ENABLE=true \
   -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -e NACOS_AUTH_IDENTITY_KEY=mpYGXyu7 \
+  -e NACOS_AUTH_IDENTITY_VALUE=mpYGXyu7 \
   -p 8848:8848 nacos/nacos-server
 ```
 

--- a/src/content/docs/next/en/guide/user/auth.md
+++ b/src/content/docs/next/en/guide/user/auth.md
@@ -90,7 +90,11 @@ NACOS_AUTH_ENABLE=true
 For example, you can run this command to run a docker container with Authentication:
 
 ```powershell
-docker run --env PREFER_HOST_MODE=hostname --env MODE=standalone --env NACOS_AUTH_ENABLE=true -p 8848:8848 nacos/nacos-server
+docker run --env PREFER_HOST_MODE=hostname \
+  --env MODE=standalone \
+  --env NACOS_AUTH_ENABLE=true \
+  -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -p 8848:8848 nacos/nacos-server
 ```
 
 Besides, you can also add the other related enviroment parameters:

--- a/src/content/docs/next/en/guide/user/auth.md
+++ b/src/content/docs/next/en/guide/user/auth.md
@@ -94,6 +94,8 @@ docker run --env PREFER_HOST_MODE=hostname \
   --env MODE=standalone \
   --env NACOS_AUTH_ENABLE=true \
   -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -e NACOS_AUTH_IDENTITY_KEY=mpYGXyu7 \
+  -e NACOS_AUTH_IDENTITY_VALUE=mpYGXyu7 \
   -p 8848:8848 nacos/nacos-server
 ```
 

--- a/src/content/docs/next/zh-cn/guide/user/auth.md
+++ b/src/content/docs/next/zh-cn/guide/user/auth.md
@@ -92,7 +92,11 @@ NACOS_AUTH_ENABLE=true
 例如，可以通过如下命令运行开启了鉴权的容器:
 
 ```powershell
-docker run --env PREFER_HOST_MODE=hostname --env MODE=standalone --env NACOS_AUTH_ENABLE=true -p 8848:8848 nacos/nacos-server
+docker run --env PREFER_HOST_MODE=hostname \
+  --env MODE=standalone \
+  --env NACOS_AUTH_ENABLE=true \
+  -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -p 8848:8848 nacos/nacos-server
 ```
 
 除此之外，还可以添加其他鉴权相关的环境变量信息：

--- a/src/content/docs/next/zh-cn/guide/user/auth.md
+++ b/src/content/docs/next/zh-cn/guide/user/auth.md
@@ -96,6 +96,8 @@ docker run --env PREFER_HOST_MODE=hostname \
   --env MODE=standalone \
   --env NACOS_AUTH_ENABLE=true \
   -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
+  -e NACOS_AUTH_IDENTITY_KEY=mpYGXyu7 \
+  -e NACOS_AUTH_IDENTITY_VALUE=mpYGXyu7 \
   -p 8848:8848 nacos/nacos-server
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

Fixed missing startup parameters causing startup failure
issue: #614

## Brief changelog
Added the variable parameter NACOS_AUTH_TOKEN required in the docker startup command


Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `npm run build`, and make sure it works as expected.
- [ ] Make sure no files under build directory is added.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).