### PR TITLE
feat(home): add Nacos CLI access and sync Java SDK docs

### DIFF
--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -1,0 +1,645 @@
+---
+name: nacos-skill-registry
+description: Discover, install, update, merge, and publish AI skills with Nacos for personal or team skill registries.
+---
+
+# Nacos Skill Registry
+
+This skill helps you discover, install, update, merge, and publish AI skills through Nacos using the `nacos-cli` tool.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a task with an existing skill in Nacos
+- Says "find a skill for X" or "is there a skill in Nacos for X"
+- Asks "what skills are available" or "list skills from Nacos"
+- Wants to search for tools, templates, or workflows stored in Nacos
+- Needs to download or install a skill from a personal, team, or organization Nacos registry
+- Wants to upload or publish a local skill to Nacos for reuse
+- Mentions sharing skills across agents, machines, teammates, or execution environments
+- Needs to merge local skill edits with a newer remote version and publish the merged result
+
+## What is nacos-cli?
+
+The nacos-cli is a command-line tool for interacting with Nacos. It supports configuration management, skill management, agent spec management, and provides an interactive terminal.
+
+**GitHub**: https://github.com/nacos-group/nacos-cli
+
+**Key skill commands:**
+
+- `nacos-cli skill-list` — Search and list available skills
+- `nacos-cli skill-get <name...>` — Download and install one or more skills locally
+- `nacos-cli skill-upload <path>` — Upload a skill and create an editing draft
+- `nacos-cli skill-review <name> [--version <version>]` — Submit a draft for review
+- `nacos-cli skill-release <name> --version <version>` — Release an approved version online
+- `nacos-cli skill-describe <name>` — Inspect skill metadata and per-version status
+
+**Other commands:**
+
+- `nacos-cli profile edit|show [name]` — Manage connection profiles
+- `nacos-cli config-list|config-get|config-set` — Manage Nacos configurations
+- `nacos-cli agentspec-list|agentspec-get|agentspec-upload|agentspec-review|agentspec-release|agentspec-describe` — Manage agent specs
+- `nacos-cli interactive` — Start interactive terminal mode
+- `nacos-cli completion [bash|zsh|fish|powershell]` — Generate shell completion scripts
+
+## Version-Aware CLI Contract
+
+Always check the installed `nacos-cli` version and available skill commands before publishing or documenting a workflow:
+
+```bash
+nacos-cli -v
+nacos-cli --help
+```
+
+Use the command contract that matches the installed version:
+
+| Installed CLI | Skill publish workflow | Notes |
+| :--- | :--- | :--- |
+| `1.0.4` | `skill-upload` -> `skill-review` -> wait for approval -> `skill-release` | Current lifecycle. `skill-publish` is deprecated and only runs upload + review for compatibility. |
+| Any other version | Inspect `nacos-cli --help` and command-specific help | Do not hard-code old behavior. Follow the commands actually present in the installed CLI. |
+
+For `1.0.4`, treat these as distinct states:
+
+- `skill-upload`: creates or updates an `editing` draft version
+- `skill-review`: submits the draft, moving it toward `reviewing`
+- `skill-describe`: use this to confirm the submitted version has passed review
+- `skill-release`: publishes a reviewed/approved version online; it requires an explicit `--version`
+
+## How to Help Users Find and Install Skills
+
+### Step 1: Ensure nacos-cli is Available
+
+Check if nacos-cli is installed:
+
+```bash
+which nacos-cli
+```
+
+If not found, install it using the official installer script:
+
+**Linux / macOS:**
+
+```bash
+curl -fsSL https://nacos.io/nacos-installer.sh | sudo bash -s -- --cli
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr -UseBasicParsing https://nacos.io/nacos-installer.ps1 -OutFile $env:TEMP\nacos-installer.ps1; & $env:TEMP\nacos-installer.ps1 -cli; Remove-Item $env:TEMP\nacos-installer.ps1
+```
+
+### Step 2: Resolve Configuration (Profile)
+
+nacos-cli uses a **profile** mechanism. Profile configs are stored in `~/.nacos-cli/<profile>.conf`. The default profile is `default` (i.e., `~/.nacos-cli/default.conf`).
+
+Before asking the user to create or edit a profile, check whether the environment already provides a complete
+`sts-hiclaw` setup:
+
+```bash
+printenv NACOS_AUTH_TYPE HICLAW_CONTROLLER_URL HICLAW_AUTH_TOKEN_FILE
+```
+
+If `NACOS_AUTH_TYPE=sts-hiclaw`, `HICLAW_CONTROLLER_URL` is set, and `HICLAW_AUTH_TOKEN_FILE` points to a readable local
+token file, use `sts-hiclaw` mode directly. Do not require a local `~/.nacos-cli/<profile>.conf` file in this case.
+
+You can verify connectivity directly:
+
+```bash
+nacos-cli skill-list
+```
+
+Treat `NACOS_AUTH_TYPE` as the source of truth for environment-based auth selection. If it is not set to `sts-hiclaw`,
+do not assume `sts-hiclaw` mode only because `HICLAW_CONTROLLER_URL` and `HICLAW_AUTH_TOKEN_FILE` exist. Fall back to
+profile initialization when the explicit environment-based setup is missing or fails.
+
+First, check if a default profile already exists:
+
+```bash
+nacos-cli profile show
+```
+
+**If a profile exists** (the command prints config content), proceed to Step 3. The default profile requires no extra flags:
+
+```bash
+nacos-cli skill-list
+```
+
+To use a named profile:
+
+```bash
+nacos-cli --profile dev skill-list
+```
+
+**If no profile exists** (the command reports an error or shows empty/default values), guide the user through first-time initialization:
+
+#### First-Time Profile Initialization
+
+Ask the user the following information:
+
+1. **Nacos server address**: the host and port of their Nacos server (e.g., `127.0.0.1:8848`, or a remote address like `nacos.example.com:8848`)
+2. **Auth type**: `none`, `nacos`, `aliyun`, or `sts-hiclaw`
+3. **Credentials**:
+   - For `none` auth: no credentials are required
+   - For `nacos` auth: username and password from the user's local Nacos instance
+   - For `aliyun` auth: AccessKey and SecretKey
+   - For `sts-hiclaw` auth: credentials are fetched dynamically from HiClaw STS; the local environment must provide
+     `HICLAW_CONTROLLER_URL` and `HICLAW_AUTH_TOKEN_FILE`
+4. **Namespace** (optional): the Nacos namespace ID to use. Leave empty for the default public namespace.
+
+Once the user provides the info, create the local profile file on their machine:
+
+```bash
+mkdir -p ~/.nacos-cli
+${EDITOR:-vi} ~/.nacos-cli/default.conf
+```
+
+Tell the user to fill in only their local connection values: host, port, auth type, credentials when the selected auth type needs them, and namespace.
+Do not include concrete usernames, passwords, access keys, or secret keys in shared docs or skill examples.
+
+For `sts-hiclaw`, the profile should set `authType: sts-hiclaw`; do not store STS credentials in the profile. The CLI reads
+`HICLAW_CONTROLLER_URL` and `HICLAW_AUTH_TOKEN_FILE`, then requests temporary credentials from
+`$HICLAW_CONTROLLER_URL/api/v1/credentials/sts`.
+
+After writing the config, verify it works:
+
+```bash
+nacos-cli profile show
+```
+
+Then do a quick connectivity test:
+
+```bash
+nacos-cli skill-list
+```
+
+If the connection succeeds, tell the user:
+
+```text
+Profile initialized! nacos-cli is now connected to <host>:<port>.
+You can start searching and installing skills.
+```
+
+If it fails (auth error, connection refused, etc.), help the user troubleshoot:
+
+- Connection refused → check host/port, is Nacos server running?
+- 401/403 → check username/password or AK/SK
+- Namespace error → verify the namespace ID is correct
+
+#### Creating Additional Profiles
+
+If the user needs to connect to multiple Nacos servers (e.g., dev and prod), they can create named profiles:
+
+```bash
+# Create or edit a named profile locally (e.g., "dev")
+mkdir -p ~/.nacos-cli
+${EDITOR:-vi} ~/.nacos-cli/dev.conf
+```
+
+Do not hard-code real credentials in shared docs, repositories, or skill examples. Fill the local profile with the
+actual host, auth type, username, password, and namespace only on the user's machine.
+
+Then use it with `--profile`:
+
+```bash
+nacos-cli --profile dev skill-list
+```
+
+### Step 3: Understand What They Need
+
+When a user asks for help, identify:
+
+1. The domain (e.g., code review, testing, deployment, documentation)
+2. The specific task (e.g., writing tests, reviewing PRs, generating docs)
+3. Whether this is a common enough task that a skill likely exists in Nacos
+
+### Step 4: Search for Skills
+
+List all skills:
+
+```bash
+nacos-cli skill-list
+```
+
+Filter by name (supports wildcard `*`):
+
+```bash
+nacos-cli skill-list --name "creator"
+```
+
+With pagination:
+
+```bash
+nacos-cli skill-list --page 2 --size 10
+```
+
+For example:
+
+- User asks "can you help me review code?" → `nacos-cli skill-list --name review`
+- User asks "is there a skill for testing?" → `nacos-cli skill-list --name test`
+- User asks "what skills do we have?" → `nacos-cli skill-list`
+
+The command returns results in this format:
+
+```text
+Skill List (Page: 1/1, Total: N)
+═══════════════════════════════════════════════════════════════════════════════
+  1. <skill-name> - <description>
+     latest=<version>  editing=<version-or->  reviewing=<version-or->  online=<count>  status=enabled
+     scope=<scope>  owner=<owner>  updated=<yyyy-mm-dd hh:mm:ss>  downloads=<count>
+  ...
+```
+
+For scripts or exact verification, use JSON output:
+
+```bash
+nacos-cli skill-list --name <skill-name> --output json
+nacos-cli skill-describe <skill-name> --output json
+```
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them clearly:
+
+1. Summarize what skills were found
+2. Highlight the most relevant skill(s) based on user's needs
+3. Provide the install command
+
+Example response:
+
+```text
+I found N skills in Nacos. The most relevant one for your needs is:
+
+**<skill-name>** - <description>
+
+To install it:
+nacos-cli skill-get <skill-name>
+
+This will download the skill to ~/.skills/ and make it available immediately.
+Would you like me to install it?
+```
+
+### Step 6: Install the Skill
+
+Download and install a skill:
+
+```bash
+nacos-cli skill-get <skill-name>
+```
+
+Download multiple skills at once:
+
+```bash
+nacos-cli skill-get skill-a skill-b skill-c
+```
+
+Download a specific version:
+
+```bash
+nacos-cli skill-get <skill-name> --version v2
+```
+
+Download via route label (e.g., latest, stable):
+
+```bash
+nacos-cli skill-get <skill-name> --label stable
+```
+
+Download to a custom directory (default is `~/.skills`):
+
+```bash
+nacos-cli skill-get <skill-name> -o ~/my-skills
+```
+
+After installation, confirm the skill is available:
+
+```bash
+ls ~/.skills/<skill-name>/SKILL.md
+```
+
+## Handling Version Conflicts When Updating Skills
+
+When a user wants to update a locally installed skill from Nacos, there may be a conflict: the user has made local edits to the skill, and Nacos also has a newer version. This section describes how to detect and resolve such conflicts.
+
+### Understanding Skill Metadata
+
+When `nacos-cli skill-get` installs a skill, it creates a `_meta.json` file in the skill directory with version and origin info:
+
+```json
+{
+  "ownerId": "abc123",
+  "slug": "skill-name",
+  "version": "1.0.1",
+  "publishedAt": 1771756867954
+}
+```
+
+Key fields:
+
+- `version` — The version that was installed from Nacos
+- `publishedAt` — Timestamp (epoch ms) of when this version was published on Nacos
+- `slug` — The skill's unique name in the registry
+
+If the active local skill directory does not have `_meta.json` (for example, a skill under `$CODEX_HOME/skills`), use the
+`version` field in `SKILL.md` frontmatter as the local version. If both exist, prefer `_meta.json` for install-origin
+metadata and use `SKILL.md` frontmatter as a consistency check.
+
+### Step 1: Detect Local Changes
+
+Before updating a skill, check if the user has made local modifications since it was installed.
+
+Read the metadata:
+
+```bash
+cat ~/.skills/<skill-name>/_meta.json
+```
+
+Check if any files (excluding `_meta.json`) have been modified after the install. Compare file modification times against the `publishedAt` timestamp:
+
+```bash
+# Convert publishedAt (epoch ms) to a reference timestamp for comparison
+PUBLISHED_AT=$(python3 -c "import json; print(json.load(open('$HOME/.skills/<skill-name>/_meta.json'))['publishedAt'] / 1000)")
+
+# Find files modified after publishedAt
+find ~/.skills/<skill-name> -name '_meta.json' -prune -o -newer <reference> -print
+```
+
+Or more simply, compare the SKILL.md modification time with the `publishedAt` timestamp. If the file was modified after install, there are local changes.
+
+### Step 2: Check Remote Version
+
+Query the remote to see if a newer version is available:
+
+```bash
+nacos-cli skill-list --name <skill-name>
+nacos-cli skill-describe <skill-name>
+```
+
+On `nacos-cli` 1.0.4, prefer `skill-describe` for version comparison because it shows each version and its lifecycle
+status. Compare the remote online/latest version with the local `_meta.json` version. If the remote version is newer, an update is available.
+If `_meta.json` is absent, compare the remote online/latest version with the `version` field in the local `SKILL.md`
+frontmatter.
+
+On older CLIs that do not have `skill-describe`, use `skill-list --name <skill-name>` and the fields available in that version.
+
+### Step 3: Determine the Scenario
+
+Based on the results of Step 1 and Step 2, there are four possible scenarios:
+
+| Local Changes? | Remote Newer? | Action |
+| :--- | :--- | :--- |
+| No | No | Already up to date. No action needed. |
+| No | Yes | Safe update — pull remote directly. |
+| Yes | No | Local is ahead — suggest publishing local changes. |
+| **Yes** | **Yes** | **Conflict — needs resolution (see below).** |
+
+Version gate for publishing local edits:
+
+- If the local version and remote online/latest version are the same, the remote has not advanced beyond the local base.
+  When local files contain intended edits, publish the local skill directly according to the installed CLI contract.
+- If the remote online/latest version is greater than the local version, do not upload the local directory directly.
+  Download the newer remote version, diff it against the local directory, merge remote changes with local edits, then
+  publish the merged result as a new version.
+- Example: local `0.0.6` and remote latest `0.0.6` means local edits can be uploaded. Local `0.0.6` and remote latest
+  `0.0.7` means merge remote `0.0.7` first.
+
+### Step 4: Resolve Conflicts
+
+When both local changes and a newer remote version exist, present the user with two options:
+
+**Option A: Discard local changes, use remote version**
+
+This is the simpler path. Back up the local version first, then overwrite with the remote:
+
+```bash
+# 1. Back up the current local skill
+cp -r ~/.skills/<skill-name> /tmp/<skill-name>-local-backup
+
+# 2. Pull the latest remote version (overwrites local)
+nacos-cli skill-get <skill-name>
+```
+
+Tell the user:
+
+```text
+Local changes have been backed up to /tmp/<skill-name>-local-backup.
+The skill has been updated to the latest remote version (<remote-version>).
+If you need to recover your local changes, the backup is available.
+```
+
+**Option B: Merge local and remote changes, then submit a new version**
+
+This preserves both local and remote changes. The workflow:
+
+```bash
+# 1. Back up local version
+cp -r ~/.skills/<skill-name> /tmp/<skill-name>-local-backup
+
+# 2. Download the remote version to a temporary directory
+nacos-cli skill-get <skill-name> -o /tmp/<skill-name>-remote
+
+# 3. Diff local vs remote to understand the differences
+diff /tmp/<skill-name>-local-backup/SKILL.md /tmp/<skill-name>-remote/<skill-name>/SKILL.md
+```
+
+After reviewing the diff:
+
+1. Help the user merge the changes in `~/.skills/<skill-name>/` — incorporate remote improvements while preserving local customizations.
+2. Keep the skill itself stateless. Runtime data such as processed issues, PR tracking, task state, or local work logs must stay in a user-level workspace outside agent-specific skill directories.
+3. Validate the merged skill before publishing.
+4. Publish or submit the merged result using the installed CLI contract.
+
+For `nacos-cli` 1.0.4:
+
+```bash
+nacos-cli skill-upload ~/.skills/<skill-name>
+nacos-cli skill-review <skill-name>
+nacos-cli skill-describe <skill-name>
+# Wait until the target version is reviewed/approved.
+nacos-cli skill-release <skill-name> --version <new-version>
+nacos-cli skill-describe <skill-name>
+```
+
+For any other version, inspect command help first and follow the installed behavior:
+
+```bash
+nacos-cli --help
+nacos-cli skill-upload --help
+nacos-cli skill-review --help
+nacos-cli skill-release --help
+nacos-cli skill-publish --help
+```
+
+Tell the user:
+
+```text
+I've merged the local changes with the remote version.
+- Local version: <local-version>
+- Remote version: <remote-version>
+- Merged version: <new-version>
+
+The merged skill has been processed according to the installed nacos-cli contract.
+- Target version: <new-version>
+- Final status: <online|reviewing|editing>
+- Latest label: <latest-version>
+- Verification command: <skill-describe or skill-list command used>
+```
+
+### Step 5: Present the Choice to the User
+
+When a conflict is detected, always explain the situation clearly before acting:
+
+```text
+Conflict detected for skill "<skill-name>":
+- Local version: <local-version> (with local modifications)
+- Remote version: <remote-version>
+
+How would you like to proceed?
+A) Discard local changes and update to the remote version (your changes will be backed up)
+B) Merge local and remote changes, then publish as a new version
+```
+
+**Never overwrite local changes without asking.** Always back up before any destructive operation.
+
+## How to Help Users Publish Skills to Nacos
+
+When a user wants to reuse or share a skill by publishing it to Nacos, follow these steps.
+
+### Step 1: Ensure nacos-cli is Available and Configured
+
+Same as the discovery flow above — check `which nacos-cli`, then use either a configured profile or the environment-based
+`sts-hiclaw` setup. If `NACOS_AUTH_TYPE=sts-hiclaw`, `HICLAW_CONTROLLER_URL`, and `HICLAW_AUTH_TOKEN_FILE` are already set,
+do not require `nacos-cli profile show` to succeed before publishing.
+
+### Step 2: Verify the Skill Directory
+
+A valid skill directory must contain a `SKILL.md` file with proper frontmatter (name, description). Confirm the path:
+
+```bash
+ls <path-to-skill>/SKILL.md
+```
+
+If the file doesn't exist or lacks frontmatter, help the user create or fix it before publishing.
+
+### Step 3: Publish the Skill
+
+First confirm the installed CLI contract:
+
+```bash
+nacos-cli -v
+nacos-cli --help
+```
+
+Before uploading a locally edited skill, compare the local version with the remote online/latest version using
+`nacos-cli skill-describe <skill-name> --output json`. If they match, proceed with upload/review/release. If the remote
+version is newer, stop the direct publish path and use the conflict merge workflow above before publishing.
+
+For `nacos-cli` 1.0.4, use the explicit lifecycle:
+
+```bash
+nacos-cli skill-upload ./my-skill
+nacos-cli skill-review my-skill
+nacos-cli skill-describe my-skill
+# Wait until the target version is reviewed/approved.
+nacos-cli skill-release my-skill --version <version>
+nacos-cli skill-describe my-skill
+```
+
+Upload all skills in a directory:
+
+```bash
+nacos-cli skill-upload --all ./skills-folder
+```
+
+For `1.0.4`, `skill-publish` is deprecated. It only runs `skill-upload` + `skill-review` for compatibility and does not complete `skill-release`.
+
+For any other version, inspect command help before acting. Do not assume whether `skill-publish` uploads only or upload+submits.
+
+### Step 4: Verify the Publish
+
+After upload/review/release, verify the exact version, not only that the skill name appears in `skill-list`.
+
+```bash
+nacos-cli skill-list --name <skill-name>
+nacos-cli skill-describe <skill-name>
+nacos-cli skill-describe <skill-name> --output json
+```
+
+For `nacos-cli` 1.0.4, the minimal acceptance check is:
+
+- before release: target version is reviewed/approved in `skill-describe`; do not run `skill-release` while it is only `editing` or still waiting for review
+- after release: target version is `online`
+- if `--update-latest=false` was not used: `labels.latest` equals the target version
+- after downloading a specific version: local `_meta.json` version equals the requested version
+
+Example response to user:
+
+```text
+Your skill "<skill-name>" has been processed with the installed nacos-cli workflow.
+- Target version: <version>
+- Final status: <online|reviewing|editing>
+- Latest label: <latest-version>
+Other agents, machines, or teammates can install it with:
+  nacos-cli skill-get <skill-name>
+```
+
+## Connection Reference
+
+**Global flags** (can override profile settings on any command):
+
+| Flag | Short | Description |
+| :--- | :--- | :--- |
+| --host | | Nacos server host (e.g., 127.0.0.1) |
+| --port | | Nacos server port (e.g., 8848) |
+| --username | -u | Username for nacos auth |
+| --password | -p | Password for nacos auth |
+| --namespace | -n | Namespace ID |
+| --profile | | Profile name, loads `~/.nacos-cli/<profile>.conf` |
+| --config | -c | Path to a config file (overrides profile) |
+| --auth-type | | Auth type: `none`, `nacos`, `aliyun`, or `sts-hiclaw` |
+| --access-key | | AccessKey for aliyun auth |
+| --secret-key | | SecretKey for aliyun auth |
+| --security-token | | STS SecurityToken for legacy/explicit sts-hiclaw auth |
+
+For `sts-hiclaw`, prefer environment-based temporary credentials instead of storing credential values in a profile:
+
+```bash
+export NACOS_AUTH_TYPE=sts-hiclaw
+export HICLAW_CONTROLLER_URL=<your-hiclaw-controller-url>
+export HICLAW_AUTH_TOKEN_FILE=<path-to-local-token-file>
+nacos-cli skill-list
+```
+
+Treat `NACOS_AUTH_TYPE` as the source of truth. Do not assume `sts-hiclaw` mode unless `NACOS_AUTH_TYPE=sts-hiclaw` is
+set explicitly.
+
+## When No Skills Are Found
+
+If no relevant skills exist in Nacos:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using general capabilities
+3. Suggest creating and publishing a new skill
+
+Example:
+
+```text
+I searched for skills related to "xyz" in Nacos but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something your team does often, you could create a skill and
+publish it to Nacos for everyone:
+  nacos-cli skill-upload /path/to/your-skill
+  nacos-cli skill-review <skill-name>
+  nacos-cli skill-release <skill-name> --version <version>
+```
+
+## Tips for Effective Use
+
+1. **Use specific keywords**: "react testing" is better than just "testing" when filtering
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check namespaces**: Different teams may store skills in different Nacos namespaces — use `-n <namespace>` to switch
+4. **Use profiles**: Save connection details in profiles (`nacos-cli profile edit`) to avoid typing credentials repeatedly
+5. **Version and label**: Use `--version` or `--label` with `skill-get` to pin specific skill versions
+6. **Shell completion**: Run `nacos-cli completion zsh` (or bash/fish) for tab completion support

--- a/src/components/home/NacosCliAccess.astro
+++ b/src/components/home/NacosCliAccess.astro
@@ -1,0 +1,471 @@
+---
+import { useTranslations } from "@i18n/util";
+
+const t = useTranslations(Astro);
+const isEn = Astro.url.pathname.startsWith('/en');
+const skillUrl = 'https://nacos.io/SKILL.md';
+const agentPrompt = `${t('home.nacoscli.agent.prompt')}\n${skillUrl}`;
+const cliDocHref = isEn ? '/en/docs/latest/manual/admin/nacos-cli/' : '/docs/latest/manual/admin/nacos-cli/';
+const cliInstallUnix = 'curl -fsSL https://nacos.io/nacos-installer.sh | sudo bash -s -- --cli';
+const cliInstallWindows = 'iwr -UseBasicParsing https://nacos.io/nacos-installer.ps1 -OutFile $env:TEMP\\nacos-installer.ps1; & $env:TEMP\\nacos-installer.ps1 -cli; Remove-Item $env:TEMP\\nacos-installer.ps1';
+---
+
+<nacos-cli-access class="nacos-cli-section block w-full pt-4 pb-6">
+  <div class="nacos-cli-content px-4 mx-auto">
+    <div class="nacos-cli-heading">
+      <h3>{t('home.nacoscli.title')}</h3>
+      <a class="nacos-cli-doc-link" href={cliDocHref}>
+        <span>{t('home.nacoscli.user.link')}</span>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M5 12h14M12 5l7 7-7 7"></path>
+        </svg>
+      </a>
+    </div>
+
+    <div class="nacos-cli-tabs">
+      <div class="nacos-cli-tab-buttons" role="tablist" aria-label="Nacos CLI access">
+        <button class="nacos-cli-tab active" type="button" role="tab" aria-selected="true" data-tab="agent">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2.5l1.72 5.04 5.28.04-4.25 3.13 1.6 5.09L12 12.77 7.65 15.8l1.6-5.09L5 7.58l5.28-.04L12 2.5z"/>
+            <path d="M4.5 16.5l.7 2.05 2.05.02-1.65 1.2.62 1.98-1.72-1.18-1.72 1.18.62-1.98-1.65-1.2 2.05-.02.7-2.05z"/>
+            <path d="M19.5 16.5l.7 2.05 2.05.02-1.65 1.2.62 1.98-1.72-1.18-1.72 1.18.62-1.98-1.65-1.2 2.05-.02.7-2.05z"/>
+          </svg>
+          <span>{t('home.nacoscli.tab.agent')}</span>
+        </button>
+        <button class="nacos-cli-tab" type="button" role="tab" aria-selected="false" data-tab="user">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 4.75A2.75 2.75 0 016.75 2h11.5A1.75 1.75 0 0120 3.75v15.5A2.75 2.75 0 0117.25 22H6.75A2.75 2.75 0 014 19.25V4.75zm3 .75v12h10v-12H7zm1.5 3h7v1.5h-7V8.5zm0 3h7v1.5h-7v-1.5zm0 3h4.5V16H8.5v-1.5z"/>
+          </svg>
+          <span>{t('home.nacoscli.tab.user')}</span>
+        </button>
+      </div>
+
+      <div class="nacos-cli-panels">
+        <div class="nacos-cli-panel active" role="tabpanel" data-panel="agent">
+          <div class="nacos-cli-code" data-code={agentPrompt}>
+            <pre><code>{agentPrompt}</code></pre>
+            <button class="nacos-cli-copy" type="button" aria-label="Copy">
+              <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="9" y="9" width="13" height="13" rx="2"/>
+                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+              </svg>
+              <svg class="check-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M20 6L9 17l-5-5"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="nacos-cli-panel" role="tabpanel" data-panel="user">
+          <div class="nacos-cli-install-tabs">
+            <div class="nacos-cli-install-tab-buttons" role="tablist" aria-label="Nacos CLI install commands">
+              <button
+                class="nacos-cli-install-tab active"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                data-install-tab="unix"
+              >
+                Linux / macOS
+              </button>
+              <button
+                class="nacos-cli-install-tab"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                data-install-tab="windows"
+              >
+                Windows (PowerShell)
+              </button>
+            </div>
+
+            <div class="nacos-cli-install-panels">
+              <div class="nacos-cli-install-panel active" role="tabpanel" data-install-panel="unix">
+                <div class="nacos-cli-code" data-code={cliInstallUnix}>
+                  <pre><code>{cliInstallUnix}</code></pre>
+                  <button class="nacos-cli-copy" type="button" aria-label="Copy">
+                    <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <rect x="9" y="9" width="13" height="13" rx="2"/>
+                      <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                    </svg>
+                    <svg class="check-icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M20 6L9 17l-5-5"/>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+
+              <div class="nacos-cli-install-panel" role="tabpanel" data-install-panel="windows">
+                <div class="nacos-cli-code" data-code={cliInstallWindows}>
+                  <pre><code>{cliInstallWindows}</code></pre>
+                  <button class="nacos-cli-copy" type="button" aria-label="Copy">
+                    <svg class="copy-icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <rect x="9" y="9" width="13" height="13" rx="2"/>
+                      <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+                    </svg>
+                    <svg class="check-icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M20 6L9 17l-5-5"/>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</nacos-cli-access>
+
+<script>
+  class NacosCliAccess extends HTMLElement {
+    constructor() {
+      super();
+
+      const tabButtons = this.querySelectorAll<HTMLButtonElement>('.nacos-cli-tab');
+      const tabPanels = this.querySelectorAll<HTMLElement>('.nacos-cli-panel');
+      const installTabButtons = this.querySelectorAll<HTMLButtonElement>('.nacos-cli-install-tab');
+      const installTabPanels = this.querySelectorAll<HTMLElement>('.nacos-cli-install-panel');
+
+      tabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const tabId = button.dataset.tab;
+
+          tabButtons.forEach((tabButton) => {
+            const isActive = tabButton === button;
+            tabButton.classList.toggle('active', isActive);
+            tabButton.setAttribute('aria-selected', String(isActive));
+          });
+
+          tabPanels.forEach((panel) => {
+            panel.classList.toggle('active', panel.dataset.panel === tabId);
+          });
+        });
+      });
+
+      installTabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const tabId = button.dataset.installTab;
+
+          installTabButtons.forEach((tabButton) => {
+            const isActive = tabButton === button;
+            tabButton.classList.toggle('active', isActive);
+            tabButton.setAttribute('aria-selected', String(isActive));
+          });
+
+          installTabPanels.forEach((panel) => {
+            panel.classList.toggle('active', panel.dataset.installPanel === tabId);
+          });
+        });
+      });
+
+      this.querySelectorAll<HTMLButtonElement>('.nacos-cli-copy').forEach((button) => {
+        button.addEventListener('click', () => {
+          const codeBlock = button.closest('.nacos-cli-code') as HTMLElement;
+          const code = codeBlock?.dataset.code || '';
+          navigator.clipboard.writeText(code).then(() => {
+            button.classList.add('copied');
+            setTimeout(() => button.classList.remove('copied'), 2000);
+          });
+        });
+      });
+    }
+  }
+
+  customElements.define('nacos-cli-access', NacosCliAccess);
+</script>
+
+<style is:global>
+  .nacos-cli-section {
+    margin-top: 0;
+    scroll-margin-top: 4rem;
+  }
+
+  .nacos-cli-content {
+    width: 85.125rem;
+  }
+
+  .nacos-cli-heading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    text-align: center;
+  }
+
+  .nacos-cli-heading h3 {
+    margin: 0;
+    color: #1f2937;
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    font-weight: 500;
+  }
+
+  .nacos-cli-doc-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    color: #8c8c8c;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .nacos-cli-doc-link:hover {
+    color: #1677ff;
+  }
+
+  .nacos-cli-doc-link svg {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .nacos-cli-tabs {
+    background: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+    overflow: hidden;
+  }
+
+  .nacos-cli-tab-buttons {
+    display: flex;
+    background: #fafafa;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .nacos-cli-tab {
+    flex: 1;
+    min-height: 2.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    color: #666;
+    background: transparent;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+  }
+
+  .nacos-cli-tab:hover {
+    color: #333;
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  .nacos-cli-tab.active {
+    color: #1677ff;
+    background: #fff;
+    border-bottom-color: #1677ff;
+  }
+
+  .nacos-cli-tab svg {
+    width: 1rem;
+    height: 1rem;
+    fill: currentColor;
+    flex-shrink: 0;
+  }
+
+  .nacos-cli-panel {
+    display: none;
+    padding: 1rem 1.5rem;
+    animation: nacosCliFadeIn 0.3s ease;
+  }
+
+  .nacos-cli-panel.active {
+    display: block;
+  }
+
+  .nacos-cli-install-tabs {
+    background: #fff;
+    border: 1px solid #e8e8e8;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .nacos-cli-install-tab-buttons {
+    display: inline-flex;
+    width: auto;
+    margin: 0.75rem 1rem 0;
+    padding: 0.1875rem;
+    background: #f5f5f5;
+    border: 1px solid #e8e8e8;
+    border-radius: 7px;
+  }
+
+  .nacos-cli-install-tab {
+    min-width: 7.5rem;
+    min-height: 2rem;
+    padding: 0.375rem 0.75rem;
+    color: #666;
+    background: transparent;
+    border: 0;
+    border-radius: 5px;
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .nacos-cli-install-tab.active {
+    color: #1677ff;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  }
+
+  .nacos-cli-install-panels {
+    padding: 0.875rem 1rem 1rem;
+  }
+
+  .nacos-cli-install-panel {
+    display: none;
+    animation: nacosCliFadeIn 0.2s ease;
+  }
+
+  .nacos-cli-install-panel.active {
+    display: block;
+  }
+
+  .nacos-cli-code {
+    position: relative;
+    padding: 0.875rem 3.25rem 0.875rem 1rem;
+    background: #f5f5f5;
+    border: 1px solid #e8e8e8;
+    border-radius: 8px;
+    overflow-x: auto;
+  }
+
+  .nacos-cli-code pre {
+    margin: 0;
+  }
+
+  .nacos-cli-code code {
+    color: #333;
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace;
+    font-size: 0.8125rem;
+    line-height: 1.65;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .nacos-cli-copy {
+    position: absolute;
+    top: 0.625rem;
+    right: 0.75rem;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .nacos-cli-code:hover .nacos-cli-copy,
+  .nacos-cli-copy:focus-visible {
+    opacity: 1;
+  }
+
+  .nacos-cli-copy:hover {
+    background: #f0f0f0;
+  }
+
+  .nacos-cli-copy svg {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    color: #666;
+  }
+
+  .nacos-cli-copy .check-icon {
+    display: none;
+    color: #52c41a;
+  }
+
+  .nacos-cli-copy.copied {
+    background: #f6ffed;
+    border-color: #b7eb8f;
+  }
+
+  .nacos-cli-copy.copied .copy-icon {
+    display: none;
+  }
+
+  .nacos-cli-copy.copied .check-icon {
+    display: block;
+  }
+
+  @keyframes nacosCliFadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .nacos-cli-section {
+      padding-bottom: 1.5rem;
+    }
+
+    .nacos-cli-content {
+      width: 100%;
+    }
+
+    .nacos-cli-heading h3 {
+      font-size: 1.125rem;
+      line-height: 1.5rem;
+    }
+
+    .nacos-cli-heading {
+      flex-wrap: wrap;
+      row-gap: 0.5rem;
+    }
+
+    .nacos-cli-panel {
+      padding: 1rem;
+    }
+
+    .nacos-cli-install-tab {
+      min-width: 0;
+      flex: 1;
+    }
+
+    .nacos-cli-code {
+      padding: 1rem 3rem 1rem 1rem;
+    }
+
+    .nacos-cli-code code {
+      font-size: 0.75rem;
+    }
+  }
+
+  @media (min-width: 640px) and (max-width: 86rem) {
+    .nacos-cli-content {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/components/home/NewUseCompanies.astro
+++ b/src/components/home/NewUseCompanies.astro
@@ -38,15 +38,15 @@ const companiesLogos = companiesLogosTop.concat(companiesLogosBottom);
 
 <span class="new-companies-wrapper">
   <use-companies
-    class="use-companies flex flex-col items-center pt-10 pb-4"
+    class="use-companies flex flex-col items-center pt-2 pb-3"
   >
-    <div class="top-title flex flex-col items-center mb-10 mt-12">
+    <div class="top-title flex flex-col items-center mb-4 mt-0">
       <span class="text-gray-10 text-xs w-full max-w-[63.5rem] text-center">
         {t("home.use.companies.about")}
       </span>
     </div>
 
-    <div class="bottom-silder mt-1">
+    <div class="bottom-silder mt-0">
       <ul class="slider">
         {
           companiesLogos.map((logo, index) => (
@@ -205,11 +205,11 @@ const companiesLogos = companiesLogosTop.concat(companiesLogosBottom);
 
     @media (max-width: 50rem) {
       .use-companies {
-        padding: 1.5rem;
+        padding: 1rem;
       }
       .top-title {
         width: 100%;
-        margin-top: 2.5rem;
+        margin-top: 0;
       }
       .bottom-silder {
         width: 100%;
@@ -238,7 +238,7 @@ const companiesLogos = companiesLogosTop.concat(companiesLogosBottom);
 
     @media (min-width: 50rem) and (max-width: 86rem) {
       .use-companies {
-        padding: 2.5rem;
+        padding: 1.5rem 2.5rem;
       }
       .top-title,
       .bottom-silder {

--- a/src/components/home/QuickStart.astro
+++ b/src/components/home/QuickStart.astro
@@ -1,17 +1,25 @@
 ---
 import { useTranslations } from "@i18n/util";
 const t = useTranslations(Astro);
+const isEn = Astro.url.pathname.startsWith('/en');
+const quickStartDocHref = isEn ? '/en/docs/latest/quickstart/quick-start/' : '/docs/latest/quickstart/quick-start/';
 ---
 
-<quickstart-section id="quickstart" class="quickstart-section block w-full py-16 flex flex-col justify-center items-center">
+<quickstart-section id="quickstart" class="quickstart-section block w-full pt-12 pb-3 flex flex-col justify-center items-center">
   <div class="quickstart-content px-4">
-    <div class="top-title flex flex-col items-center mb-12">
-      <h3 class="font-light text-gray-10 text-xs mb-6 tracking-[0.15em]">
-        {t('home.quickstart.title')}
-      </h3>
+    <div class="top-title flex flex-col items-center mb-7">
       <b class="title text-gray-14 text-[2.5rem] leading-[3.5rem] font-medium">
         {t('home.quickstart.subtitle')}
       </b>
+      <a
+        href={quickStartDocHref}
+        class="quickstart-doc-link inline-flex items-center gap-2 text-sm text-gray-08 hover:text-gray-11 transition-colors no-underline mt-3"
+      >
+        {t('home.quickstart.view.full')}
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M5 12h14M12 5l7 7-7 7"/>
+        </svg>
+      </a>
     </div>
 
     <div class="quickstart-tabs mx-auto">
@@ -91,17 +99,6 @@ const t = useTranslations(Astro);
       </div>
     </div>
 
-    <div class="text-center mt-8">
-      <a
-        href="/docs/latest/quickstart/quick-start/"
-        class="inline-flex items-center gap-2 text-sm text-gray-08 hover:text-gray-11 transition-colors no-underline"
-      >
-        {t('home.quickstart.view.full')}
-        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M5 12h14M12 5l7 7-7 7"/>
-        </svg>
-      </a>
-    </div>
   </div>
 </quickstart-section>
 

--- a/src/i18n/en/ui.ts
+++ b/src/i18n/en/ui.ts
@@ -129,6 +129,12 @@ export default {
 	'home.quickstart.install.nacos.setup': 'Install nacos-setup',
 	'home.quickstart.start.nacos': 'Deploy Nacos with one click',
 	'home.quickstart.view.full': 'View full documentation',
+	'home.nacoscli.title': 'Use Nacos CLI',
+	'home.nacoscli.tab.agent': 'Agent',
+	'home.nacoscli.tab.user': 'User',
+	'home.nacoscli.agent.prompt': 'Read this Skill and use it when working with Nacos CLI:',
+	'home.nacoscli.user.text': 'Install, configure, and use common commands',
+	'home.nacoscli.user.link': 'Nacos CLI docs',
 
 	'cloud.title': 'Nacos Cloud',
 	'cloud.description': 'Nacos Cloud is specifically designed for cloud-native applications, providing powerful features for service discovery, dynamic configuration management, and service management. It supports efficient application development and operations.',

--- a/src/i18n/zh-cn/ui.ts
+++ b/src/i18n/zh-cn/ui.ts
@@ -128,6 +128,12 @@ export default {
 	'home.quickstart.install.nacos.setup': '安装 nacos-setup',
 	'home.quickstart.start.nacos': '一键部署 Nacos',
 	'home.quickstart.view.full': '查看完整文档',
+	'home.nacoscli.title': '使用 Nacos CLI',
+	'home.nacoscli.tab.agent': 'Agent',
+	'home.nacoscli.tab.user': '用户',
+	'home.nacoscli.agent.prompt': 'Read this Skill and use it when working with Nacos CLI:',
+	'home.nacoscli.user.text': '查看安装、配置和常用命令',
+	'home.nacoscli.user.link': 'Nacos CLI 文档',
 
 	'cloud.title': 'Nacos Cloud',
 	'cloud.description': 'Nacos Cloud 专为云原生应用设计，提供强大的服务发现、动态配置管理和服务管理功能，支持高效的应用开发和运维。',

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import EarthBackground from '@components/home/EarthBackground.astro';
 import QuickStart from '@components/home/QuickStart.astro';
+import NacosCliAccess from '@components/home/NacosCliAccess.astro';
 import ChooseReason from '@components/home/ChooseReason.astro';
 import RegistryMcp from '@components/home/RegistryMcp.astro';
 import NacosEBook from '@components/home/NacosEBook.astro';
@@ -24,6 +25,7 @@ const t = useTranslations(Astro);
   <home-body>
     <EarthBackground />
     <QuickStart />
+    <NacosCliAccess />
     <NewUseCompanies />
     <ChooseReason />
     <RegistryMcp />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import EarthBackground from '@components/home/EarthBackground.astro';
 import QuickStart from '@components/home/QuickStart.astro';
+import NacosCliAccess from '@components/home/NacosCliAccess.astro';
 import ChooseReason from '@components/home/ChooseReason.astro';
 import RegistryMcp from '@components/home/RegistryMcp.astro';
 import NacosEBook from '@components/home/NacosEBook.astro';
@@ -24,6 +25,7 @@ const t = useTranslations(Astro);
   <home-body>
     <EarthBackground />
     <QuickStart />
+    <NacosCliAccess />
     <NewUseCompanies />
     <ChooseReason />
     <RegistryMcp />


### PR DESCRIPTION
## What is the purpose of the change

Add a homepage entry for agents and users to access Nacos CLI, and sync the latest Java SDK usage manual from the preview version:
- serve nacos-skill-registry as /SKILL.md for agent consumption
- add an Agent/User tab on the homepage below Quick Start
- add one-click Nacos CLI install commands for Linux/macOS and Windows
- tighten Quick Start and company-logo spacing so the sections fit together
- copy the preview Java SDK usage manual into the latest zh-cn document

## Brief changelog

- Added public/SKILL.md with nacos-skill-registry instructions.
- Added NacosCliAccess homepage component and localized labels.
- Moved the Quick Start documentation link near the title and adjusted homepage spacing.
- Synced src/content/docs/v3.1/zh-cn/manual/user/java-sdk/usage.md from the preview document.

## Verifying this change

- `curl -fsSL http://localhost:4321/SKILL.md`
- `diff -q public/SKILL.md /private/tmp/nacos-skill-test.md`
- `cmp -s src/content/docs/next/zh-cn/manual/user/java-sdk/usage.md src/content/docs/v3.1/zh-cn/manual/user/java-sdk/usage.md`
- `git diff --check -- src/content/docs/v3.1/zh-cn/manual/user/java-sdk/usage.md`
- `npm run astro -- build`

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a GITHUB_issue filed for the change.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
