### PR TITLE
Fix: Update quick-start.mdx , add nacos start command in ubuntu

### DIFF
--- a/src/content/docs/latest/zh-cn/quickstart/quick-start.mdx
+++ b/src/content/docs/latest/zh-cn/quickstart/quick-start.mdx
@@ -62,6 +62,9 @@ Nacos 依赖 [Java](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_j
     `sh startup.sh -m standalone`
 
     如果您使用的是ubuntu系统，或者运行脚本报错提示[[符号找不到，可尝试如下运行：
+
+    `bash startup.sh -m standalone`
+
   </TabItem>
   <TabItem label="Windows">
     启动命令(standalone代表着单机模式运行，非集群模式):


### PR DESCRIPTION
Fix: Add the exact command, Start nacos stand-alone in Ubuntu

## What is the purpose of the change

Make the Quick Started documentation more complete

## Brief changelog

![image](https://github.com/user-attachments/assets/7ff7db1d-0054-4f9e-8dfc-bfb04b247181)
Missing startup command in ubuntu
