### PR TITLE
fix: 修改错误的等宽字体设置

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -78,7 +78,6 @@ export default {
 			},
 			fontFamily: {
 				sans: ["Roboto","SourceHanSans","sans-serif"],
-				mono: ["Roboto","SourceHanSans","sans-serif"],
 			},
 			screens: {
 				'ssm': '450px',


### PR DESCRIPTION
## What is the purpose of the change

修改错误的等宽字体设置

## Brief changelog

"Roboto","SourceHanSans","sans-serif" 这几个字体非等宽设置，在 tailwind 配置当中设置会导致页面当中的代码渲染成非等宽字体，让等宽字体直接引用 `--sl-font-system-mono` 这个 CSS 变量即可。

修改前：
<img width="511" height="328" alt="image" src="https://github.com/user-attachments/assets/4f5011bc-89fa-4341-bf95-bf4cb285ef30" />

修改后：
<img width="566" height="269" alt="image" src="https://github.com/user-attachments/assets/08549503-2caa-4e10-a3a9-1408bad35b97" />



Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Test your code locally by running `npm run build`, and make sure it works as expected.
- [x ] Make sure no files under build directory is added.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).