### PR TITLE
docs(cli,java-sdk): update nacos-cli and Java SDK skill docs

### DIFF
--- a/src/content/docs/next/en/manual/admin/nacos-cli.md
+++ b/src/content/docs/next/en/manual/admin/nacos-cli.md
@@ -1,14 +1,14 @@
 ---
 title: Nacos CLI User Guide
 keywords: [ Nacos, Nacos CLI ]
-description: Nacos CLI User Guide, introducing how to install and use Nacos CLI for configuration management, AI skill management, and interactive terminal operations.
+description: Nacos CLI User Guide, introducing how to install and use Nacos CLI for configuration management, full lifecycle management of AI Skills and AgentSpecs, and interactive terminal operations.
 sidebar:
   order: 14
 ---
 
 # Nacos CLI User Guide
 
-Nacos CLI is a command-line tool for Nacos configuration center, supporting configuration management, AI skill management, and interactive terminal mode.
+Nacos CLI is a command-line tool for Nacos configuration center, supporting configuration management, full lifecycle management of AI Skills and AgentSpecs (upload → review → release), and interactive terminal mode.
 
 ## 1. Prerequisites
 ### 1.1. Runtime Requirements
@@ -25,7 +25,7 @@ This is the simplest installation method. After installation, configure the Naco
 **Linux / macOS:**
 
 ```bash
-curl -fsSL https://nacos.io/nacos-installer.sh | sudo bash -s -- --cli
+curl -fsSL https://nacos.io/nacos-installer.sh | bash -s -- --cli
 ```
 
 **Windows (PowerShell):**
@@ -52,81 +52,180 @@ nacos-cli --help
 ```
 
 ## 3. Authentication Configuration
-Nacos CLI supports two authentication methods:
+Nacos CLI supports the following authentication methods:
 
-### 3.1. Configuration File (Recommended)
-To avoid entering authentication information every time, using a configuration file is recommended.
+- `none`: no authentication
+- `nacos`: username / password
+- `aliyun`: Alibaba Cloud AccessKey / SecretKey (for Alibaba Cloud MSE Nacos)
+- `sts-hiclaw`: STS temporary credentials (resolved dynamically from the `HICLAW_CONTROLLER_URL` and `HICLAW_AUTH_TOKEN_FILE` environment variables)
+
+### 3.1. Profile-Based Configuration (Recommended)
+Nacos CLI stores per-environment connection settings as profiles. Each profile maps to a YAML file at `~/.nacos-cli/<profile>.conf`. The default profile is named `default`, stored at `~/.nacos-cli/default.conf`.
+
+> **First run**: Just execute `nacos-cli`. When no profile exists, the CLI launches an interactive wizard that walks you through host, port, authType, username, password, etc., and saves the result to `~/.nacos-cli/default.conf` for future reuse.
+
+#### 3.1.1. Create / Edit a Profile
+`nacos-cli profile edit` enters an interactive editor. Existing values are shown as defaults — press Enter to keep them.
 
 ```bash
-# Create configuration file
-cat > local.conf << EOF
-host: <your_nacos_host>
-port: <your_nacos_port>
-username: <your_username>
-password: <your_password>
-namespace: ""
-EOF
+# Create / edit the default profile (saved to ~/.nacos-cli/default.conf)
+nacos-cli profile edit
 
-# Use configuration file
-nacos-cli --config ./local.conf skill-list
+# Create / edit the dev profile (saved to ~/.nacos-cli/dev.conf)
+nacos-cli profile edit dev
+
+# Create / edit the prod profile
+nacos-cli profile edit prod
 ```
 
-**Configuration File Format** (YAML):
+After editing, the CLI asks whether to log in immediately and enter the interactive terminal — pressing Enter accepts.
+
+#### 3.1.2. Show a Profile
+```bash
+# Show the default profile
+nacos-cli profile show
+
+# Show the dev profile
+nacos-cli profile show dev
+```
+
+Sample output (passwords / secret keys are masked):
+```plain
+Profile: dev
+Config file: /Users/<user>/.nacos-cli/dev.conf
+─────────────────────────────────────────
+host:           127.0.0.1
+port:           8848
+auth-type:      nacos
+username:       nacos
+password:       ******
+namespace:      (public)
+```
+
+#### 3.1.3. Switch Profiles
+The `default` profile is loaded automatically. Use `--profile` to switch:
+
+```bash
+# Use the default profile (equivalent to omitting --profile)
+nacos-cli skill-list
+
+# Use the dev profile (loads ~/.nacos-cli/dev.conf)
+nacos-cli --profile dev skill-list
+
+# Use the prod profile
+nacos-cli --profile prod config-list
+```
+
+#### 3.1.4. Configuration File Format
+Profile files are YAML (note: fields use camelCase):
 
 ```yaml
-# Nacos server address
+# Nacos server host
 host: <your_nacos_host>
 
 # Nacos server port
 port: <your_nacos_port>
 
-# Authentication type: nacos or aliyun
-auth_type: nacos
+# Authentication type: none | nacos | aliyun | sts-hiclaw
+authType: nacos
 
-# Nacos authentication
+# Nacos authentication (used when authType=nacos)
 username: <your_username>
 password: <your_password>
 
-# Alibaba Cloud authentication (optional)
-access_key: ""
-secret_key: ""
+# Alibaba Cloud authentication (used when authType=aliyun)
+accessKey: ""
+secretKey: ""
+
+# STS SecurityToken (legacy)
+securityToken: ""
 
 # Namespace ID (optional, leave empty for public)
 namespace: ""
 ```
 
-### 3.2. Command-Line Parameters
-#### 3.2.1. Nacos Authentication (Username/Password)
+> **Note**: When `authType=sts-hiclaw`, do not store credentials in the profile file. The CLI resolves them dynamically from the `HICLAW_CONTROLLER_URL` and `HICLAW_AUTH_TOKEN_FILE` environment variables.
+
+### 3.2. Explicit Configuration File (`--config`)
+You can also point the CLI at any config file path with `--config`, which is convenient when checking config into a project repo or wiring up a script environment:
+
+```bash
+nacos-cli --config /path/to/custom.conf skill-list
+```
+
+`--config` overrides profile resolution: when set, both `--profile` and the files under `~/.nacos-cli/` are ignored.
+
+### 3.3. Command-Line Parameters
+You can also provide everything via command-line flags, with no config file at all:
+
+#### 3.3.1. Nacos Authentication (Username/Password)
 ```bash
 nacos-cli --host <host> --port <port> -u <username> -p <password>
 ```
 
-#### 3.2.2. Alibaba Cloud Authentication (AccessKey/SecretKey)
-If you are using Alibaba Cloud MSE Nacos, you can use AK/SK for authentication:
-
+#### 3.3.2. Alibaba Cloud Authentication (AccessKey/SecretKey)
 ```bash
 nacos-cli --host <host> --port <port> --auth-type aliyun --access-key <your_ak> --secret-key <your_sk>
 ```
 
-### 3.3. Configuration Priority
-Configuration values are applied in the following priority order:
+#### 3.3.3. STS (sts-hiclaw) Authentication
+```bash
+export HICLAW_CONTROLLER_URL=https://<controller-host>
+export HICLAW_AUTH_TOKEN_FILE=/path/to/token
 
-1. **Command-line parameters** (highest priority)
-2. **Configuration file**
-3. **Default values** (lowest priority)
+nacos-cli --host <host> --port <port> --auth-type sts-hiclaw
+```
 
-Example:
+### 3.4. Environment Variables
+You can also provide Nacos connection information via environment variables:
 
 ```bash
-# Use configuration file but override host
-nacos-cli --config ./local.conf --host <another_host> skill-list
+export NACOS_HOST=127.0.0.1
+export NACOS_PORT=8848
+export NACOS_NAMESPACE=xxx
+export NACOS_AUTH_TYPE=nacos
+```
 
-# Use configuration file entirely
-nacos-cli --config ./local.conf skill-list
+`sts-hiclaw` additionally requires:
+
+```bash
+export HICLAW_CONTROLLER_URL=https://<controller-host>
+export HICLAW_AUTH_TOKEN_FILE=/path/to/token
+```
+
+### 3.5. Configuration Priority
+Configuration values are applied in the following priority order (highest to lowest):
+
+1. **Command-line parameters** (highest priority)
+2. **Configuration file specified by `--config`**
+3. **Profile selected by `--profile` (defaults to `default`)**
+4. **Environment variables** (`NACOS_HOST` / `NACOS_PORT` / `NACOS_NAMESPACE` / `NACOS_AUTH_TYPE`)
+5. **Default values** (lowest priority)
+
+Examples:
+
+```bash
+# Use the dev profile, but override host via command line
+nacos-cli --profile dev --host 10.0.0.1 skill-list
+
+# Explicit config file
+nacos-cli --config /path/to/custom.conf skill-list
+
+# Use environment variables (when command line, --config, and profile all do not provide a value)
+NACOS_HOST=127.0.0.1 NACOS_PORT=8848 NACOS_NAMESPACE=xxx nacos-cli skill-list
+
+# Without any arguments, the CLI runs the interactive wizard to create the default profile, then connects to that server
+nacos-cli
+
+# When only --host is provided, port defaults to 8848
+nacos-cli --host 127.0.0.1
+
+# When only --port is provided, host defaults to 127.0.0.1
+nacos-cli --port 8849
 ```
 
 ## 4. Quick Start
-> **Tip**: The following examples assume a configuration file has been set up. See [3.1 Configuration File](#31-configuration-file-recommended) for details.
+> **Tip**: The following examples assume the default profile has been configured via `nacos-cli profile edit`. See [3.1 Profile-Based Configuration](#31-profile-based-configuration-recommended) for details.
 >
 
 ### 4.1. CLI Mode
@@ -163,10 +262,13 @@ nacos> help
 
 ### 5.1. AI Skill Management ✅
 
-Nacos CLI provides complete AI skill lifecycle management, including listing, downloading, uploading, and real-time synchronization.
+Skills follow a three-stage lifecycle aligned with the server:
+`upload` (editing) → `review` (reviewing → reviewed) → `release` (online).
+
+Nacos CLI provides complete Skill lifecycle management: list, describe, get, upload, review, release, plus real-time synchronization.
 
 #### 5.1.1. List Skills
-Get the list of AI skills stored in Nacos. By default, skill descriptions are displayed (truncated to 50 characters).
+Get the list of AI skills stored in Nacos. By default, skill descriptions are displayed (truncated to 50 characters). Supports script-friendly JSON output.
 
 **Command Format**
 ```bash
@@ -180,6 +282,7 @@ nacos-cli skill-list [flags]
 | --name |  |  | Filter by skill name |
 | --page |  | 1 | Page number |
 | --size |  | 10 | Page size |
+| --output |  | pretty | Output format: `pretty` (default) or `json` (machine-readable for scripting) |
 
 **Usage Examples**
 ```bash
@@ -187,16 +290,37 @@ nacos-cli skill-list [flags]
 nacos-cli skill-list
 
 # Filter by name
-nacos-cli skill-list --name <skill-name>
+nacos-cli skill-list --name <skill-name> --page 1 --size 20
+
+# Machine-readable JSON output
+nacos-cli skill-list --output json
 
 # Interactive mode
 nacos> skill-list
 nacos> skill-list --name <skill-name> --page 2
+nacos> skill-list --output json
 ```
 
-#### 5.1.2. Get/Download Skills
+#### 5.1.2. Describe Skill
+Show detail and version history of the specified skill (latest / editing / reviewing / online, plus per-version status).
 
-Download skills from Nacos to a local directory, including skill metadata (SKILL.md) and all resource files.
+**Command Format**
+```bash
+nacos-cli skill-describe <skill-name> [flags]
+```
+
+**Usage Examples**
+```bash
+nacos-cli skill-describe <skill-name>
+nacos-cli skill-describe <skill-name> --output json
+
+# Interactive mode
+nacos> skill-describe <skill-name>
+```
+
+#### 5.1.3. Get/Download Skill
+
+Download a skill from Nacos to a local directory, including skill metadata (SKILL.md) and all resource files.
 
 **Command Format**
 ```bash
@@ -233,9 +357,9 @@ The downloaded skill directory structure is as follows:
     └── init_skill.py
 ```
 
-#### 5.1.3. Upload Skills
+#### 5.1.4. Upload Skill
 
-Upload local skills to Nacos, supporting single or batch uploads.
+Upload a local skill to Nacos (creates or updates the `editing` version), supporting single or batch uploads.
 
 **Command Format**
 ```bash
@@ -246,7 +370,7 @@ nacos-cli skill-upload <path> [flags]
 
 | Parameter | Default | Description |
 | --- | --- | --- |
-| --all | false | Batch upload all skills in the directory |
+| --all | false | Batch upload all skills under the directory |
 
 **Usage Examples**
 ```bash
@@ -261,11 +385,58 @@ nacos> skill-upload /path/to/skill
 nacos> skill-upload --all /path/to/skills
 ```
 
-#### 5.1.4. Real-time Skill Synchronization
+#### 5.1.5. Review Skill
 
-Listen for skill changes in Nacos and automatically sync to the local directory. When a skill is updated in Nacos, local files are automatically updated.
+Submit the current `editing` version for review (editing → reviewing). The server-side review pipeline runs asynchronously and eventually marks the version as `reviewed`.
 
-> **Note**: `skill-sync` is only available in CLI mode and does not support interactive terminal mode.
+**Command Format**
+```bash
+nacos-cli skill-review <skill-name>
+```
+
+**Usage Examples**
+```bash
+nacos-cli skill-review <skill-name>
+
+# Interactive mode
+nacos> skill-review <skill-name>
+```
+
+#### 5.1.6. Release Skill
+
+Publish an approved (`reviewed`) version online.
+
+**Command Format**
+```bash
+nacos-cli skill-release <skill-name> --version <version> [flags]
+```
+
+**Usage Examples**
+```bash
+nacos-cli skill-release <skill-name> --version 0.0.2
+nacos-cli skill-release <skill-name> --version 0.0.2 --update-latest=false
+
+# Interactive mode
+nacos> skill-release <skill-name> --version 0.0.2
+```
+
+> **Note**: If `skill-release` fails with `HTTP 400 parameter validate error` immediately after `skill-review`, the async review pipeline most likely hasn't marked the version as `reviewed` yet. The CLI prints a hint suggesting to wait a few seconds, re-check the status via `skill-describe`, and retry once `STATUS=reviewed`.
+
+#### 5.1.7. Publish Skill (deprecated)
+
+`skill-publish` is kept as a backward-compatible shortcut that runs `upload` + `review` in sequence and prints a deprecation warning. It will be removed in a future release — prefer the explicit lifecycle commands above.
+
+```bash
+# Legacy shortcut (deprecated)
+nacos-cli skill-publish /path/to/skill
+nacos-cli skill-publish --all /path/to/skills/folder
+```
+
+#### 5.1.8. Real-time Skill Synchronization
+
+Listen for skill changes in Nacos and automatically sync to the local directory. When a skill is updated in Nacos, local files are updated automatically.
+
+> **Note**: `skill-sync` is only available in CLI mode and is not supported in interactive terminal mode.
 
 **Command Format**
 ```bash
@@ -293,11 +464,119 @@ nacos-cli skill-sync --all
 # Press Ctrl+C to stop syncing
 ```
 
-### 5.2. Configuration Management ✅
+### 5.2. AgentSpec Management ✅
+
+AgentSpecs follow the same three-stage lifecycle as Skills:
+`upload` (editing) → `review` (reviewing → reviewed) → `release` (online).
+
+#### 5.2.1. List AgentSpecs
+
+```bash
+# CLI mode (pretty output by default)
+nacos-cli agentspec-list
+
+# With filters
+nacos-cli agentspec-list --name <agentspec-name> --page 1 --size 20
+
+# Machine-readable JSON output
+nacos-cli agentspec-list --output json
+
+# Interactive mode
+nacos> agentspec-list
+nacos> agentspec-list --name <agentspec-name> --page 2
+nacos> agentspec-list --output json
+```
+
+#### 5.2.2. Describe AgentSpec
+
+Show detail and version history (latest / editing / reviewing / online, plus per-version status):
+
+```bash
+nacos-cli agentspec-describe <agentspec-name>
+nacos-cli agentspec-describe <agentspec-name> --output json
+
+# Interactive mode
+nacos> agentspec-describe <agentspec-name>
+```
+
+#### 5.2.3. Get/Download AgentSpec
+
+Download an AgentSpec to a local directory (default: `~/.agentspecs`):
+
+```bash
+# CLI mode
+nacos-cli agentspec-get <agentspec-name>
+nacos-cli agentspec-get <agentspec-name> -o /custom/path
+
+# Download a specific version
+nacos-cli agentspec-get <agentspec-name> --version v1
+
+# Download by route label
+nacos-cli agentspec-get <agentspec-name> --label latest
+
+# Download multiple AgentSpecs
+nacos-cli agentspec-get spec1 spec2 spec3
+
+# Interactive mode
+nacos> agentspec-get <agentspec-name>
+```
+
+#### 5.2.4. Upload AgentSpec
+
+Upload an AgentSpec from a local directory (creates or updates the `editing` version):
+
+```bash
+# Upload a single AgentSpec
+nacos-cli agentspec-upload /path/to/agentspec
+
+# Batch upload all AgentSpecs in a directory
+nacos-cli agentspec-upload --all /path/to/agentspecs/folder
+
+# Interactive mode
+nacos> agentspec-upload /path/to/agentspec
+nacos> agentspec-upload --all /path/to/agentspecs
+```
+
+#### 5.2.5. Review AgentSpec
+
+Submit the current `editing` version for review (editing → reviewing). The server-side review pipeline runs asynchronously and eventually marks the version as `reviewed`.
+
+```bash
+nacos-cli agentspec-review <agentspec-name>
+
+# Interactive mode
+nacos> agentspec-review <agentspec-name>
+```
+
+#### 5.2.6. Release AgentSpec
+
+Publish an approved (`reviewed`) version online:
+
+```bash
+nacos-cli agentspec-release <agentspec-name> --version 0.0.2
+nacos-cli agentspec-release <agentspec-name> --version 0.0.2 --update-latest=false
+
+# Interactive mode
+nacos> agentspec-release <agentspec-name> --version 0.0.2
+```
+
+> **Note**: If `agentspec-release` fails with `HTTP 400 parameter validate error` immediately after `agentspec-review`, the async review pipeline most likely hasn't marked the version as `reviewed` yet. The CLI prints a hint suggesting to wait a few seconds, re-check the status via `agentspec-describe`, and retry once `STATUS=reviewed`.
+
+#### 5.2.7. Publish AgentSpec (deprecated)
+
+`agentspec-publish` is kept as a backward-compatible shortcut that runs `upload` + `review` in sequence and prints a deprecation warning. It will be removed in a future release — prefer the explicit lifecycle commands above.
+
+```bash
+# Legacy shortcut (deprecated)
+nacos-cli agentspec-publish /path/to/agentspec
+nacos-cli agentspec-publish --all /path/to/agentspecs/folder
+```
+
+### 5.3. Configuration Management ✅
 
 Provides configuration list queries and configuration content retrieval for the configuration center.
 
-#### 5.2.1. List Configurations
+#### 5.3.1. List Configurations
 
 Get the configuration list from the Nacos configuration center, supporting filtering by dataId and group.
 
@@ -331,7 +610,7 @@ nacos> config-list
 nacos> config-list --data-id <dataId> --page 2
 ```
 
-#### 5.2.2. Get Configuration
+#### 5.3.2. Get Configuration
 
 Get the configuration content for a specified dataId and group.
 
@@ -356,7 +635,7 @@ nacos-cli config-get <dataId> <group>
 nacos> config-get <dataId> <group>
 ```
 
-### 5.3. Service Registration (Naming) ❌
+### 5.4. Service Registration (Naming) ❌
 
 Service registration and discovery features are not yet implemented, including:
 
@@ -366,14 +645,14 @@ Service registration and discovery features are not yet implemented, including:
 - `instance-register` - Register service instance
 - `instance-deregister` - Deregister service instance
 
-### 5.4. Distributed Lock (Lock) ❌
+### 5.5. Distributed Lock (Lock) ❌
 
 Distributed lock features are not yet implemented, including:
 
 - `lock-acquire` - Acquire distributed lock
 - `lock-release` - Release distributed lock
 
-### 5.5. Contribution Guide
+### 5.6. Contribution Guide
 
 We welcome community developers to participate in building Nacos CLI! Feel free to submit Issues or Pull Requests on [GitHub](https://github.com/nacos-group/nacos-cli).
 
@@ -404,18 +683,22 @@ nacos> quit           # Exit
 ## 7. Global Parameters
 The following parameters apply to all commands:
 
-| Parameter | Short | Description |
-| --- | --- | --- |
-| --host |  | Nacos server address |
-| --port |  | Nacos server port |
-| --username | -u | Username (Nacos authentication) |
-| --password | -p | Password (Nacos authentication) |
-| --auth-type |  | Authentication type: nacos or aliyun |
-| --access-key |  | AccessKey (Alibaba Cloud authentication) |
-| --secret-key |  | SecretKey (Alibaba Cloud authentication) |
-| --namespace | -n | Namespace ID |
-| --config | -c | Configuration file path |
-| --help | -h | Show help information |
+| Parameter | Short | Default | Description |
+| --- | --- | --- | --- |
+| --host |  | `market.hiclaw.io` when both `--host` and `--port` are omitted; `127.0.0.1` when only `--port` is provided | Nacos server address |
+| --port |  | `80` when both `--host` and `--port` are omitted; `8848` when only `--host` is provided | Nacos server port |
+| --server | -s | `market.hiclaw.io:80` when no host/port is provided | Nacos server address (deprecated, use `--host` and `--port`) |
+| --profile |  | default | Profile name; loads `~/.nacos-cli/<profile>.conf` |
+| --config | -c |  | Explicit configuration file path; overrides `--profile` |
+| --username | -u |  | Username (authType=nacos) |
+| --password | -p |  | Password (authType=nacos) |
+| --auth-type |  |  | Authentication type: none / nacos / aliyun / sts-hiclaw |
+| --access-key |  |  | AccessKey (authType=aliyun) |
+| --secret-key |  |  | SecretKey (authType=aliyun) |
+| --security-token |  |  | STS SecurityToken (legacy) |
+| --namespace | -n | (empty/public) | Namespace ID |
+| --verbose |  | false | Print debug output |
+| --help | -h |  | Show help information |
 
 
 ## 8. API Compatibility
@@ -453,6 +736,15 @@ The CLI automatically detects the server version and selects the appropriate API
 1. Use the `ns` command to check the current namespace
 2. Confirm the namespace ID is correct in the Nacos console
 3. Note: The namespace ID is not the namespace name
+
+### 9.4. HTTP 400 parameter validate error on release
+**Problem**: Running `*-release` immediately after `skill-review` / `agentspec-review` fails with `HTTP 400 parameter validate error`
+
+**Solution**:
+
+1. The server-side review pipeline runs asynchronously and may not have updated the version status to `reviewed` yet
+2. Wait a few seconds and re-check the status via `skill-describe` / `agentspec-describe`
+3. Retry `*-release` once `STATUS=reviewed`
 
 ## 10. Related Resources
 + [Nacos GitHub](https://github.com/alibaba/nacos)

--- a/src/content/docs/next/en/manual/user/java-sdk/usage.md
+++ b/src/content/docs/next/en/manual/user/java-sdk/usage.md
@@ -2356,133 +2356,13 @@ try {
 }
 ```
 
-## 8. Skill 能力
+## 8. Skill Capabilities
 
-### 8.1. Load Skill
+> Skills are distributed via the Java SDK as ZIP packages containing SKILL.md and all resource files (binary resources are decoded from Base64 back to raw bytes). The SDK currently exposes three download variants: by name, by version, and by label.
 
-#### 描述
+### 8.1. Download Skill ZIP
 
-Load the complete Skill object by skill name, including main configuration and all resource configurations.
-
-```java
-Skill loadSkill(String skillName) throws NacosException;
-```
-
-#### 请求参数
-
-| 名称       | 类型     | 描述                    | 默认值  |
-|:---------|:-------|-----------------------|------|
-| skillName | String | Skill name (unique identifier) | 无，必填 |
-
-#### 返回参数
-
-| 参数类型 | 描述        |
-| :--- | :--- |
-| Skill | Complete Skill object with all resources |
-
-#### 请求示例
-
-```java
-Properties properties = new Properties();
-properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
-AiService aiService = AiFactory.createAiService(properties);
-try {
-    Skill skill = aiService.loadSkill("{skillName}");
-    System.out.println(JacksonUtils.toJson(skill));
-} catch (NacosException e) {
-    e.printStackTrace();
-}
-```
-
-#### 异常说明
-
-Throws NacosException when skill not found or query error.
-
-### 8.2. Subscribe Skill
-
-#### 描述
-
-Subscribe to a skill; the listener is invoked when the skill configuration changes.
-
-```java
-Skill subscribeSkill(String skillName, AbstractNacosSkillListener skillListener) throws NacosException;
-```
-
-#### 请求参数
-
-| 名称           | 类型                         | 描述                | 默认值  |
-|:-------------|:---------------------------|-------------------|------|
-| skillName    | String                     | Skill name           | 无，必填 |
-| skillListener | AbstractNacosSkillListener | Callback listener for skill changes     | 无，必填 |
-
-#### 返回参数
-
-| 参数类型 | 描述              |
-| :--- | :--- |
-| Skill | Current Skill at subscribe time, or null if not found |
-
-#### 请求示例
-
-```java
-Properties properties = new Properties();
-properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
-AiService aiService = AiFactory.createAiService(properties);
-try {
-    Skill skill = aiService.subscribeSkill("{skillName}", new AbstractNacosSkillListener() {
-        @Override
-        public void onEvent(NacosSkillEvent event) {
-            System.out.println("skill changed: " + event.getSkillName());
-        }
-    });
-    System.out.println(JacksonUtils.toJson(skill));
-} catch (NacosException e) {
-    e.printStackTrace();
-}
-```
-
-#### 异常说明
-
-Throws NacosException when parameters are invalid or on handle error.
-
-### 8.3. Unsubscribe Skill
-
-#### 描述
-
-Unsubscribe from a skill. The listener must be the same instance used when subscribing, otherwise unsubscribe may fail.
-
-```java
-void unsubscribeSkill(String skillName, AbstractNacosSkillListener skillListener) throws NacosException;
-```
-
-#### 请求参数
-
-| 名称           | 类型                         | 描述            | 默认值  |
-|:-------------|:---------------------------|---------------|------|
-| skillName    | String                     | Skill name       | 无，必填 |
-| skillListener | AbstractNacosSkillListener | Listener used when subscribing   | 无，必填 |
-
-#### 返回参数
-
-无
-
-#### 请求示例
-
-```java
-Properties properties = new Properties();
-properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
-AiService aiService = AiFactory.createAiService(properties);
-AbstractNacosSkillListener listener = new AbstractNacosSkillListener() {};
-try {
-    aiService.subscribeSkill("{skillName}", listener);
-    aiService.unsubscribeSkill("{skillName}", listener);
-} catch (NacosException e) {
-    e.printStackTrace();
-}
-```
-
-### 8.4. Download Skill ZIP
-
-#### 描述
+#### Description
 
 Download the latest Skill ZIP package (byte array) by skill name.
 
@@ -2490,17 +2370,17 @@ Download the latest Skill ZIP package (byte array) by skill name.
 byte[] downloadSkillZip(String skillName) throws NacosException;
 ```
 
-#### 请求参数
+#### Request Parameters
 
-| 名称       | 类型     | 描述                    | 默认值  |
-|:---------|:-------|-----------------------|------|
-| skillName | String | Skill name (unique identifier) | 无，必填 |
+| Name      | Type   | Description                    | Default     |
+|:----------|:-------|--------------------------------|-------------|
+| skillName | String | Skill name (unique identifier) | — required  |
 
-#### 返回参数
+#### Response
 
-Skill ZIP bytes `byte[]`.
+Skill ZIP bytes `byte[]` containing SKILL.md and all resource files.
 
-#### 请求示例
+#### Example
 
 ```java
 Properties properties = new Properties();
@@ -2514,28 +2394,32 @@ try {
 }
 ```
 
-### 8.5. Download Skill ZIP by Version
+#### Exceptions
 
-#### 描述
+Throws NacosException when the skill is not found or on query error.
 
-Download a specific version of Skill ZIP package (byte array) by skill name and version.
+### 8.2. Download Skill ZIP by Version
+
+#### Description
+
+Download a specific version of the Skill ZIP package (byte array) by skill name and version.
 
 ```java
 byte[] downloadSkillZipByVersion(String skillName, String version) throws NacosException;
 ```
 
-#### 请求参数
+#### Request Parameters
 
-| 名称       | 类型     | 描述                       | 默认值  |
-|:---------|:-------|--------------------------|------|
-| skillName | String | Skill name (unique identifier) | 无，必填 |
-| version   | String | Target skill version; latest when null | 无      |
+| Name      | Type   | Description                              | Default     |
+|:----------|:-------|------------------------------------------|-------------|
+| skillName | String | Skill name (unique identifier)           | — required  |
+| version   | String | Target skill version; latest when null   | —           |
 
-#### 返回参数
+#### Response
 
 Skill ZIP bytes `byte[]`.
 
-#### 请求示例
+#### Example
 
 ```java
 Properties properties = new Properties();
@@ -2549,9 +2433,13 @@ try {
 }
 ```
 
-### 8.6. Download Skill ZIP by Label
+#### Exceptions
 
-#### 描述
+Throws NacosException when the skill or specified version is not found, or on query error.
+
+### 8.3. Download Skill ZIP by Label
+
+#### Description
 
 Download a labeled Skill ZIP package (byte array) by skill name and label.
 
@@ -2559,18 +2447,18 @@ Download a labeled Skill ZIP package (byte array) by skill name and label.
 byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException;
 ```
 
-#### 请求参数
+#### Request Parameters
 
-| 名称       | 类型     | 描述                         | 默认值  |
-|:---------|:-------|----------------------------|------|
-| skillName | String | Skill name (unique identifier) | 无，必填 |
-| label     | String | Target label (for example: `latest`, `stable`) | 无，必填 |
+| Name      | Type   | Description                                    | Default     |
+|:----------|:-------|------------------------------------------------|-------------|
+| skillName | String | Skill name (unique identifier)                 | — required  |
+| label     | String | Target label (for example: `latest`, `stable`) | — required  |
 
-#### 返回参数
+#### Response
 
 Skill ZIP bytes `byte[]`.
 
-#### 请求示例
+#### Example
 
 ```java
 Properties properties = new Properties();
@@ -2583,6 +2471,10 @@ try {
     e.printStackTrace();
 }
 ```
+
+#### Exceptions
+
+Throws NacosException when the skill or specified label is not found, or on query error.
 
 ## 9. Prompt 能力
 

--- a/src/content/docs/next/zh-cn/manual/admin/nacos-cli.md
+++ b/src/content/docs/next/zh-cn/manual/admin/nacos-cli.md
@@ -1,14 +1,14 @@
 ---
 title: Nacos CLI 使用指南
 keywords: [ Nacos, Nacos CLI ]
-description: Nacos CLI 使用指南，介绍如何安装和使用 Nacos CLI 进行配置管理、AI 技能管理以及交互式终端操作。
+description: Nacos CLI 使用指南，介绍如何安装和使用 Nacos CLI 进行配置管理、AI 技能（Skill）和 AgentSpec 的全生命周期管理，以及交互式终端操作。
 sidebar:
   order: 14
 ---
 
 # Nacos CLI 使用指南
 
-Nacos CLI 是一个面向 Nacos 配置中心的命令行工具，支持配置管理、AI 技能管理以及交互式终端模式。
+Nacos CLI 是一个面向 Nacos 配置中心的命令行工具，支持配置管理、AI 技能（Skill）和 AgentSpec 的全生命周期管理（upload → review → release），以及交互式终端模式。
 
 ## 1. 环境准备
 ### 1.1. 运行环境要求
@@ -25,7 +25,7 @@ Nacos CLI 是一个面向 Nacos 配置中心的命令行工具，支持配置管
 **Linux / macOS：**
 
 ```bash
-curl -fsSL https://nacos.io/nacos-installer.sh | sudo bash -s -- --cli
+curl -fsSL https://nacos.io/nacos-installer.sh | bash -s -- --cli
 ```
 
 **Windows（PowerShell）：**
@@ -52,26 +52,72 @@ nacos-cli --help
 ```
 
 ## 3. 认证配置
-Nacos CLI 支持两种认证方式：
+Nacos CLI 支持以下几种认证方式：
 
-### 3.1. 配置文件（推荐）
-为避免每次都输入认证信息，推荐使用配置文件。
+- `none`：无认证
+- `nacos`：用户名 / 密码
+- `aliyun`：阿里云 AccessKey / SecretKey（适用于阿里云 MSE Nacos）
+- `sts-hiclaw`：STS 临时凭证（通过 `HICLAW_CONTROLLER_URL` 和 `HICLAW_AUTH_TOKEN_FILE` 环境变量动态获取）
+
+### 3.1. Profile 配置（推荐）
+Nacos CLI 将不同环境的连接信息保存为 profile，每个 profile 对应 `~/.nacos-cli/<profile>.conf` 一个 YAML 文件。默认 profile 名称为 `default`，对应 `~/.nacos-cli/default.conf`。
+
+> **首次使用**：直接执行 `nacos-cli` 即可。CLI 检测不到 profile 时会自动进入交互式向导，引导你填写 host、port、authType、用户名、密码等字段，并将结果保存到 `~/.nacos-cli/default.conf`，下次再启动会直接复用。
+
+#### 3.1.1. 创建/编辑 profile
+通过 `nacos-cli profile edit` 进入交互式编辑，会显示当前值作为默认提示，回车保留原值。
 
 ```bash
-# 创建配置文件
-cat > local.conf << EOF
-host: <your_nacos_host>
-port: <your_nacos_port>
-username: <your_username>
-password: <your_password>
-namespace: ""
-EOF
+# 创建/编辑 default profile（保存到 ~/.nacos-cli/default.conf）
+nacos-cli profile edit
 
-# 使用配置文件
-nacos-cli --config ./local.conf skill-list
+# 创建/编辑 dev profile（保存到 ~/.nacos-cli/dev.conf）
+nacos-cli profile edit dev
+
+# 创建/编辑 prod profile
+nacos-cli profile edit prod
 ```
 
-**配置文件格式**（YAML）：
+编辑完成后，CLI 会询问是否立即登录并进入交互式终端，回车默认登录。
+
+#### 3.1.2. 查看 profile
+```bash
+# 查看 default profile
+nacos-cli profile show
+
+# 查看 dev profile
+nacos-cli profile show dev
+```
+
+输出示例（密码/SecretKey 默认掩码显示）：
+```plain
+Profile: dev
+Config file: /Users/<user>/.nacos-cli/dev.conf
+─────────────────────────────────────────
+host:           127.0.0.1
+port:           8848
+auth-type:      nacos
+username:       nacos
+password:       ******
+namespace:      (public)
+```
+
+#### 3.1.3. 切换 profile
+默认加载 `default` profile，可通过 `--profile` 参数切换：
+
+```bash
+# 使用 default profile（等价于不传 --profile）
+nacos-cli skill-list
+
+# 使用 dev profile（加载 ~/.nacos-cli/dev.conf）
+nacos-cli --profile dev skill-list
+
+# 使用 prod profile
+nacos-cli --profile prod config-list
+```
+
+#### 3.1.4. 配置文件格式
+profile 文件采用 YAML 格式（注意：字段使用 camelCase）：
 
 ```yaml
 # Nacos 服务器地址
@@ -80,53 +126,106 @@ host: <your_nacos_host>
 # Nacos 服务器端口
 port: <your_nacos_port>
 
-# 认证方式：nacos 或 aliyun
-auth_type: nacos
+# 认证方式：none | nacos | aliyun | sts-hiclaw
+authType: nacos
 
-# Nacos 认证
+# Nacos 认证（authType=nacos 时使用）
 username: <your_username>
 password: <your_password>
 
-# 阿里云认证（可选）
-access_key: ""
-secret_key: ""
+# 阿里云认证（authType=aliyun 时使用）
+accessKey: ""
+secretKey: ""
+
+# STS SecurityToken（旧版兼容）
+securityToken: ""
 
 # 命名空间 ID（可选，留空使用 public）
 namespace: ""
 ```
 
-### 3.2. 命令行参数
-#### 3.2.1. Nacos 认证（用户名/密码）
+> **注意**：`authType=sts-hiclaw` 时无需在配置文件中填写凭证，CLI 会从环境变量 `HICLAW_CONTROLLER_URL` 与 `HICLAW_AUTH_TOKEN_FILE` 中动态读取。
+
+### 3.2. 显式指定配置文件（`--config`）
+也可以通过 `--config` 加载任意路径的配置文件，常用于把配置签入项目仓库或脚本环境：
+
+```bash
+nacos-cli --config /path/to/custom.conf skill-list
+```
+
+`--config` 的优先级高于 profile，指定后将忽略 `--profile` 与 `~/.nacos-cli/` 下的 profile。
+
+### 3.3. 命令行参数
+也可以完全通过命令行参数提供，不依赖任何配置文件：
+
+#### 3.3.1. Nacos 认证（用户名/密码）
 ```bash
 nacos-cli --host <host> --port <port> -u <username> -p <password>
 ```
 
-#### 3.2.2. 阿里云认证（AccessKey/SecretKey）
-如果您使用的是阿里云 MSE Nacos，可以使用 AK/SK 进行认证：
-
+#### 3.3.2. 阿里云认证（AccessKey/SecretKey）
 ```bash
 nacos-cli --host <host> --port <port> --auth-type aliyun --access-key <your_ak> --secret-key <your_sk>
 ```
 
-### 3.3. 配置优先级
-配置值按以下优先级应用：
+#### 3.3.3. STS（sts-hiclaw）认证
+```bash
+export HICLAW_CONTROLLER_URL=https://<controller-host>
+export HICLAW_AUTH_TOKEN_FILE=/path/to/token
+
+nacos-cli --host <host> --port <port> --auth-type sts-hiclaw
+```
+
+### 3.4. 环境变量
+也可以通过环境变量提供 Nacos 连接信息：
+
+```bash
+export NACOS_HOST=127.0.0.1
+export NACOS_PORT=8848
+export NACOS_NAMESPACE=xxx
+export NACOS_AUTH_TYPE=nacos
+```
+
+`sts-hiclaw` 还需要：
+
+```bash
+export HICLAW_CONTROLLER_URL=https://<controller-host>
+export HICLAW_AUTH_TOKEN_FILE=/path/to/token
+```
+
+### 3.5. 配置优先级
+配置值按以下优先级应用（从高到低）：
 
 1. **命令行参数**（最高优先级）
-2. **配置文件**
-3. **默认值**（最低优先级）
+2. **`--config` 显式指定的配置文件**
+3. **`--profile` 指定的 profile（默认 `default`）**
+4. **环境变量**（`NACOS_HOST` / `NACOS_PORT` / `NACOS_NAMESPACE` / `NACOS_AUTH_TYPE`）
+5. **默认值**（最低优先级）
 
 示例：
 
 ```bash
-# 使用配置文件，但覆盖 host
-nacos-cli --config ./local.conf --host <another_host> skill-list
+# 使用 dev profile，但通过命令行覆盖 host
+nacos-cli --profile dev --host 10.0.0.1 skill-list
 
-# 完全使用配置文件
-nacos-cli --config ./local.conf skill-list
+# 显式指定配置文件
+nacos-cli --config /path/to/custom.conf skill-list
+
+# 使用环境变量（命令行、--config、profile 均未提供时）
+NACOS_HOST=127.0.0.1 NACOS_PORT=8848 NACOS_NAMESPACE=xxx nacos-cli skill-list
+
+# 不传任何参数时，自动进入交互向导生成 default profile，并连接其中的服务器
+nacos-cli
+
+# 仅传 --host 时，端口默认 8848
+nacos-cli --host 127.0.0.1
+
+# 仅传 --port 时，host 默认 127.0.0.1
+nacos-cli --port 8849
 ```
 
 ## 4. 快速开始
-> **提示**：以下示例假设已配置好配置文件，详见 [3.1 配置文件](#31-配置文件推荐)。
+> **提示**：以下示例假设已通过 `nacos-cli profile edit` 配置好默认 profile，详见 [3.1 Profile 配置](#31-profile-配置推荐)。
 >
 
 ### 4.1. CLI 模式
@@ -161,12 +260,15 @@ nacos> help
 
 ## 5. 功能模块
 
-### 5.1. AI 技能管理 ✅
+### 5.1. AI 技能（Skill）管理 ✅
 
-Nacos CLI 提供了完整的 AI 技能生命周期管理功能，包括列出、下载、上传和实时同步。
+Skill 遵循三阶段生命周期，与服务端保持一致：
+`upload`（editing）→ `review`（reviewing → reviewed）→ `release`（online）。
+
+Nacos CLI 提供 Skill 的完整生命周期管理：列出、查看详情、下载、上传、提交评审、发布上线，以及实时同步。
 
 #### 5.1.1. 列出技能
-获取 Nacos 中存储的 AI 技能列表，默认显示技能描述（截断为 50 字符）。
+获取 Nacos 中存储的 AI 技能列表，默认显示技能描述（截断为 50 字符），支持脚本友好的 JSON 输出。
 
 **命令格式**
 ```bash
@@ -180,6 +282,7 @@ nacos-cli skill-list [flags]
 | --name |  |  | 按技能名称过滤 |
 | --page |  | 1 | 页码 |
 | --size |  | 10 | 每页数量 |
+| --output |  | pretty | 输出格式：`pretty`(默认) 或 `json`(便于脚本解析) |
 
 **使用示例**
 ```bash
@@ -187,14 +290,35 @@ nacos-cli skill-list [flags]
 nacos-cli skill-list
 
 # 按名称过滤
-nacos-cli skill-list --name <skill-name>
+nacos-cli skill-list --name <skill-name> --page 1 --size 20
+
+# 脚本友好的 JSON 输出
+nacos-cli skill-list --output json
 
 # 交互模式
 nacos> skill-list
 nacos> skill-list --name <skill-name> --page 2
+nacos> skill-list --output json
 ```
 
-#### 5.1.2. 获取/下载技能
+#### 5.1.2. 查看技能详情（describe）
+查看指定 Skill 的详情和版本历史（latest / editing / reviewing / online，以及每个版本的状态）。
+
+**命令格式**
+```bash
+nacos-cli skill-describe <skill-name> [flags]
+```
+
+**使用示例**
+```bash
+nacos-cli skill-describe <skill-name>
+nacos-cli skill-describe <skill-name> --output json
+
+# 交互模式
+nacos> skill-describe <skill-name>
+```
+
+#### 5.1.3. 获取/下载技能
 
 从 Nacos 下载技能到本地目录，包括技能元数据（SKILL.md）和所有资源文件。
 
@@ -233,9 +357,9 @@ nacos> skill-get <skill-name>
     └── init_skill.py
 ```
 
-#### 5.1.3. 上传技能
+#### 5.1.4. 上传技能
 
-将本地技能上传到 Nacos，支持单个技能或批量上传。
+将本地技能上传到 Nacos（创建或更新 `editing` 版本），支持单个技能或批量上传。
 
 **命令格式**
 ```bash
@@ -261,7 +385,54 @@ nacos> skill-upload /path/to/skill
 nacos> skill-upload --all /path/to/skills
 ```
 
-#### 5.1.4. 实时同步技能
+#### 5.1.5. 提交技能评审（review）
+
+将当前 `editing` 版本提交进入评审流程（editing → reviewing）。服务端的评审管线是异步执行的，最终会将版本标记为 `reviewed`。
+
+**命令格式**
+```bash
+nacos-cli skill-review <skill-name>
+```
+
+**使用示例**
+```bash
+nacos-cli skill-review <skill-name>
+
+# 交互模式
+nacos> skill-review <skill-name>
+```
+
+#### 5.1.6. 发布技能（release）
+
+将已评审通过（reviewed）的版本发布上线。
+
+**命令格式**
+```bash
+nacos-cli skill-release <skill-name> --version <version> [flags]
+```
+
+**使用示例**
+```bash
+nacos-cli skill-release <skill-name> --version 0.0.2
+nacos-cli skill-release <skill-name> --version 0.0.2 --update-latest=false
+
+# 交互模式
+nacos> skill-release <skill-name> --version 0.0.2
+```
+
+> **注意**：如果在 `skill-review` 后立即执行 `skill-release` 出现 `HTTP 400 parameter validate error`，通常是异步评审管线尚未将版本标记为 `reviewed`。CLI 会打印提示，建议等待几秒后通过 `skill-describe` 重新查看状态，等到 `STATUS=reviewed` 后再重试。
+
+#### 5.1.7. 发布技能（publish，已废弃）
+
+`skill-publish` 是一个向后兼容的快捷命令，会依次执行 `upload` + `review`，并打印废弃提示。后续版本将移除，建议改用上述独立的生命周期命令。
+
+```bash
+# 旧版快捷命令（已废弃）
+nacos-cli skill-publish /path/to/skill
+nacos-cli skill-publish --all /path/to/skills/folder
+```
+
+#### 5.1.8. 实时同步技能
 
 监听 Nacos 中技能的变更，自动同步到本地目录。当技能在 Nacos 中更新时，本地文件会自动更新。
 
@@ -293,11 +464,119 @@ nacos-cli skill-sync --all
 # 按 Ctrl+C 停止同步
 ```
 
-### 5.2. 配置管理 ✅
+### 5.2. AgentSpec 管理 ✅
+
+AgentSpec 遵循与 Skill 相同的三阶段生命周期：
+`upload`（editing）→ `review`（reviewing → reviewed）→ `release`（online）。
+
+#### 5.2.1. 列出 AgentSpec
+
+```bash
+# CLI 模式（默认 pretty 输出）
+nacos-cli agentspec-list
+
+# 带过滤条件
+nacos-cli agentspec-list --name <agentspec-name> --page 1 --size 20
+
+# 脚本友好的 JSON 输出
+nacos-cli agentspec-list --output json
+
+# 交互模式
+nacos> agentspec-list
+nacos> agentspec-list --name <agentspec-name> --page 2
+nacos> agentspec-list --output json
+```
+
+#### 5.2.2. 查看 AgentSpec 详情
+
+显示详情和版本历史（latest / editing / reviewing / online，以及每个版本的状态）：
+
+```bash
+nacos-cli agentspec-describe <agentspec-name>
+nacos-cli agentspec-describe <agentspec-name> --output json
+
+# 交互模式
+nacos> agentspec-describe <agentspec-name>
+```
+
+#### 5.2.3. 获取/下载 AgentSpec
+
+将 AgentSpec 下载到本地目录（默认：`~/.agentspecs`）：
+
+```bash
+# CLI 模式
+nacos-cli agentspec-get <agentspec-name>
+nacos-cli agentspec-get <agentspec-name> -o /custom/path
+
+# 下载指定版本
+nacos-cli agentspec-get <agentspec-name> --version v1
+
+# 按路由标签下载
+nacos-cli agentspec-get <agentspec-name> --label latest
+
+# 批量下载多个 AgentSpec
+nacos-cli agentspec-get spec1 spec2 spec3
+
+# 交互模式
+nacos> agentspec-get <agentspec-name>
+```
+
+#### 5.2.4. 上传 AgentSpec
+
+从本地目录上传 AgentSpec（创建或更新 `editing` 版本）：
+
+```bash
+# 上传单个 AgentSpec
+nacos-cli agentspec-upload /path/to/agentspec
+
+# 批量上传目录下所有 AgentSpec
+nacos-cli agentspec-upload --all /path/to/agentspecs/folder
+
+# 交互模式
+nacos> agentspec-upload /path/to/agentspec
+nacos> agentspec-upload --all /path/to/agentspecs
+```
+
+#### 5.2.5. 提交 AgentSpec 评审
+
+将当前 `editing` 版本提交进入评审流程（editing → reviewing），服务端评审管线异步执行，最终会将版本标记为 `reviewed`。
+
+```bash
+nacos-cli agentspec-review <agentspec-name>
+
+# 交互模式
+nacos> agentspec-review <agentspec-name>
+```
+
+#### 5.2.6. 发布 AgentSpec
+
+将已评审通过（reviewed）的版本发布上线：
+
+```bash
+nacos-cli agentspec-release <agentspec-name> --version 0.0.2
+nacos-cli agentspec-release <agentspec-name> --version 0.0.2 --update-latest=false
+
+# 交互模式
+nacos> agentspec-release <agentspec-name> --version 0.0.2
+```
+
+> **注意**：如果在 `agentspec-review` 后立即执行 `agentspec-release` 出现 `HTTP 400 parameter validate error`，通常是异步评审管线尚未将版本标记为 `reviewed`。CLI 会打印提示，建议等待几秒后通过 `agentspec-describe` 重新查看状态，等到 `STATUS=reviewed` 后再重试。
+
+#### 5.2.7. 发布 AgentSpec（publish，已废弃）
+
+`agentspec-publish` 是一个向后兼容的快捷命令，会依次执行 `upload` + `review`，并打印废弃提示。后续版本将移除，建议改用上述独立的生命周期命令。
+
+```bash
+# 旧版快捷命令（已废弃）
+nacos-cli agentspec-publish /path/to/agentspec
+nacos-cli agentspec-publish --all /path/to/agentspecs/folder
+```
+
+### 5.3. 配置管理 ✅
 
 提供配置中心的配置列表查询和配置内容获取功能。
 
-#### 5.2.1. 列出配置
+#### 5.3.1. 列出配置
 
 获取 Nacos 配置中心的配置列表，支持按 dataId、group 进行过滤。
 
@@ -331,7 +610,7 @@ nacos> config-list
 nacos> config-list --data-id <dataId> --page 2
 ```
 
-#### 5.2.2. 获取配置
+#### 5.3.2. 获取配置
 
 获取指定 dataId 和 group 的配置内容。
 
@@ -356,7 +635,7 @@ nacos-cli config-get <dataId> <group>
 nacos> config-get <dataId> <group>
 ```
 
-### 5.3. 服务注册 (Naming) ❌
+### 5.4. 服务注册 (Naming) ❌
 
 服务注册与发现功能尚未实现，包括：
 
@@ -366,14 +645,14 @@ nacos> config-get <dataId> <group>
 - `instance-register` - 注册服务实例
 - `instance-deregister` - 注销服务实例
 
-### 5.4. 分布式锁 (Lock) ❌
+### 5.5. 分布式锁 (Lock) ❌
 
 分布式锁功能尚未实现，包括：
 
 - `lock-acquire` - 获取分布式锁
 - `lock-release` - 释放分布式锁
 
-### 5.5. 贡献指南
+### 5.6. 贡献指南
 
 我们欢迎社区开发者一起参与 Nacos CLI 的建设！欢迎通过 [GitHub](https://github.com/nacos-group/nacos-cli) 提交 Issue 或 Pull Request。
 
@@ -404,18 +683,22 @@ nacos> quit           # 退出
 ## 7. 全局参数
 以下参数适用于所有命令：
 
-| 参数 | 简写 | 描述 |
-| --- | --- | --- |
-| --host |  | Nacos 服务器地址 |
-| --port |  | Nacos 服务器端口 |
-| --username | -u | 用户名（Nacos 认证） |
-| --password | -p | 密码（Nacos 认证） |
-| --auth-type |  | 认证类型：nacos 或 aliyun |
-| --access-key |  | AccessKey（阿里云认证） |
-| --secret-key |  | SecretKey（阿里云认证） |
-| --namespace | -n | 命名空间 ID |
-| --config | -c | 配置文件路径 |
-| --help | -h | 显示帮助信息 |
+| 参数 | 简写 | 默认值 | 描述 |
+| --- | --- | --- | --- |
+| --host |  | 当 `--host` 与 `--port` 都未指定时为 `market.hiclaw.io`；仅指定 `--port` 时为 `127.0.0.1` | Nacos 服务器地址 |
+| --port |  | 当 `--host` 与 `--port` 都未指定时为 `80`；仅指定 `--host` 时为 `8848` | Nacos 服务器端口 |
+| --server | -s | 当未指定 host/port 时为 `market.hiclaw.io:80` | Nacos 服务器地址（已废弃，请使用 `--host` 与 `--port`） |
+| --profile |  | default | profile 名称，加载 `~/.nacos-cli/<profile>.conf` |
+| --config | -c |  | 显式指定配置文件路径，优先级高于 `--profile` |
+| --username | -u |  | 用户名（authType=nacos） |
+| --password | -p |  | 密码（authType=nacos） |
+| --auth-type |  |  | 认证类型：none / nacos / aliyun / sts-hiclaw |
+| --access-key |  |  | AccessKey（authType=aliyun） |
+| --secret-key |  |  | SecretKey（authType=aliyun） |
+| --security-token |  |  | STS SecurityToken（旧版兼容） |
+| --namespace | -n | (空/public) | 命名空间 ID |
+| --verbose |  | false | 打印调试信息 |
+| --help | -h |  | 显示帮助信息 |
 
 
 ## 8. API 兼容性
@@ -453,6 +736,15 @@ CLI 会自动检测服务器版本并选择合适的 API 版本，无需用户�
 1. 使用 `ns` 命令查看当前命名空间
 2. 在 Nacos 控制台确认命名空间 ID 是否正确
 3. 注意：命名空间 ID 不是命名空间名称
+
+### 9.4. release 时返回 HTTP 400 parameter validate error
+**问题**：刚执行 `skill-review` / `agentspec-review` 后立即执行 `*-release`，提示 `HTTP 400 parameter validate error`
+
+**解决方案**：
+
+1. 服务端评审管线异步执行，可能尚未将版本状态更新为 `reviewed`
+2. 等待几秒后通过 `skill-describe` / `agentspec-describe` 重新查看状态
+3. 当 `STATUS=reviewed` 后再重试 `*-release`
 
 ## 10. 相关资源
 + [Nacos GitHub](https://github.com/alibaba/nacos)

--- a/src/content/docs/next/zh-cn/manual/user/java-sdk/usage.md
+++ b/src/content/docs/next/zh-cn/manual/user/java-sdk/usage.md
@@ -2358,129 +2358,9 @@ try {
 
 ## 8. Skill 能力
 
-### 8.1. 加载 Skill
+> Skill 在 Java SDK 中以 ZIP 压缩包的形式分发，包含 SKILL.md 和全部资源文件（二进制资源会从 Base64 自动解码为原始字节）。SDK 当前提供按名称、按版本、按标签三种下载方式。
 
-#### 描述
-
-根据 Skill 名称加载完整的 Skill 对象，包含主配置及全部资源配置。
-
-```java
-Skill loadSkill(String skillName) throws NacosException;
-```
-
-#### 请求参数
-
-| 名称       | 类型     | 描述                    | 默认值  |
-|:---------|:-------|-----------------------|------|
-| skillName | String | Skill 名称（唯一标识）       | 无，必填 |
-
-#### 返回参数
-
-| 参数类型 | 描述        |
-| :--- | :--- |
-| Skill | 包含全部资源的完整 Skill 对象 |
-
-#### 请求示例
-
-```java
-Properties properties = new Properties();
-properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
-AiService aiService = AiFactory.createAiService(properties);
-try {
-    Skill skill = aiService.loadSkill("{skillName}");
-    System.out.println(JacksonUtils.toJson(skill));
-} catch (NacosException e) {
-    e.printStackTrace();
-}
-```
-
-#### 异常说明
-
-Skill 不存在或查询异常时，抛出 NacosException。
-
-### 8.2. 订阅 Skill
-
-#### 描述
-
-订阅指定 Skill，当 Skill 配置发生变更时通过监听器回调。
-
-```java
-Skill subscribeSkill(String skillName, AbstractNacosSkillListener skillListener) throws NacosException;
-```
-
-#### 请求参数
-
-| 名称           | 类型                         | 描述                | 默认值  |
-|:-------------|:---------------------------|-------------------|------|
-| skillName    | String                     | Skill 名称           | 无，必填 |
-| skillListener | AbstractNacosSkillListener | Skill 变更回调监听器     | 无，必填 |
-
-#### 返回参数
-
-| 参数类型 | 描述              |
-| :--- | :--- |
-| Skill | 订阅成功时返回当前 Skill 对象，未找到可为 null |
-
-#### 请求示例
-
-```java
-Properties properties = new Properties();
-properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
-AiService aiService = AiFactory.createAiService(properties);
-try {
-    Skill skill = aiService.subscribeSkill("{skillName}", new AbstractNacosSkillListener() {
-        @Override
-        public void onEvent(NacosSkillEvent event) {
-            System.out.println("skill changed: " + event.getSkillName());
-        }
-    });
-    System.out.println(JacksonUtils.toJson(skill));
-} catch (NacosException e) {
-    e.printStackTrace();
-}
-```
-
-#### 异常说明
-
-参数无效或处理异常时，抛出 NacosException。
-
-### 8.3. 取消订阅 Skill
-
-#### 描述
-
-取消对指定 Skill 的订阅。取消时传入的监听器必须与订阅时一致，否则可能导致取消失败。
-
-```java
-void unsubscribeSkill(String skillName, AbstractNacosSkillListener skillListener) throws NacosException;
-```
-
-#### 请求参数
-
-| 名称           | 类型                         | 描述            | 默认值  |
-|:-------------|:---------------------------|---------------|------|
-| skillName    | String                     | Skill 名称       | 无，必填 |
-| skillListener | AbstractNacosSkillListener | 订阅时使用的监听器   | 无，必填 |
-
-#### 返回参数
-
-无
-
-#### 请求示例
-
-```java
-Properties properties = new Properties();
-properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
-AiService aiService = AiFactory.createAiService(properties);
-AbstractNacosSkillListener listener = new AbstractNacosSkillListener() {};
-try {
-    aiService.subscribeSkill("{skillName}", listener);
-    aiService.unsubscribeSkill("{skillName}", listener);
-} catch (NacosException e) {
-    e.printStackTrace();
-}
-```
-
-### 8.4. 下载 Skill ZIP
+### 8.1. 下载 Skill ZIP
 
 #### 描述
 
@@ -2498,7 +2378,7 @@ byte[] downloadSkillZip(String skillName) throws NacosException;
 
 #### 返回参数
 
-Skill ZIP 压缩包字节数组 `byte[]`。
+Skill ZIP 压缩包字节数组 `byte[]`，包含 SKILL.md 与全部资源文件。
 
 #### 请求示例
 
@@ -2514,7 +2394,11 @@ try {
 }
 ```
 
-### 8.5. 按版本下载 Skill ZIP
+#### 异常说明
+
+Skill 不存在或查询异常时，抛出 NacosException。
+
+### 8.2. 按版本下载 Skill ZIP
 
 #### 描述
 
@@ -2529,7 +2413,7 @@ byte[] downloadSkillZipByVersion(String skillName, String version) throws NacosE
 | 名称       | 类型     | 描述                       | 默认值  |
 |:---------|:-------|--------------------------|------|
 | skillName | String | Skill 名称（唯一标识）           | 无，必填 |
-| version   | String | 目标 Skill 版本，空时获取最新版本    | 无     |
+| version   | String | 目标 Skill 版本，为 null 时获取最新版本 | 无     |
 
 #### 返回参数
 
@@ -2549,7 +2433,11 @@ try {
 }
 ```
 
-### 8.6. 按标签下载 Skill ZIP
+#### 异常说明
+
+Skill 或指定版本不存在、查询异常时，抛出 NacosException。
+
+### 8.3. 按标签下载 Skill ZIP
 
 #### 描述
 
@@ -2583,6 +2471,10 @@ try {
     e.printStackTrace();
 }
 ```
+
+#### 异常说明
+
+Skill 或指定标签不存在、查询异常时，抛出 NacosException。
 
 ## 9. Prompt 能力
 


### PR DESCRIPTION
## Summary

- nacos-cli docs (next, zh-cn + en): align with the new CLI README —
  three-stage lifecycle (upload → review → release), new `agentspec-*`
  commands, `skill-describe / skill-review / skill-release`, deprecate
  `*-publish`, add `--output pretty|json` on list/describe.
- nacos-cli docs: rewrite the auth section around profile-based config
  (`~/.nacos-cli/<profile>.conf`, `nacos-cli profile edit/show`,
  `--profile`). Switch YAML keys to camelCase (`authType`/`accessKey`/
  `secretKey`/`securityToken`), document `none` and `sts-hiclaw` auth
  types, and refresh the priority chain to: CLI flags > `--config` >
  `--profile` > env vars > defaults.
- nacos-cli docs: refresh the global flags table (`--profile`,
  `--security-token`, `--verbose`; correct `--auth-type` values and
  `--host`/`--port` defaults).
- nacos-cli docs: drop the unnecessary `sudo` from the Linux/macOS
  install command — `nacos-installer.sh` writes to `$HOME/.nacos/` and
  edits the shell rc, so root is not required and `sudo` actively
  breaks `$HOME` resolution.
- java-sdk docs (next, zh-cn + en): drop `loadSkill` /
  `subscribeSkill` / `unsubscribeSkill` (removed from `AiService`);
  keep only the three `downloadSkillZip*` variants that still exist.

Scope: `next` only. `latest` and historical versions are unchanged.