### PR TITLE
Add new committer announcement

### DIFF
--- a/.agents/skills/nacos-committer-update/SKILL.md
+++ b/.agents/skills/nacos-committer-update/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: nacos-committer-update
+description: Updates Nacos committer documentation and announcements in nacos-group.github.io. Use when adding one or more new Nacos Committers, creating a committer community announcement, syncing committer/developer rows across all versioned zh-cn and en nacos-dev.md files, handling missing company information such as defaulting to independent developer, or validating historical developer-list consistency.
+---
+
+# Nacos Committer Update
+
+## Overview
+
+Use this skill to add new Nacos Committers consistently across the website:
+
+- Create a community announcement under `src/content/blog/`.
+- Add committer rows to every versioned developer list in both Chinese and English.
+- Repair historical omissions so all `nacos-dev.md` files share the same developer list.
+- Validate row consistency before finalizing.
+
+Also use `nacos-doc-sync-en` discipline for every edited `zh-cn` documentation file: update the corresponding `en` file in the same version.
+
+## Required Inputs
+
+Before editing files, make sure the user has provided the required information for every new Committer. If any required item is missing, ask the user for it instead of guessing.
+
+Required for each Committer:
+
+- GitHub ID.
+- Name, preferably Chinese name plus English name if the English developer list should not rely on inferred pinyin.
+- Email.
+- Certificate image URLs, including the person/front image and certificate/back image.
+
+Optional for each Committer:
+
+- Company or organization. If missing, use `自由开发者` in Chinese files and `Independent developer` in English files.
+- Main contributions. If missing, inspect the Committer's public contributions to `alibaba/nacos` and repositories under `nacos-group`, then summarize the largest 3-4 contribution areas for the announcement. Prefer GitHub PRs, commits, issues, and release notes as evidence. Keep the summary factual and do not invent contribution areas.
+
+## Workflow
+
+1. Start from a synced base branch unless the user says otherwise.
+   - Check `git status --short --branch`.
+   - If creating a branch, use the repository or maintainer's normal branch naming convention.
+   - Never overwrite unrelated user changes.
+
+2. Inspect current patterns.
+   - List developer files: `rg --files src/content/docs | rg '(^|/)nacos-dev\.md$'`.
+   - Read the latest announcement, usually `src/content/blog/committer-*.md`.
+   - Use `src/content/docs/latest/zh-cn/community/nacos-dev.md` and `src/content/docs/latest/en/community/nacos-dev.md` as the canonical row-value baseline after updating.
+
+3. Normalize new committer input.
+   - GitHub ID: preserve case in the markdown link and display text.
+   - Required fields: GitHub ID, name, email, and certificate image URLs must be available before editing files.
+   - Chinese name and English name: infer pinyin-style English names only when not provided.
+   - Organization:
+     - If provided in Chinese and English, use each as given.
+     - If only Chinese is provided but an English name is clear, translate it conservatively.
+     - If company is unknown or left blank, use `自由开发者` in Chinese files and `Independent developer` in English files.
+   - Contributions:
+     - Prefer user-provided nomination text.
+     - If absent, research GitHub activity in `alibaba/nacos` and `nacos-group/*`.
+     - Summarize the largest 3-4 areas of contribution and cite the evidence in working notes or final summary when useful.
+   - Role is `Committer`; mail is the provided email.
+
+4. Update all developer lists.
+   - Add each new committer before `### 活跃贡献者` / `### Contributors`.
+   - Update every file returned by the `nacos-dev.md` search, including:
+     - `src/content/docs/v1/{zh-cn,en}/nacos-dev.md`
+     - `src/content/docs/{v2,v2.3,v2.4,v2.5,v3.0,v3.1,latest,next}/{zh-cn,en}/community/nacos-dev.md`
+   - When historical versions are missing older committers, backfill the missing rows too. The final GitHub ID set should match `latest`.
+   - Preserve local table style when possible; do not reformat full tables just for alignment.
+   - Preserve CRLF in `src/content/docs/v1/**/nacos-dev.md` if those files already use CRLF.
+
+5. Create the announcement.
+   - File name: `src/content/blog/committer-YYYYMMDD.md` unless the user gives another date.
+   - Frontmatter:
+     - `title`: `恭喜 <ids> 晋升 Nacos Committer`
+     - `keywords`: include `Committer晋升` and the GitHub IDs.
+     - `description`: mirror the title.
+     - `date`: quoted `YYYY-MM-DD`.
+     - `category: community`
+   - Body:
+     - Start with the same H1 as the title.
+     - Use `## Nacos 社区新晋Committer`.
+     - Summarize each committer's contribution from the user-provided nomination text.
+     - Add certificate images in a markdown table. For two people, use the first row for front/person images and the second row for back/certificate images.
+     - Reuse the `About Nacos` section and community group QR-code block from the most recent committer announcement unless the user asks for different text.
+
+6. Validate.
+   - Run `node .agents/skills/nacos-committer-update/scripts/validate_developer_lists.mjs`.
+   - Run `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`.
+   - If feasible, run the repository build command. If it fails due environment, dependency, or network issues, report the exact blocker.
+   - Use `git diff --stat` and targeted `rg -n "<GitHubID>" src/content/docs src/content/blog/...` checks to review scope.
+
+7. Commit only when requested.
+   - Stage only the announcement, developer-list docs, and skill files if the task is updating the skill.
+   - Use a concise docs commit message such as `docs: add new committer announcement`.
+
+## Validation Script
+
+Use `scripts/validate_developer_lists.mjs` from the repository root. It checks that:
+
+- Every versioned `nacos-dev.md` contains the full canonical GitHub ID list.
+- English files match the latest English row values.
+- Chinese files match the latest Chinese row values.
+- No developer row has an empty organization cell.
+
+If the script reports row-value mismatches in older files, prefer updating the older files to the `latest` row values unless the user explicitly wants version-specific historical data.

--- a/.agents/skills/nacos-committer-update/agents/openai.yaml
+++ b/.agents/skills/nacos-committer-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nacos Committer Update"
+  short_description: "Add committer announcements and sync developer lists"
+  default_prompt: "Use $nacos-committer-update to add a Nacos committer announcement and synchronize all developer lists."

--- a/.agents/skills/nacos-committer-update/scripts/validate_developer_lists.mjs
+++ b/.agents/skills/nacos-committer-update/scripts/validate_developer_lists.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const docsRoot = path.join(repoRoot, "src/content/docs");
+const zhBaselinePath = path.join(docsRoot, "latest/zh-cn/community/nacos-dev.md");
+const enBaselinePath = path.join(docsRoot, "latest/en/community/nacos-dev.md");
+
+function collectNacosDevFiles(dir, result = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectNacosDevFiles(fullPath, result);
+    } else if (entry.isFile() && entry.name === "nacos-dev.md") {
+      result.push(fullPath);
+    }
+  }
+  return result.sort();
+}
+
+function parseRows(filePath) {
+  const rows = new Map();
+  const duplicates = [];
+  const content = fs.readFileSync(filePath, "utf8");
+
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.match(/^\|\s*\[([^\]]+)\]\(https:\/\/github\.com\/[^)]+\)\s*\|(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const id = match[1];
+    const cells = match[2]
+      .split("|")
+      .map((cell) => cell.replace(/｜\s*$/, "").trim());
+    while (cells[cells.length - 1] === "") {
+      cells.pop();
+    }
+
+    if (rows.has(id)) {
+      duplicates.push(id);
+    }
+    rows.set(id, cells);
+  }
+
+  return { rows, duplicates };
+}
+
+function formatRelative(filePath) {
+  return path.relative(repoRoot, filePath);
+}
+
+const zhBaseline = parseRows(zhBaselinePath).rows;
+const enBaseline = parseRows(enBaselinePath).rows;
+const canonicalIds = [...zhBaseline.keys()];
+const files = collectNacosDevFiles(docsRoot);
+const errors = [];
+
+for (const filePath of files) {
+  const { rows, duplicates } = parseRows(filePath);
+  const relativePath = formatRelative(filePath);
+  const baseline = relativePath.includes("/en/") ? enBaseline : zhBaseline;
+
+  if (duplicates.length > 0) {
+    errors.push(`${relativePath}: duplicate GitHub IDs: ${duplicates.join(", ")}`);
+  }
+
+  const missing = canonicalIds.filter((id) => !rows.has(id));
+  if (missing.length > 0) {
+    errors.push(`${relativePath}: missing GitHub IDs: ${missing.join(", ")}`);
+  }
+
+  const extra = [...rows.keys()].filter((id) => !zhBaseline.has(id));
+  if (extra.length > 0) {
+    errors.push(`${relativePath}: extra GitHub IDs not in latest baseline: ${extra.join(", ")}`);
+  }
+
+  for (const [id, cells] of rows) {
+    if (!baseline.has(id)) {
+      continue;
+    }
+
+    const baselineCells = baseline.get(id);
+    if (cells.join("\t") !== baselineCells.join("\t")) {
+      errors.push(`${relativePath}: row differs from latest baseline for ${id}`);
+    }
+
+    const organization = cells[1];
+    if (!organization) {
+      errors.push(`${relativePath}: empty organization for ${id}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+
+console.log("all nacos-dev.md files match the latest zh/en developer baselines");

--- a/src/content/blog/committer-20260509.md
+++ b/src/content/blog/committer-20260509.md
@@ -1,0 +1,48 @@
+---
+title: 恭喜 cxhello, WangzJi 两位同学晋升 Nacos Committer
+keywords: [Committer晋升, cxhello, WangzJi]
+description: 恭喜 cxhello, WangzJi 两位同学晋升 Nacos Committer
+date: "2026-05-09"
+category: community
+---
+# 恭喜 cxhello, WangzJi 两位同学晋升 Nacos Committer
+
+## Nacos 社区新晋Committer
+
+在过去一段时间中，Nacos 社区持续收到来自社区同学在代码质量、CI/CD、多语言 SDK、云原生生态、插件化体系、AI 生态集成以及多数据源架构等方向的贡献。
+
+[cxhello](https://github.com/cxhello) 蔡晓慧同学近 10 个月持续参与 Nacos 社区建设，主要围绕代码质量体系化治理、CI/CD 流水线优化与自动化运维、多语言 SDK 与云原生生态建设，以及大量服务端核心功能与安全修复进行贡献。
+
+[WangzJi](https://github.com/WangzJi) 王健同学近 5 个月持续参与 Nacos 社区建设，主要围绕插件化管理体系与 OIDC 认证插件、MCP Server 导入与 AI 生态集成、多数据源架构重构与 PostgreSQL 适配进行贡献。
+
+恭喜两位同学晋升为 Nacos Committer，希望两位同学在社区中保持活跃，为 Nacos 社区贡献自己的力量。
+
+| ![](https://img.alicdn.com/imgextra/i3/O1CN01ezYM2Z1vzoAqJT3OH_!!6000000006244-0-tps-1500-2260.jpg) | ![](https://img.alicdn.com/imgextra/i4/O1CN01Ii5csb248z2COPQpx_!!6000000007347-0-tps-1500-2260.jpg) |
+| --- | --- |
+| ![](https://img.alicdn.com/imgextra/i1/O1CN01s5UhIe1lVRlCuoBVS_!!6000000004824-0-tps-1190-1684.jpg) | ![](https://img.alicdn.com/imgextra/i2/O1CN01jiU6By1EwZu19Z0Mj_!!6000000000416-0-tps-1190-1684.jpg) |
+
+同时欢迎更多的 Committer 同学加入社区，一起打造一个活跃的、健康的社区。
+
+## About Nacos
+Nacos 致力于帮助您发现、配置和管理微服务。Nacos 提供了一组简单易用的特性集，帮助您快速实现动态服务发现、服务配置、服务元数据及 AI 管理。
+
+Nacos 帮助用户更敏捷和容易地构建、交付和管理云原生 AI 应用的平台。 Nacos 是构建以“服务”为中心的现代应用架构 (例如微服务范式、云原生范式、AI 原生范式) 的服务基础设施。
+
+Nacos 3.0 还有很多待完成的功能及大量待探索和开发的领域，欢迎大家扫码加入 Nacos 社区群及 Nacos MCP 社区讨论群，参与 Nacos 社区的贡献和讨论，在 Nacos 社区一起搭把手，让你的代码和能力有机会能在各行各业领域内进行释放能量，期待认识你和你一起共建 Nacos 社区；
+
+
+
+_<font style="color:#585a5a;">“Nacos 相信一切都是服务，每个服务节点被构想为一个星球，每个服务都是一个星系；Nacos 致力于帮助这些服务建立连接赋予智能，助力每个有面向星辰的梦想能够透过云层，飞在云上，更好的链接整片星空。”</font>_
+
+
+
+Nacos 官网：[https://nacos.io/](https://nacos.io/)
+
+Nacos 仓库地址：[https://github.com/alibaba/nacos](https://github.com/alibaba/nacos)
+
+“Nacos社区群6”群的钉钉群号： 145925004742
+
+“Nacos MCP 社区讨论群2”群的钉钉群号： 115205016856
+
+| ![](https://intranetproxy.alipay.com/skylark/lark/0/2025/png/297800/1758610254667-6853e2dc-8e89-4ad5-b938-edfdfde8b0d1.png) | ![](https://intranetproxy.alipay.com/skylark/lark/0/2025/png/297800/1758610123865-f1dc233c-d445-492e-bdf8-6ad97afa8e6b.png) |
+| --- | --- |

--- a/src/content/docs/latest/en/community/nacos-dev.md
+++ b/src/content/docs/latest/en/community/nacos-dev.md
@@ -100,6 +100,8 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [KiteSoar](https://github.com/KiteSoar)                             | Shihao Hu     | Beijing University of Posts and Telecommunications | Committer  | hushihao2020x@163.com        |
 | [luoxiner](https://github.com/luoxiner)                             | Xin Luo       | Aliyun                                             | Committer  | luoxiner527@gmail.com        |
 | [Sunrisea](https://github.com/Sunrisea)                             | Tong Zhu      | Aliyun                                             | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | Xiaohui Cai   | Lenztech                                           | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | Jian Wang     | Independent developer | Committer  | wangjian@apache.org          |
 
 ### Contributors
 

--- a/src/content/docs/latest/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/latest/zh-cn/community/nacos-dev.md
@@ -97,6 +97,8 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [KiteSoar](https://github.com/KiteSoar)                             | 胡世豪 | 北京邮电大学            | Committer  | hushihao2020x@163.com        |
 | [luoxiner](https://github.com/luoxiner)                             | 罗鑫  | 阿里云飞天信息技术有限公司     | Committer  | luoxiner527@gmail.com        |
 | [Sunrisea](https://github.com/Sunrisea)                             | 朱桐  | 阿里云飞天信息技术有限公司     | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | 蔡晓慧 | 北京朗镜科技有限责任公司       | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | 王健  | 自由开发者 | Committer  | wangjian@apache.org          |
 
 ### 活跃贡献者
 

--- a/src/content/docs/next/en/community/nacos-dev.md
+++ b/src/content/docs/next/en/community/nacos-dev.md
@@ -100,6 +100,8 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [KiteSoar](https://github.com/KiteSoar)                             | Shihao Hu     | Beijing University of Posts and Telecommunications | Committer  | hushihao2020x@163.com        |
 | [luoxiner](https://github.com/luoxiner)                             | Xin Luo       | Aliyun                                             | Committer  | luoxiner527@gmail.com        |
 | [Sunrisea](https://github.com/Sunrisea)                             | Tong Zhu      | Aliyun                                             | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | Xiaohui Cai   | Lenztech                                           | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | Jian Wang     | Independent developer | Committer  | wangjian@apache.org          |
 
 ### Contributors
 

--- a/src/content/docs/next/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/next/zh-cn/community/nacos-dev.md
@@ -97,6 +97,8 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [KiteSoar](https://github.com/KiteSoar)                             | 胡世豪 | 北京邮电大学            | Committer  | hushihao2020x@163.com        |
 | [luoxiner](https://github.com/luoxiner)                             | 罗鑫  | 阿里云飞天信息技术有限公司     | Committer  | luoxiner527@gmail.com        |
 | [Sunrisea](https://github.com/Sunrisea)                             | 朱桐  | 阿里云飞天信息技术有限公司     | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | 蔡晓慧 | 北京朗镜科技有限责任公司       | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | 王健  | 自由开发者 | Committer  | wangjian@apache.org          |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v1/en/nacos-dev.md
+++ b/src/content/docs/v1/en/nacos-dev.md
@@ -66,7 +66,7 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [fangjian0423](https://github.com/fangjian0423) | Jian Fang    | Alibaba      | Committer  | fangjian.fj@alibaba-inc.com                                  |
 | [wyp12](https://github.com/wyp12)               | Yuanpiao Wu  | Alibaba      | Committer  | caogu.wyp@antfin.com                                         |
 | [TsingLiang](https://github.com/TsingLiang)     | Liang qing   | Alibaba      | Committer  | qingliang.ql@alibaba-inc.com                                 |
-| [caojiele](https://github.com/caojiele)         | Jiele Cao    | Sinocare     | Committer  | caojiele1225@126.com                                         | 
+| [caojiele](https://github.com/caojiele)         | Jiele Cao    | Sinocare     | Committer  | caojiele1225@126.com                                         |
 | [KeRan213539](https://github.com/KeRan213539)   | Ying Xie     | ShengDa      | Committer  | 213539@qq.com                                                |
 | [zongtanghu](https://github.com/zongtanghu)     | Zongtang Hu  | China Mobile Cloud Centre | Committer | zongtanghu@hotmail.com                           |
 | [Maijh97](https://github.com/Maijh97)           | Jianhui Mai  | Yunliuchain  | Committer | xiaomai_h@163.com                                             |
@@ -79,13 +79,25 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [JackSun-Developer](https://github.com/JackSun-Developer) | Li Sun | Alibaba  | Committer | yongyue.sl@alibaba-inc.com |
 | [brotherlu-xcq](https://github.com/brotherlu-xcq) | Lu Cheng | KuJiaLe | Committer | 1285823170@qq.com |
 | [li-xiao-shuang](https://github.com/li-xiao-shuang) | XiaoShuang Li | DiDi | Committer | 644968328@qq.com |
-| [MajorHe1](https://github.com/MajorHe1)         | Fan He       | WeBank       | Committer | 601023364@qq.com | 
+| [MajorHe1](https://github.com/MajorHe1)         | Fan He       | WeBank       | Committer | 601023364@qq.com |
 | [hujun-w-2](https://github.com/hujun-w-2)       | Jun Hu       | Xiaomi       | Committer | 510830970@qq.com |
 | [onewe](https://github.com/onewe)               | Wenchao Mao | Independent developer| Committer | 2583021406@qq.com |
 | [chenhao26-nineteen](https://github.com/chenhao26-nineteen)|Hao Chen| Xiaomi | Committer | hashmap2018@163.com |
 | [shenkonghui](https://github.com/shenkonghui)   | Konghui Shen | Harmony Cloud| Committer | shenkh1992@gmail.com |
 | [CherishCai](https://github.com/CherishCai)     | Hongwen Cai | Ant Financial| Committer | 785427346@qq.com ｜
 | [The-Gamer-01](https://github.com/The-Gamer-01) | Yixuan Huang | Jishou University | Committer | 19974361760@163.com ｜
+| [Karsonto](https://github.com/karsonto) | Karson | ICBC (Asia) | Committer | karsontao@hotmail.com |
+| [Daydreamer-ia](https://github.com/Daydreamer-ia) | Yiqin Chen | Guangdong University of Technology | Committer | 2296032269@qq.com |
+| [shalk](https://github.com/shalk) | Kun Xiao | NASDAQ：TIGR | Committer | xshalk@163.com |
+| [heqingpan](https://github.com/heqingpan) | Qingpan He | Aicheng Technology | Committer | heqingpan@126.com |
+| [godhth](https://github.com/godhth) | Tianhui Huang | CE Cloud | Committer | 1165559068@qq.com |
+| [kiko-cyy](https://github.com/kiko-cyy) | Yinyin Cao | Alibaba Cloud | Committer | caoyinyin_cyy@163.com |
+| [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | Yunfan Wu | Alibaba Cloud | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | Shihao Hu | Beijing University of Posts and Telecommunications | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | Xin Luo | Aliyun | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | Tong Zhu | Aliyun | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | Xiaohui Cai | Lenztech | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | Jian Wang | Independent developer | Committer | wangjian@apache.org |
 
 ### Contributors
 

--- a/src/content/docs/v1/zh-cn/nacos-dev.md
+++ b/src/content/docs/v1/zh-cn/nacos-dev.md
@@ -41,7 +41,7 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 
 本页面展示了Nacos的开发团队，并且还在持续扩充中。
 
-### 
+###
 
  Github 账号                                     | 名字    | 组织     | 角色       | 邮箱                                                         |
 | ----------------------------------------------- | ------ | --------| --------- | ------------------------------------------------------------ |
@@ -78,13 +78,25 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [JackSun-Developer](https://github.com/JackSun-Developer) | 孙立 | 阿里巴巴 | Committer | yongyue.sl@alibaba-inc.com |
 | [brotherlu-xcq](https://github.com/brotherlu-xcq) | 程露 | 杭州群核信息技术有限公司(酷家乐) | Committer | 1285823170@qq.com |
 | [li-xiao-shuang](https://github.com/li-xiao-shuang) | 李晓双 | 滴滴出行 | Committer | 644968328@qq.com |
-| [MajorHe1](https://github.com/MajorHe1)         | 贺繁   | 微众银行 | Committer | 601023364@qq.com | 
+| [MajorHe1](https://github.com/MajorHe1)         | 贺繁   | 微众银行 | Committer | 601023364@qq.com |
 | [hujun-w-2](https://github.com/hujun-w-2)       | 胡俊   | 小米科技 | Committer | 510830970@qq.com |
 | [onewe](https://github.com/onewe)               | 毛文超 | 自由开发者| Committer | 2583021406@qq.com |
 | [chenhao26-nineteen](https://github.com/chenhao26-nineteen)|陈浩| 小米科技 | Committer | hashmap2018@163.com |
 | [shenkonghui](https://github.com/shenkonghui)   | 沈孔辉 | 杭州谐云科技有限公司| Committer | shenkh1992@gmail.com |
 | [CherishCai](https://github.com/CherishCai)     | 蔡鸿文 | 蚂蚁金服 | Committer | 785427346@qq.com ｜
 | [The-Gamer-01](https://github.com/The-Gamer-01) | 黄乙轩 | 吉首大学 | Committer | 19974361760@163.com ｜
+| [Karsonto](https://github.com/karsonto) | 陶健敏 | 中国工商银行（亚洲） | Committer | karsontao@hotmail.com |
+| [Daydreamer-ia](https://github.com/Daydreamer-ia) | 陈亿钦 | 广东工业大学 | Committer | 2296032269@qq.com |
+| [shalk](https://github.com/shalk) | 肖焜 | 老虎证券 | Committer | xshalk@163.com |
+| [heqingpan](https://github.com/heqingpan) | 何庆攀 | 爱橙科技 | Committer | heqingpan@126.com |
+| [godhth](https://github.com/godhth) | 黄天辉 | 中电云计算技术有限公司 | Committer | 1165559068@qq.com |
+| [kiko-cyy](https://github.com/kiko-cyy) | 曹茵茵 | 阿里云智能集团 | Committer | caoyinyin_cyy@163.com |
+| [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | 吴云凡 | 阿里云智能集团 | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | 胡世豪 | 北京邮电大学 | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | 罗鑫 | 阿里云飞天信息技术有限公司 | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | 朱桐 | 阿里云飞天信息技术有限公司 | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | 蔡晓慧 | 北京朗镜科技有限责任公司 | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | 王健 | 自由开发者 | Committer | wangjian@apache.org |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v2.3/en/community/nacos-dev.md
+++ b/src/content/docs/v2.3/en/community/nacos-dev.md
@@ -92,7 +92,15 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [Karsonto](https://github.com/karsonto)         | Karson        | ICBC (Asia) | Committer | karsontao@hotmail.com |
 | [Daydreamer-ia](https://github.com/Daydreamer-ia) | Yiqin Chen    | Guangdong University of Technology | Committer | 2296032269@qq.com  |
 | [shalk](https://github.com/shalk) | Kun Xiao      | NASDAQ：TIGR | Committer | xshalk@163.com               |
-| [heqingpan](https://github.com/heqingpan) | Qingpan He    | 爱橙科技 | Committer | heqingpan@126.com            |
+| [heqingpan](https://github.com/heqingpan) | Qingpan He    | Aicheng Technology | Committer | heqingpan@126.com            |
+| [godhth](https://github.com/godhth) | Tianhui Huang | CE Cloud | Committer | 1165559068@qq.com |
+| [kiko-cyy](https://github.com/kiko-cyy) | Yinyin Cao | Alibaba Cloud | Committer | caoyinyin_cyy@163.com |
+| [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | Yunfan Wu | Alibaba Cloud | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | Shihao Hu | Beijing University of Posts and Telecommunications | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | Xin Luo | Aliyun | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | Tong Zhu | Aliyun | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | Xiaohui Cai | Lenztech | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | Jian Wang | Independent developer | Committer | wangjian@apache.org |
 
 ### Contributors
 

--- a/src/content/docs/v2.3/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/v2.3/zh-cn/community/nacos-dev.md
@@ -91,6 +91,14 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [Daydreamer-ia](https://github.com/Daydreamer-ia) | 陈亿钦 | 广东工业大学 | Committer | 2296032269@qq.com            |
 | [shalk](https://github.com/shalk) | 肖焜 | 老虎证券 | Committer | xshalk@163.com               |
 | [heqingpan](https://github.com/heqingpan) | 何庆攀 | 爱橙科技 | Committer | heqingpan@126.com            |
+| [godhth](https://github.com/godhth) | 黄天辉 | 中电云计算技术有限公司 | Committer | 1165559068@qq.com |
+| [kiko-cyy](https://github.com/kiko-cyy) | 曹茵茵 | 阿里云智能集团 | Committer | caoyinyin_cyy@163.com |
+| [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | 吴云凡 | 阿里云智能集团 | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | 胡世豪 | 北京邮电大学 | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | 罗鑫 | 阿里云飞天信息技术有限公司 | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | 朱桐 | 阿里云飞天信息技术有限公司 | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | 蔡晓慧 | 北京朗镜科技有限责任公司 | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | 王健 | 自由开发者 | Committer | wangjian@apache.org |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v2.4/en/community/nacos-dev.md
+++ b/src/content/docs/v2.4/en/community/nacos-dev.md
@@ -97,6 +97,11 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [godhth](https://github.com/godhth)                                 | Tianhui Huang | CE Cloud                           | Committer  | 1165559068@qq.com            |
 | [kiko-cyy](https://github.com/kiko-cyy)                             | Yinyin Cao    | Alibaba Cloud                      | Committer  | caoyinyin_cyy@163.com        |
 | [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT)                   | Yunfan Wu     | Alibaba Cloud                      | Committer  | wyf_mohen@163.com            |
+| [KiteSoar](https://github.com/KiteSoar)                             | Shihao Hu     | Beijing University of Posts and Telecommunications | Committer  | hushihao2020x@163.com        |
+| [luoxiner](https://github.com/luoxiner)                             | Xin Luo       | Aliyun                             | Committer  | luoxiner527@gmail.com        |
+| [Sunrisea](https://github.com/Sunrisea)                             | Tong Zhu      | Aliyun                             | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | Xiaohui Cai   | Lenztech                           | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | Jian Wang     | Independent developer | Committer  | wangjian@apache.org          |
 
 ### Contributors
 

--- a/src/content/docs/v2.4/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/v2.4/zh-cn/community/nacos-dev.md
@@ -94,6 +94,11 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [godhth](https://github.com/godhth) | 黄天辉 | 中电云计算技术有限公司       | Committer | 1165559068@qq.com            |
 | [kiko-cyy](https://github.com/kiko-cyy) | 曹茵茵 | 阿里云智能集团 | Committer | caoyinyin_cyy@163.com |
 | [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | 吴云凡 | 阿里云智能集团 | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | 胡世豪 | 北京邮电大学 | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | 罗鑫 | 阿里云飞天信息技术有限公司 | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | 朱桐 | 阿里云飞天信息技术有限公司 | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | 蔡晓慧 | 北京朗镜科技有限责任公司 | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | 王健 | 自由开发者 | Committer | wangjian@apache.org |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v2.5/en/community/nacos-dev.md
+++ b/src/content/docs/v2.5/en/community/nacos-dev.md
@@ -97,6 +97,11 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [godhth](https://github.com/godhth)                                 | Tianhui Huang | CE Cloud                           | Committer  | 1165559068@qq.com            |
 | [kiko-cyy](https://github.com/kiko-cyy)                             | Yinyin Cao    | Alibaba Cloud                      | Committer  | caoyinyin_cyy@163.com        |
 | [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT)                   | Yunfan Wu     | Alibaba Cloud                      | Committer  | wyf_mohen@163.com            |
+| [KiteSoar](https://github.com/KiteSoar)                             | Shihao Hu     | Beijing University of Posts and Telecommunications | Committer  | hushihao2020x@163.com        |
+| [luoxiner](https://github.com/luoxiner)                             | Xin Luo       | Aliyun                             | Committer  | luoxiner527@gmail.com        |
+| [Sunrisea](https://github.com/Sunrisea)                             | Tong Zhu      | Aliyun                             | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | Xiaohui Cai   | Lenztech                           | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | Jian Wang     | Independent developer | Committer  | wangjian@apache.org          |
 
 ### Contributors
 

--- a/src/content/docs/v2.5/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/v2.5/zh-cn/community/nacos-dev.md
@@ -94,6 +94,11 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [godhth](https://github.com/godhth) | 黄天辉 | 中电云计算技术有限公司       | Committer | 1165559068@qq.com            |
 | [kiko-cyy](https://github.com/kiko-cyy) | 曹茵茵 | 阿里云智能集团 | Committer | caoyinyin_cyy@163.com |
 | [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | 吴云凡 | 阿里云智能集团 | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | 胡世豪 | 北京邮电大学 | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | 罗鑫 | 阿里云飞天信息技术有限公司 | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | 朱桐 | 阿里云飞天信息技术有限公司 | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | 蔡晓慧 | 北京朗镜科技有限责任公司 | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | 王健 | 自由开发者 | Committer | wangjian@apache.org |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v2/en/community/nacos-dev.md
+++ b/src/content/docs/v2/en/community/nacos-dev.md
@@ -90,6 +90,16 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [The-Gamer-01](https://github.com/The-Gamer-01) | Yixuan Huang | Jishou University | Committer | 19974361760@163.com |
 | [Karsonto](https://github.com/karsonto)         | Karson | ICBC (Asia) | Committer | karsontao@hotmail.com |
 | [Daydreamer-ia](https://github.com/Daydreamer-ia) | Yiqin Chen | Guangdong University of Technology | Committer | 2296032269@qq.com  |
+| [shalk](https://github.com/shalk) | Kun Xiao | NASDAQ：TIGR | Committer | xshalk@163.com |
+| [heqingpan](https://github.com/heqingpan) | Qingpan He | Aicheng Technology | Committer | heqingpan@126.com |
+| [godhth](https://github.com/godhth) | Tianhui Huang | CE Cloud | Committer | 1165559068@qq.com |
+| [kiko-cyy](https://github.com/kiko-cyy) | Yinyin Cao | Alibaba Cloud | Committer | caoyinyin_cyy@163.com |
+| [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | Yunfan Wu | Alibaba Cloud | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | Shihao Hu | Beijing University of Posts and Telecommunications | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | Xin Luo | Aliyun | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | Tong Zhu | Aliyun | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | Xiaohui Cai | Lenztech | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | Jian Wang | Independent developer | Committer | wangjian@apache.org |
 
 ### Contributors
 

--- a/src/content/docs/v2/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/v2/zh-cn/community/nacos-dev.md
@@ -89,6 +89,16 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [The-Gamer-01](https://github.com/The-Gamer-01) | 黄乙轩 | 吉首大学 | Committer | 19974361760@163.com |
 | [Karsonto](https://github.com/karsonto)         | 陶健敏 | 中国工商银行（亚洲） | Committer | karsontao@hotmail.com |
 | [Daydreamer-ia](https://github.com/Daydreamer-ia) | 陈亿钦 | 广东工业大学 | Committer | 2296032269@qq.com  |
+| [shalk](https://github.com/shalk) | 肖焜 | 老虎证券 | Committer | xshalk@163.com |
+| [heqingpan](https://github.com/heqingpan) | 何庆攀 | 爱橙科技 | Committer | heqingpan@126.com |
+| [godhth](https://github.com/godhth) | 黄天辉 | 中电云计算技术有限公司 | Committer | 1165559068@qq.com |
+| [kiko-cyy](https://github.com/kiko-cyy) | 曹茵茵 | 阿里云智能集团 | Committer | caoyinyin_cyy@163.com |
+| [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | 吴云凡 | 阿里云智能集团 | Committer | wyf_mohen@163.com |
+| [KiteSoar](https://github.com/KiteSoar) | 胡世豪 | 北京邮电大学 | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | 罗鑫 | 阿里云飞天信息技术有限公司 | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | 朱桐 | 阿里云飞天信息技术有限公司 | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | 蔡晓慧 | 北京朗镜科技有限责任公司 | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | 王健 | 自由开发者 | Committer | wangjian@apache.org |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v3.0/en/community/nacos-dev.md
+++ b/src/content/docs/v3.0/en/community/nacos-dev.md
@@ -98,6 +98,10 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [kiko-cyy](https://github.com/kiko-cyy)                             | Yinyin Cao    | Alibaba Cloud                      | Committer  | caoyinyin_cyy@163.com        |
 | [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT)                   | Yunfan Wu     | Alibaba Cloud                      | Committer  | wyf_mohen@163.com            |
 | [KiteSoar](https://github.com/KiteSoar) | Shihao Hu | Beijing University of Posts and Telecommunications | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | Xin Luo | Aliyun | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | Tong Zhu | Aliyun | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | Xiaohui Cai | Lenztech | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | Jian Wang | Independent developer | Committer | wangjian@apache.org |
 
 ### Contributors
 

--- a/src/content/docs/v3.0/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/v3.0/zh-cn/community/nacos-dev.md
@@ -95,6 +95,10 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [kiko-cyy](https://github.com/kiko-cyy) | 曹茵茵 | 阿里云智能集团 | Committer | caoyinyin_cyy@163.com |
 | [Wuyunfan-BUPT](https://github.com/Wuyunfan-BUPT) | 吴云凡 | 阿里云智能集团 | Committer | wyf_mohen@163.com |
 | [KiteSoar](https://github.com/KiteSoar) | 胡世豪 | 北京邮电大学 | Committer | hushihao2020x@163.com |
+| [luoxiner](https://github.com/luoxiner) | 罗鑫 | 阿里云飞天信息技术有限公司 | Committer | luoxiner527@gmail.com |
+| [Sunrisea](https://github.com/Sunrisea) | 朱桐 | 阿里云飞天信息技术有限公司 | Committer | szzhutong@gmail.com |
+| [cxhello](https://github.com/cxhello) | 蔡晓慧 | 北京朗镜科技有限责任公司 | Committer | caixiaohuichn@gmail.com |
+| [WangzJi](https://github.com/WangzJi) | 王健 | 自由开发者 | Committer | wangjian@apache.org |
 
 ### 活跃贡献者
 

--- a/src/content/docs/v3.1/en/community/nacos-dev.md
+++ b/src/content/docs/v3.1/en/community/nacos-dev.md
@@ -100,6 +100,8 @@ This page shows Nacos developers and continues to expand. The list is not priori
 | [KiteSoar](https://github.com/KiteSoar)                             | Shihao Hu     | Beijing University of Posts and Telecommunications | Committer  | hushihao2020x@163.com        |
 | [luoxiner](https://github.com/luoxiner)                             | Xin Luo       | Aliyun                                             | Committer  | luoxiner527@gmail.com        |
 | [Sunrisea](https://github.com/Sunrisea)                             | Tong Zhu      | Aliyun                                             | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | Xiaohui Cai   | Lenztech                                           | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | Jian Wang     | Independent developer | Committer  | wangjian@apache.org          |
 
 ### Contributors
 

--- a/src/content/docs/v3.1/zh-cn/community/nacos-dev.md
+++ b/src/content/docs/v3.1/zh-cn/community/nacos-dev.md
@@ -97,6 +97,8 @@ Contributor是对Nacos项目有贡献的个人，标准为：
 | [KiteSoar](https://github.com/KiteSoar)                             | 胡世豪 | 北京邮电大学            | Committer  | hushihao2020x@163.com        |
 | [luoxiner](https://github.com/luoxiner)                             | 罗鑫  | 阿里云飞天信息技术有限公司     | Committer  | luoxiner527@gmail.com        |
 | [Sunrisea](https://github.com/Sunrisea)                             | 朱桐  | 阿里云飞天信息技术有限公司     | Committer  | szzhutong@gmail.com          |
+| [cxhello](https://github.com/cxhello)                               | 蔡晓慧 | 北京朗镜科技有限责任公司       | Committer  | caixiaohuichn@gmail.com      |
+| [WangzJi](https://github.com/WangzJi)                               | 王健  | 自由开发者 | Committer  | wangjian@apache.org          |
 
 ### 活跃贡献者
 


### PR DESCRIPTION
## Summary
- add a community announcement for cxhello and WangzJi becoming Nacos Committers
- sync committer/developer lists across all versioned zh-cn and en nacos-dev.md files
- add a reusable nacos-committer-update skill and developer-list validation script

## Validation
- node .agents/skills/nacos-committer-update/scripts/validate_developer_lists.mjs
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check