### PR TITLE
fix: add index prefix length for AI tables to avoid MySQL 1071 error

### DIFF
--- a/src/content/docs/latest/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/latest/en/manual/admin/upgrading.mdx
@@ -85,8 +85,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource` (
     `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
-    KEY `idx_ai_resource_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`(128),`name`(191),`type`(32),`c_from`(191)),
+    KEY `idx_ai_resource_name` (`name`(191)),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
-    KEY `idx_ai_resource_ver_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`(128),`name`(191),`type`(32),`version`(64)),
+    KEY `idx_ai_resource_ver_name` (`name`(191)),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';

--- a/src/content/docs/latest/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/latest/zh-cn/manual/admin/upgrading.mdx
@@ -85,8 +85,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource` (
     `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
-    KEY `idx_ai_resource_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`(128),`name`(191),`type`(32),`c_from`(191)),
+    KEY `idx_ai_resource_name` (`name`(191)),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
-    KEY `idx_ai_resource_ver_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`(128),`name`(191),`type`(32),`version`(64)),
+    KEY `idx_ai_resource_ver_name` (`name`(191)),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -85,8 +85,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource` (
     `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
-    KEY `idx_ai_resource_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`(128),`name`(191),`type`(32),`c_from`(191)),
+    KEY `idx_ai_resource_name` (`name`(191)),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
-    KEY `idx_ai_resource_ver_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`(128),`name`(191),`type`(32),`version`(64)),
+    KEY `idx_ai_resource_ver_name` (`name`(191)),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';

--- a/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
@@ -85,8 +85,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource` (
     `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
-    KEY `idx_ai_resource_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`(128),`name`(191),`type`(32),`c_from`(191)),
+    KEY `idx_ai_resource_name` (`name`(191)),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
-    KEY `idx_ai_resource_ver_name` (`name`),
+    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`(128),`name`(191),`type`(32),`version`(64)),
+    KEY `idx_ai_resource_ver_name` (`name`(191)),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';


### PR DESCRIPTION
## What this PR does

Fix the MySQL index key length issue reported in https://github.com/alibaba/nacos/issues/14935.

### Problem

The AI-related tables (`ai_resource` and `ai_resource_version`) in the upgrading documentation have composite indexes without prefix length constraints. When using MySQL with `utf8mb4` charset and `innodb_large_prefix=OFF` (default in MySQL 5.6), the index key length exceeds the 767-byte limit, causing:

```
1071 - Specified key was too long; max key length is 767 bytes
```

For example, `uk_ai_resource_ns_name_type` on `(namespace_id(128), name(256), type(32), c_from(256))` = (128+256+32+256)×4 = **2688 bytes** >> 767 bytes.

### Fix

Added prefix length constraints to all affected indexes:

| Table | Index | Change |
|-------|-------|--------|
| `ai_resource` | `uk_ai_resource_ns_name_type` | `(namespace_id(128), name(191), type(32), c_from(191))` |
| `ai_resource` | `idx_ai_resource_name` | `(name(191))` |
| `ai_resource_version` | `uk_ai_resource_ver_ns_name_type_ver` | `(namespace_id(128), name(191), type(32), version(64))` |
| `ai_resource_version` | `idx_ai_resource_ver_name` | `(name(191))` |

The prefix lengths follow the rule: columns with varchar > 191 use prefix 191 (191×4=764 < 767 bytes), others use their full column length.

### Files Changed (4 files)

- `src/content/docs/latest/zh-cn/manual/admin/upgrading.mdx`
- `src/content/docs/latest/en/manual/admin/upgrading.mdx`
- `src/content/docs/next/zh-cn/manual/admin/upgrading.mdx`
- `src/content/docs/next/en/manual/admin/upgrading.mdx`

Closes https://github.com/alibaba/nacos/issues/14935