### PR TITLE
docs(ai): add targetVersion parameter to skill upload APIs

### DIFF
--- a/src/content/docs/next/en/manual/admin/admin-api.md
+++ b/src/content/docs/next/en/manual/admin/admin-api.md
@@ -6956,6 +6956,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSi
 |--------|------|------|----------|
 | `namespaceId` | `string` | 否 | 命名空间。 |
 | `overwrite` | `boolean` | 否 | Whether to overwrite an existing skill with the same name. |
+| `targetVersion` | `string` | 否 | Target version of the skill to create, e.g. `1.0.0`. Resolution order: frontmatter `metadata.version` in `SKILL.md` → `meta.json` in ZIP → this `targetVersion` parameter → default `0.0.1`. |
 | `file` | `file` | 否 | ZIP file containing skill package |
 
 #### 返回数据
@@ -6968,7 +6969,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSi
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload' \
-  -F "file=@skill.zip" -F "namespaceId=public"
+  -F "file=@skill.zip" -F "namespaceId=public" -F "targetVersion=1.0.0"
 ```
 
 * 返回示例

--- a/src/content/docs/next/en/manual/admin/console-api.md
+++ b/src/content/docs/next/en/manual/admin/console-api.md
@@ -4952,9 +4952,10 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?pageNo=1&pageSize=1
 
 | 参数名         | 类型     | 必填 | 参数描述                                                                 |
 |-------------|--------|----|----------------------------------------------------------------------|
-| `file`      | `file` | 否  | 包含 Skill 定义的 ZIP 文件。                                                          |
-| `namespaceId` | `string` | 否 | 命名空间 ID，不传默认为 `public`。                                                |
-| `overwrite` | `boolean` | 否 | 导入时若 Skill 已存在是否覆盖，默认 `false`。                                           |
+| `file`      | `file` | 否  | 包含 Skill 定义的 ZIP 文件。                                                  |
+| `namespaceId` | `string` | 否 | 命名空间 ID，不传默认为 `public`。                                                 |
+| `overwrite` | `boolean` | 否 | 导入时若 Skill 已存在是否覆盖，默认 `false`。                                          |
+| `targetVersion` | `string` | 否 | 要创建的 Skill 版本号，例如 `1.0.0`。版本解析优先级：`SKILL.md` 中 frontmatter 的 `metadata.version` → ZIP 包中的 `meta.json` → 该 `targetVersion` 参数 → 默认 `0.0.1`。 |
 
 #### 返回数据
 
@@ -4969,7 +4970,8 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?pageNo=1&pageSize=1
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload' \
   -F "file=@/path/to/skill.zip" \
-  -F "namespaceId=public"
+  -F "namespaceId=public" \
+  -F "targetVersion=1.0.0"
 ```
 
 * 返回示例

--- a/src/content/docs/next/zh-cn/manual/admin/admin-api.md
+++ b/src/content/docs/next/zh-cn/manual/admin/admin-api.md
@@ -6956,6 +6956,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSi
 |--------|------|------|----------|
 | `namespaceId` | `string` | 否 | 命名空间。 |
 | `overwrite` | `boolean` | 否 | 是否覆盖同名技能；默认不覆盖。 |
+| `targetVersion` | `string` | 否 | 要创建的技能版本号，例如 `1.0.0`。版本解析优先级：`SKILL.md` 中 frontmatter 的 `metadata.version` → ZIP 包中的 `meta.json` → 该 `targetVersion` 参数 → 默认 `0.0.1`。 |
 | `file` | `file` | 否 | 包含技能内容的 ZIP 包文件。 |
 
 #### 返回数据
@@ -6968,7 +6969,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSi
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload' \
-  -F "file=@skill.zip" -F "namespaceId=public"
+  -F "file=@skill.zip" -F "namespaceId=public" -F "targetVersion=1.0.0"
 ```
 
 * 返回示例

--- a/src/content/docs/next/zh-cn/manual/admin/console-api.md
+++ b/src/content/docs/next/zh-cn/manual/admin/console-api.md
@@ -4955,6 +4955,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?pageNo=1&pageSize=1
 | `file`      | `file` | 否  | 包含 Skill 定义的 ZIP 文件。                                                          |
 | `namespaceId` | `string` | 否 | 命名空间 ID，不传默认为 `public`。                                                  |
 | `overwrite` | `boolean` | 否 | 导入时若 Skill 已存在是否覆盖，默认 `false`。                                           |
+| `targetVersion` | `string` | 否 | 要创建的 Skill 版本号，例如 `1.0.0`。版本解析优先级：`SKILL.md` 中 frontmatter 的 `metadata.version` → ZIP 包中的 `meta.json` → 该 `targetVersion` 参数 → 默认 `0.0.1`。 |
 
 #### 返回数据
 
@@ -4969,7 +4970,8 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?pageNo=1&pageSize=1
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload' \
   -F "file=@/path/to/skill.zip" \
-  -F "namespaceId=public"
+  -F "namespaceId=public" \
+  -F "targetVersion=1.0.0"
 ```
 
 * 返回示例


### PR DESCRIPTION
## What is this PR for?

Aligns the documentation with nacos PR alibaba/nacos#14979, which adds an optional `targetVersion` form parameter to the skill upload REST APIs.

## Changes

Adds the new `targetVersion` request parameter to two upload-ZIP endpoints in both English and Chinese docs (4 files, pure additions):

- `src/content/docs/next/en/manual/admin/admin-api.md` — §7.6 Upload skill from ZIP (`/nacos/v3/admin/ai/skills/upload`)
- `src/content/docs/next/zh-cn/manual/admin/admin-api.md` — same as above
- `src/content/docs/next/en/manual/admin/console-api.md` — §7.4 Upload Skill (ZIP) (`/v3/console/ai/skills/upload`)
- `src/content/docs/next/zh-cn/manual/admin/console-api.md` — same as above

For each endpoint, the parameter table now also lists `targetVersion`, and the `curl` example appends `-F "targetVersion=1.0.0"`.

## Parameter description

Version resolution order is documented as:

`SKILL.md` frontmatter `metadata.version` → `meta.json` in ZIP → this `targetVersion` parameter → default `0.0.1`.

This matches the resolution order agreed in the review discussion of alibaba/nacos#14979.

## Scope

- Admin REST API doc: updated
- Console REST API doc: updated
- Maintainer SDK doc (`maintainer-sdk.md`): NOT updated — the SDK interface `SkillMaintainerService.uploadSkillFromZip(...)` was intentionally left at its existing 3-parameter signature in alibaba/nacos#14979, so the SDK doc is still correct.

## Checklist

- [x] Docs added/updated for the new API parameter
- [x] Both `en` and `zh-cn` versions updated
- [x] Parameter description consistent with upstream PR review feedback
