### PR TITLE
Add OIDC authentication guide for Nacos console

### DIFF
--- a/src/content/docs/next/_sidebar.json
+++ b/src/content/docs/next/_sidebar.json
@@ -135,6 +135,13 @@
         "link": "docs/manual/admin/auth"
       },
       {
+        "label": "OIDC 认证",
+        "translations": {
+          "en": "OIDC Authentication"
+        },
+        "link": "docs/manual/admin/oidc-auth"
+      },
+      {
         "label": "升级手册",
         "translations": {
           "en": "Upgrading Manual"

--- a/src/content/docs/next/en/manual/admin/oidc-auth.md
+++ b/src/content/docs/next/en/manual/admin/oidc-auth.md
@@ -1,0 +1,316 @@
+---
+title: OIDC Authentication
+keywords: [OIDC, OAuth2, SSO, Keycloak, Single Sign-On]
+description: Guide for configuring the Nacos OIDC authentication plugin to integrate with Keycloak, Okta, Auth0, and other identity providers for SSO.
+sidebar:
+    order: 8
+---
+
+# OIDC Authentication
+
+## Overview
+
+The Nacos OIDC authentication plugin provides OpenID Connect 1.0 / OAuth2 based authentication for the Nacos console, allowing Nacos to delegate user authentication and authorization to an external Identity Provider (IdP).
+
+When the OIDC plugin is enabled, the Nacos console login page displays a **"Sign in with SSO"** button. Users click the button to be redirected to the IdP for authentication, and are automatically returned to the Nacos console upon successful login.
+
+### Use Cases
+
+- Enterprise with an existing identity system (Keycloak, Okta, Auth0, Azure AD, etc.) that wants Nacos to use SSO
+- Centralized user and permission management, avoiding separate account maintenance in Nacos
+- Compliance with enterprise security requirements (MFA, audit logging, password policies)
+
+### Supported Identity Providers
+
+Any OIDC 1.0 compliant IdP that exposes a `/.well-known/openid-configuration` discovery endpoint. Verified with:
+
+- Keycloak (>= 18.0)
+- Okta
+- Auth0
+- Azure AD / Microsoft Entra ID
+
+### Requirements
+
+- Nacos: 3.2.0+
+- JDK: 17+
+
+---
+
+## 1. Prerequisites
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| JDK | 17+ | For compiling and running Nacos |
+| OIDC IdP | OIDC 1.0 compliant | This guide uses Keycloak 24 as an example |
+| Nacos | 3.2.0+ | Source or pre-built distribution |
+
+---
+
+## 2. Set Up OIDC IdP (Keycloak Example)
+
+> Skip this section if you already have a working OIDC IdP.
+
+### 2.1 Start Keycloak
+
+```bash
+docker run -d --name keycloak \
+  -p 8081:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:24.0 \
+  start-dev
+```
+
+Access `http://localhost:8081` and log in with `admin/admin`.
+
+### 2.2 Create a Realm
+
+1. Click **Create Realm** in the top-left dropdown
+2. Realm name: `nacos`
+3. Click **Create**
+
+### 2.3 Create a Client
+
+1. Go to **Clients** → **Create client**
+2. Step 1:
+   - Client type: `OpenID Connect`
+   - Client ID: `nacos-server`
+   - Click **Next**
+3. Step 2:
+   - Client authentication: `On`
+   - Authorization: `Off`
+   - Check `Standard flow`
+   - Click **Next**
+4. Step 3:
+   - Valid redirect URIs: `http://localhost:8080/*`
+   - Web origins: `http://localhost:8080`
+   - Click **Save**
+5. Go to the **Credentials** tab and copy the **Client secret**
+
+### 2.4 Create a Test User
+
+1. Go to **Users** → **Add user**
+2. Username: `testuser`, Email: `test@example.com`, **Email verified: On**
+3. Click **Create**
+4. Go to the **Credentials** tab
+5. Click **Set password**, enter a password, set **Temporary: Off**
+
+### 2.5 Record Key Information
+
+| Item | Value |
+|------|-------|
+| Issuer URI | `http://localhost:8081/realms/nacos` |
+| Client ID | `nacos-server` |
+| Client Secret | (from step 2.3) |
+| Discovery URL | `http://localhost:8081/realms/nacos/.well-known/openid-configuration` |
+
+Verify the discovery endpoint:
+
+```bash
+curl http://localhost:8081/realms/nacos/.well-known/openid-configuration
+```
+
+---
+
+## 3. Configure application.properties
+
+Edit `<NACOS_HOME>/conf/application.properties`.
+
+### 3.1 Switch Auth System to OIDC
+
+```properties
+### Enable OIDC authentication
+nacos.core.auth.system.type=oidc
+
+### Enable authentication
+nacos.core.auth.enabled=true
+```
+
+### 3.2 General Auth Configuration (Required)
+
+These settings are still **required** even with OIDC enabled, as Nacos uses its own JWT for internal server-to-server communication.
+
+```properties
+### Server identity for inter-node communication (any non-empty string)
+nacos.core.auth.server.identity.key=serverIdentity
+nacos.core.auth.server.identity.value=security
+
+### Internal JWT signing key (Base64 encoded, original string >= 32 chars)
+nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+```
+
+> **Important**: If `nacos.core.auth.plugin.nacos.token.secret.key` is not set, the startup script will enter interactive mode prompting for input. Generate a key with `openssl rand -base64 32`.
+
+### 3.3 OIDC Plugin Configuration (Required)
+
+```properties
+### IdP Issuer URI (for OIDC auto-discovery)
+nacos.core.auth.plugin.oidc.issuer-uri=http://localhost:8081/realms/nacos
+
+### OAuth2 Client credentials
+nacos.core.auth.plugin.oidc.client-id=nacos-server
+nacos.core.auth.plugin.oidc.client-secret=nacos-client-secret
+
+### OAuth2 scopes
+nacos.core.auth.plugin.oidc.scope=openid profile email
+
+### Claim field for username extraction from ID Token
+nacos.core.auth.plugin.oidc.username-claim=preferred_username
+```
+
+### 3.4 OIDC Optional Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `nacos.core.auth.plugin.oidc.token-validation-method` | `jwt` | Token validation: `jwt` (local JWKS) or `introspection` (IdP endpoint) |
+| `nacos.core.auth.plugin.oidc.jwks-cache-ttl-seconds` | `3600` | JWKS public key cache TTL (seconds) |
+| `nacos.core.auth.plugin.oidc.roles-claim` | `roles` | Claim name for roles in ID Token |
+| `nacos.core.auth.plugin.oidc.admin-role` | `nacos-admin` | Admin role name |
+| `nacos.core.auth.plugin.oidc.auto-create-user` | `true` | Auto-create user on first login |
+| `nacos.core.auth.plugin.oidc.authorization-endpoint` | (empty) | External authorization decision endpoint |
+| `nacos.core.auth.plugin.oidc.authorization-timeout-ms` | `5000` | Authorization request timeout (ms) |
+| `nacos.core.auth.plugin.oidc.strict-nonce-validation` | `false` | Enable strict nonce validation |
+| `nacos.core.auth.plugin.oidc.strict-audience-validation` | `false` | Enable strict audience validation |
+
+---
+
+## 4. Start Nacos
+
+```bash
+cd <NACOS_HOME>
+bin/startup.sh -m standalone   # Standalone mode
+# or
+bin/startup.sh                  # Cluster mode
+```
+
+Check logs:
+
+```bash
+tail -f logs/start.out
+```
+
+Success indicator: `Nacos started successfully` in logs.
+
+---
+
+## 5. Verify OIDC Login
+
+### 5.1 Access the Console
+
+Open `http://localhost:8080/` in your browser. The login page should display a **"Sign in with SSO"** button with the username/password form hidden.
+
+### 5.2 Click the SSO Button
+
+Clicking the button redirects to the IdP login page. After authenticating at the IdP, you are automatically redirected back to the Nacos console.
+
+### 5.3 Verify OIDC User Behavior
+
+| Check | Expected Behavior |
+|-------|-------------------|
+| Username display | Header shows the IdP username |
+| Change Password menu | **Hidden** (passwords managed by IdP) |
+| Permission management | **Hidden** (managed by IdP) |
+| Logout | Redirects to IdP logout endpoint (RP-initiated logout) |
+
+---
+
+## 6. Login Flow
+
+```
+Browser              Nacos                    IdP (Keycloak)
+   |                    |                            |
+   | GET /              |                            |
+   |------------------->|                            |
+   | HTML + JS          |                            |
+   |<-------------------|                            |
+   | GET /v3/console/server/state                    |
+   |------------------->|                            |
+   | {auth_system_type: "oidc"}                      |
+   |<-------------------|                            |
+   | Render "Sign in with SSO" button                |
+   | User clicks button |                            |
+   | GET /v1/auth/oidc/login                         |
+   |------------------->|                            |
+   | 302 IdP authorize  |                            |
+   |<-------------------|                            |
+   | GET IdP authorize  |                            |
+   |-------------------------------------------->    |
+   | IdP login page     |                            |
+   |<--------------------------------------------    |
+   | User enters creds  |                            |
+   |-------------------------------------------->    |
+   | 302 callback?code= |                            |
+   |<--------------------------------------------    |
+   | GET /v1/auth/oidc/callback?code=...             |
+   |------------------->|                            |
+   |                    | POST token endpoint        |
+   |                    |--------------------------->|
+   |                    | {access_token, id_token}    |
+   |                    |<---------------------------|
+   |                    | JWKS signature validation   |
+   |                    |--------------------------->|
+   |                    |<---------------------------|
+   | 302 / + Set-Cookie |                            |
+   |<-------------------|                            |
+   | JS reads cookies   |                            |
+   | Syncs to localStorage                           |
+   | Deletes cookies    |                            |
+   | Enters console     |                            |
+```
+
+---
+
+## 7. Troubleshooting
+
+### 7.1 Startup hangs at "Please input the JWT token secret key"
+
+**Cause**: `nacos.core.auth.plugin.nacos.token.secret.key` is not set.
+
+**Fix**: Set a Base64-encoded key in `application.properties`:
+
+```properties
+nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+```
+
+### 7.2 Startup fails: Empty identity
+
+**Cause**: `nacos.core.auth.server.identity.key/value` are empty.
+
+**Fix**:
+
+```properties
+nacos.core.auth.server.identity.key=serverIdentity
+nacos.core.auth.server.identity.value=security
+```
+
+### 7.3 IdP reports redirect_uri error
+
+**Cause**: The IdP client's Valid Redirect URIs does not include the Nacos callback URL.
+
+**Fix**: Add `http://<nacos-host>:<port>/*` to the IdP client configuration.
+
+### 7.4 Callback returns "No valid OIDC token found"
+
+**Cause**: JWT signature validation failed.
+
+**Steps**:
+1. Verify `issuer-uri` matches the IdP's actual issuer (no trailing slash)
+2. Check `logs/nacos.log` for detailed errors
+3. Temporarily disable strict validation: `strict-audience-validation=false`
+4. Verify the IdP's JWKS endpoint is accessible
+
+### 7.5 Auto-login after logout
+
+This is standard OIDC SSO behavior. The IdP's SSO session is still valid, so the IdP returns a logged-in state automatically. To force re-authentication, clear the IdP session at its logout endpoint.
+
+---
+
+## 8. Comparison with Other Auth Modes
+
+| Feature | nacos | ldap | oidc |
+|---------|-------|------|------|
+| User storage | Nacos built-in DB | LDAP server | IdP |
+| Password management | Nacos console | LDAP server | IdP |
+| Single Sign-On | No | No | **Yes** |
+| Multi-Factor Auth | No | Depends on LDAP | **Yes** |
+| Use case | Small standalone deployments | Enterprises with LDAP | Modern enterprise SSO |

--- a/src/content/docs/next/zh-cn/manual/admin/oidc-auth.md
+++ b/src/content/docs/next/zh-cn/manual/admin/oidc-auth.md
@@ -1,0 +1,316 @@
+---
+title: OIDC 认证
+keywords: [OIDC, OAuth2, SSO, Keycloak, 单点登录]
+description: Nacos OIDC 认证插件配置与使用指南，支持与 Keycloak、Okta、Auth0 等 IdP 集成实现单点登录。
+sidebar:
+    order: 8
+---
+
+# OIDC 认证
+
+## 概述
+
+Nacos OIDC 认证插件为 Nacos 控制台提供基于 OpenID Connect 1.0 / OAuth2 的认证能力，使 Nacos 能够将用户的身份认证与授权工作完全委托给外部身份提供商（IdP）。
+
+启用 OIDC 插件后，Nacos 控制台登录页会显示 **"使用 SSO 登录"** 按钮，用户点击后跳转到 IdP 完成认证，登录成功后自动回到 Nacos 控制台。
+
+### 适用场景
+
+- 企业已部署统一身份系统（Keycloak、Okta、Auth0、Azure AD 等），希望 Nacos 接入 SSO
+- 需要集中管理用户和权限，避免在 Nacos 中单独维护账号
+- 希望符合企业安全合规要求（强制 MFA、审计日志、密码策略等）
+
+### 支持的身份提供商
+
+支持任何符合 OIDC 1.0 规范、暴露 `/.well-known/openid-configuration` 发现端点的 IdP。已验证：
+
+- Keycloak（≥ 18.0）
+- Okta
+- Auth0
+- Azure AD / Microsoft Entra ID
+
+### 版本要求
+
+- Nacos：3.2.0 及以上
+- JDK：17 及以上
+
+---
+
+## 1. 前置条件
+
+| 组件 | 版本要求 | 说明 |
+|------|---------|------|
+| JDK | 17+ | 编译和运行 Nacos |
+| OIDC IdP | OIDC 1.0 兼容 | 本文以 Keycloak 24 为例 |
+| Nacos | 3.2.0+ | 源码或预编译发行包 |
+
+---
+
+## 2. 准备 OIDC IdP（Keycloak 示例）
+
+> 如果你已有可用的 OIDC IdP，跳过本节。
+
+### 2.1 启动 Keycloak
+
+```bash
+docker run -d --name keycloak \
+  -p 8081:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:24.0 \
+  start-dev
+```
+
+启动后访问 `http://localhost:8081`，使用 `admin/admin` 登录管理控制台。
+
+### 2.2 创建 Realm
+
+1. 左上角下拉菜单点击 **Create Realm**
+2. Realm name 填写：`nacos`
+3. 点击 **Create**
+
+### 2.3 创建 Client
+
+1. 左侧菜单进入 **Clients** → **Create client**
+2. 第一步：
+   - Client type: `OpenID Connect`
+   - Client ID: `nacos-server`
+   - 点击 **Next**
+3. 第二步：
+   - Client authentication: `On`
+   - Authorization: `Off`
+   - 勾选 `Standard flow`
+   - 点击 **Next**
+4. 第三步：
+   - Valid redirect URIs: `http://localhost:8080/*`
+   - Web origins: `http://localhost:8080`
+   - 点击 **Save**
+5. 创建后进入 **Credentials** 标签页，复制 **Client secret** 备用
+
+### 2.4 创建测试用户
+
+1. 左侧菜单 **Users** → **Add user**
+2. Username: `testuser`，Email: `test@example.com`，**Email verified: On**
+3. 点击 **Create**
+4. 进入用户详情的 **Credentials** 标签
+5. 点击 **Set password**，输入密码，**Temporary: Off**
+
+### 2.5 记录关键信息
+
+| 项 | 值 |
+|----|----|
+| Issuer URI | `http://localhost:8081/realms/nacos` |
+| Client ID | `nacos-server` |
+| Client Secret | （步骤 2.3 中获取的值） |
+| Discovery URL | `http://localhost:8081/realms/nacos/.well-known/openid-configuration` |
+
+可以通过 curl 验证 Discovery 端点是否可访问：
+
+```bash
+curl http://localhost:8081/realms/nacos/.well-known/openid-configuration
+```
+
+---
+
+## 3. 配置 application.properties
+
+修改文件 `<NACOS_HOME>/conf/application.properties`。
+
+### 3.1 切换认证系统类型为 OIDC
+
+```properties
+### 启用 OIDC 认证系统
+nacos.core.auth.system.type=oidc
+
+### 启用认证
+nacos.core.auth.enabled=true
+```
+
+### 3.2 通用认证配置（必填）
+
+即使启用了 OIDC，以下配置仍然**必填**，因为 Nacos 集群内部 server-to-server 通信使用 Nacos 自有的 JWT。
+
+```properties
+### 服务间通信身份标识（自定义任意非空字符串）
+nacos.core.auth.server.identity.key=serverIdentity
+nacos.core.auth.server.identity.value=security
+
+### Nacos 内部 JWT 签名密钥（Base64 编码，原串至少 32 字符）
+nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+```
+
+> **重要**：如果不设置 `nacos.core.auth.plugin.nacos.token.secret.key`，启动脚本会进入交互模式要求手动输入密钥，导致服务无法正常启动。可使用 `openssl rand -base64 32` 生成密钥。
+
+### 3.3 OIDC 插件核心配置（必填）
+
+```properties
+### IdP 的 Issuer URI（用于自动发现 OIDC 端点）
+nacos.core.auth.plugin.oidc.issuer-uri=http://localhost:8081/realms/nacos
+
+### OAuth2 Client 凭证
+nacos.core.auth.plugin.oidc.client-id=nacos-server
+nacos.core.auth.plugin.oidc.client-secret=nacos-client-secret
+
+### 请求的 OAuth2 scope
+nacos.core.auth.plugin.oidc.scope=openid profile email
+
+### 从 ID Token 中读取用户名的 claim 字段
+nacos.core.auth.plugin.oidc.username-claim=preferred_username
+```
+
+### 3.4 OIDC 插件可选配置
+
+| 配置项 | 默认值 | 说明 |
+|--------|-------|------|
+| `nacos.core.auth.plugin.oidc.token-validation-method` | `jwt` | Token 校验方式：`jwt` 本地 JWKS 校验 / `introspection` 调用 IdP introspection 端点 |
+| `nacos.core.auth.plugin.oidc.jwks-cache-ttl-seconds` | `3600` | JWKS 公钥缓存 TTL（秒） |
+| `nacos.core.auth.plugin.oidc.roles-claim` | `roles` | ID Token 中读取角色的 claim 名 |
+| `nacos.core.auth.plugin.oidc.admin-role` | `nacos-admin` | 管理员角色名 |
+| `nacos.core.auth.plugin.oidc.auto-create-user` | `true` | 首次登录时是否自动创建用户 |
+| `nacos.core.auth.plugin.oidc.authorization-endpoint` | （空） | 外部授权决策端点 |
+| `nacos.core.auth.plugin.oidc.authorization-timeout-ms` | `5000` | 授权请求超时时间（毫秒） |
+| `nacos.core.auth.plugin.oidc.strict-nonce-validation` | `false` | 是否启用严格 nonce 校验 |
+| `nacos.core.auth.plugin.oidc.strict-audience-validation` | `false` | 是否启用严格 audience 校验 |
+
+---
+
+## 4. 启动 Nacos
+
+```bash
+cd <NACOS_HOME>
+bin/startup.sh -m standalone   # 单机模式
+# 或
+bin/startup.sh                  # 集群模式
+```
+
+观察日志：
+
+```bash
+tail -f logs/start.out
+```
+
+启动成功标志：日志中出现 `Nacos started successfully`。
+
+---
+
+## 5. 验证 OIDC 登录
+
+### 5.1 浏览器访问
+
+打开浏览器访问 `http://localhost:8080/`，Nacos 登录页会显示 **"使用 SSO 登录"** 按钮，用户名/密码表单被隐藏。
+
+### 5.2 点击 SSO 按钮
+
+点击按钮后浏览器跳转到 IdP 登录页。在 IdP 完成认证后自动跳回 Nacos 控制台。
+
+### 5.3 验证 OIDC 用户行为
+
+| 验证点 | 预期行为 |
+|--------|---------|
+| 用户名显示 | Header 显示 IdP 中的用户名 |
+| 修改密码菜单 | **隐藏**（密码由 IdP 管理） |
+| 权限管理菜单 | **隐藏**（权限由 IdP 集中管理） |
+| 登出 | 跳转到 IdP logout 端点（RP-initiated logout） |
+
+---
+
+## 6. 登录流程
+
+```
+浏览器                Nacos                    IdP (Keycloak)
+   |                    |                            |
+   | GET /              |                            |
+   |------------------->|                            |
+   | HTML + JS          |                            |
+   |<-------------------|                            |
+   | GET /v3/console/server/state                    |
+   |------------------->|                            |
+   | {auth_system_type: "oidc"}                      |
+   |<-------------------|                            |
+   | 渲染 "使用 SSO 登录" 按钮                       |
+   | 用户点击按钮                                    |
+   | GET /v1/auth/oidc/login                         |
+   |------------------->|                            |
+   | 302 IdP authorize  |                            |
+   |<-------------------|                            |
+   | GET IdP authorize  |                            |
+   |-------------------------------------------->    |
+   | IdP 登录页         |                            |
+   |<--------------------------------------------    |
+   | 用户输入凭证       |                            |
+   |-------------------------------------------->    |
+   | 302 callback?code= |                            |
+   |<--------------------------------------------    |
+   | GET /v1/auth/oidc/callback?code=...             |
+   |------------------->|                            |
+   |                    | POST token endpoint        |
+   |                    |--------------------------->|
+   |                    | {access_token, id_token}    |
+   |                    |<---------------------------|
+   |                    | JWKS 签名校验              |
+   |                    |--------------------------->|
+   |                    |<---------------------------|
+   | 302 / + Set-Cookie |                            |
+   |<-------------------|                            |
+   | JS 读取 cookies    |                            |
+   | 同步到 localStorage|                            |
+   | 删除 cookies       |                            |
+   | 进入控制台         |                            |
+```
+
+---
+
+## 7. 常见问题
+
+### 7.1 启动卡在 "Please input the JWT token secret key"
+
+**原因**：`nacos.core.auth.plugin.nacos.token.secret.key` 未设置。
+
+**解决**：在 `application.properties` 中配置密钥：
+
+```properties
+nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+```
+
+### 7.2 启动失败：Empty identity
+
+**原因**：`nacos.core.auth.server.identity.key/value` 为空。
+
+**解决**：
+
+```properties
+nacos.core.auth.server.identity.key=serverIdentity
+nacos.core.auth.server.identity.value=security
+```
+
+### 7.3 IdP 报 redirect_uri 错误
+
+**原因**：IdP client 配置的 Valid Redirect URIs 缺少 Nacos 回调地址。
+
+**解决**：在 IdP client 配置中添加 `http://<nacos-host>:<port>/*`。
+
+### 7.4 登录回调报 No valid OIDC token found
+
+**原因**：JWT 签名校验失败。
+
+**排查**：
+1. 检查 `issuer-uri` 是否正确（注意末尾不要带斜杠）
+2. 查看 `logs/nacos.log` 中的错误详情
+3. 临时关闭严格校验：`strict-audience-validation=false`
+4. 确认 IdP 的 JWKS 端点可访问
+
+### 7.5 登出后立即被自动登入
+
+这是 OIDC SSO 的标准行为。IdP 的 SSO session 仍然有效，访问 Nacos 时 IdP 直接返回已登录状态。如需强制重新登录，手动访问 IdP 的 logout 端点清除 session。
+
+---
+
+## 8. 与其他认证模式对比
+
+| 特性 | nacos | ldap | oidc |
+|------|-------|------|------|
+| 用户存储 | Nacos 内置数据库 | LDAP 服务器 | IdP |
+| 密码管理 | Nacos 控制台 | LDAP 服务器 | IdP |
+| 单点登录（SSO） | 否 | 否 | **是** |
+| 多因素认证（MFA） | 否 | 取决于 LDAP | **是** |
+| 适用场景 | 单机/小型部署 | 已有 LDAP 的企业 | 现代化企业 SSO |


### PR DESCRIPTION
## What is the purpose of the change

Add documentation for the Nacos OIDC authentication plugin (introduced in alibaba/nacos#14527, frontend in alibaba/nacos#14912), covering configuration, IdP setup (Keycloak example), login flow, and troubleshooting.

## Brief changelog

- Add `next/zh-cn/manual/admin/oidc-auth.md` — Chinese OIDC auth guide
- Add `next/en/manual/admin/oidc-auth.md` — English OIDC auth guide
- Update `next/_sidebar.json` — Add "OIDC 认证" entry under Admin Manual, after "鉴权手册"

### Document contents

1. Overview & supported IdPs
2. Keycloak setup (step-by-step with Docker)
3. application.properties configuration (required & optional params)
4. Startup & verification
5. Login flow sequence diagram
6. Troubleshooting (6 common issues from real testing)
7. Comparison with nacos/ldap/oidc auth modes

---

- [x] Make sure there is a GITHUB issue filed for the change
- [x] Format the pull request title
- [x] Write a pull request description that is detailed enough
- [ ] Test your code locally by running `npm run build`
- [x] Make sure no files under build directory is added