### PR TITLE
[ISSUE #14911] docs(auth): clarify LDAP plugin deployment

### DIFF
--- a/src/content/docs/next/en/manual/admin/auth.mdx
+++ b/src/content/docs/next/en/manual/admin/auth.mdx
@@ -101,7 +101,42 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   </TabItem>
 </Tabs>
 
-### 3.1. 设置管理员密码
+### 3.1. LDAP auth deployment
+
+When `nacos.core.auth.system.type=ldap` is enabled, the default distribution now ships the LDAP auth plugin jar by default:
+
+- `nacos-ldap-auth-plugin-<version>.jar` is included in `plugins/`
+- `org.springframework.ldap:spring-ldap-core` is **not** included in `plugins/` by default
+
+Before enabling LDAP auth, manually add the required `spring-ldap-core` jar into the Nacos `plugins/` directory.
+
+Example:
+
+```properties
+nacos.core.auth.system.type=ldap
+nacos.core.auth.enabled=true
+nacos.core.auth.admin.enabled=true
+nacos.core.auth.console.enabled=true
+```
+
+:::note
+If LDAP auth is enabled without `spring-ldap-core` in `plugins/`, the LDAP plugin will not be fully available. Add the dependency jar first, then start or restart Nacos.
+:::
+
+<Tabs>
+  <TabItem label="Non-Docker deployment">
+
+    Copy `spring-ldap-core-*.jar` into `${nacos.home}/plugins/`.
+
+  </TabItem>
+  <TabItem label="Docker deployment">
+
+    The official image does not bundle `spring-ldap-core` by default. Mount or copy the required jar into the container `plugins/` directory before enabling LDAP auth.
+
+  </TabItem>
+</Tabs>
+
+### 3.2. 设置管理员密码
 
 自2.4.0版本开始，Nacos构建时不再提供管理员用户`nacos`的默认密码，需要在首次开启鉴权后，通过API或Nacos控制台进行管理员用户`nacos`的密码初始化步骤，具体操作如下：
 
@@ -132,11 +167,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   </TabItem>
 </Tabs>
 
-### 3.2. 密码强度注意事项
+### 3.3. 密码强度注意事项
 
 > 重要：在Nacos在初始化管理员用户`nacos`、创建或用户密码更新操作期间不强制执行特定密码长度。Nacos集群管理员有责任对自行构建的密码强度进行控制。为了避免与密码强度相关的安全风险，强烈建议初始化时使用强度较高的密码。
 
-### 3.3. 升级集群注意事项
+### 3.4. 升级集群注意事项
 
 > 若Nacos集群升级自旧版本的Nacos，Nacos会认为当前已经存在管理员用户`nacos`，因此并不会要求进行管理员用户`nacos`的初始化流程，管理员用户`nacos`的密码仍然会保留旧版本时所使用的密码；因此若是使用旧版本时未修改过管理员用户`nacos`的默认密码，强烈建议升级后尽快修改管理员用户`nacos`的密码。
 

--- a/src/content/docs/next/zh-cn/manual/admin/auth.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/auth.mdx
@@ -101,7 +101,42 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   </TabItem>
 </Tabs>
 
-### 3.1. 设置管理员密码
+### 3.1. LDAP 鉴权部署说明
+
+当启用 `nacos.core.auth.system.type=ldap` 时，默认发行包的行为如下：
+
+- `plugins/` 目录默认包含 `nacos-ldap-auth-plugin-<version>.jar`
+- 默认**不会**包含 `org.springframework.ldap:spring-ldap-core`
+
+因此，在开启 LDAP 鉴权前，需要手动将 `spring-ldap-core` 相关 jar 放入 Nacos 的 `plugins/` 目录。
+
+示例配置：
+
+```properties
+nacos.core.auth.system.type=ldap
+nacos.core.auth.enabled=true
+nacos.core.auth.admin.enabled=true
+nacos.core.auth.console.enabled=true
+```
+
+:::note
+如果开启 LDAP 鉴权时 `plugins/` 目录中没有 `spring-ldap-core`，LDAP 插件将无法完整生效。请先补充依赖 jar，再启动或重启 Nacos。
+:::
+
+<Tabs>
+  <TabItem label="非 Docker 部署">
+
+    将 `spring-ldap-core-*.jar` 复制到 `${nacos.home}/plugins/`。
+
+  </TabItem>
+  <TabItem label="Docker 镜像部署">
+
+    官方镜像默认不会携带 `spring-ldap-core`。开启 LDAP 鉴权前，请先通过挂载或复制的方式，将所需 jar 放入容器内的 `plugins/` 目录。
+
+  </TabItem>
+</Tabs>
+
+### 3.2. 设置管理员密码
 
 自2.4.0版本开始，Nacos构建时不再提供管理员用户`nacos`的默认密码，需要在首次开启鉴权后，通过API或Nacos控制台进行管理员用户`nacos`的密码初始化步骤，具体操作如下：
 
@@ -132,11 +167,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   </TabItem>
 </Tabs>
 
-### 3.2. 密码强度注意事项
+### 3.3. 密码强度注意事项
 
 > 重要：在Nacos在初始化管理员用户`nacos`、创建或用户密码更新操作期间不强制执行特定密码长度。Nacos集群管理员有责任对自行构建的密码强度进行控制。为了避免与密码强度相关的安全风险，强烈建议初始化时使用强度较高的密码。
 
-### 3.3. 升级集群注意事项
+### 3.4. 升级集群注意事项
 
 > 若Nacos集群升级自旧版本的Nacos，Nacos会认为当前已经存在管理员用户`nacos`，因此并不会要求进行管理员用户`nacos`的初始化流程，管理员用户`nacos`的密码仍然会保留旧版本时所使用的密码；因此若是使用旧版本时未修改过管理员用户`nacos`的默认密码，强烈建议升级后尽快修改管理员用户`nacos`的密码。
 


### PR DESCRIPTION
Document the LDAP auth deployment behavior after #15118.

Clarify that nacos-ldap-auth-plugin ships by default, while spring-ldap-core must be added manually to the plugins directory when LDAP auth is enabled.


## What is the purpose of the change

- nacos-ldap-auth-plugin-<version>.jar ships by default

- spring-ldap-core does not ship by default

- users must manually place spring-ldap-core-*.jar into plugins/

- Docker users must mount/copy that jar into the container before enabling LDAP auth

## Brief changelog

- updated src/content/docs/next/en/manual/admin/auth.mdx

- updated src/content/docs/next/zh-cn/manual/admin/auth.mdx

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Test your code locally by running `npm run build`, and make sure it works as expected.
- [x] Make sure no files under build directory is added.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).