### PR TITLE
docs: update next Java SDK docs

### DIFF
--- a/.agents/skills/nacos-java-maintainer-sdk/scripts/compare_maintainer_api_with_doc.py
+++ b/.agents/skills/nacos-java-maintainer-sdk/scripts/compare_maintainer_api_with_doc.py
@@ -220,16 +220,20 @@ def main():
     doc_methods = parse_maintainer_md(usage_content)
     structure_warnings = detect_structure_warnings(usage_content)
 
-    doc_method_set = set()
+    doc_chapter_method_set = set()
     for name, entries in doc_methods.items():
-        for _ in entries:
-            doc_method_set.add(name)
+        for section_id, _ in entries:
+            chapter = section_id.split(".")[0]
+            if chapter.isdigit():
+                doc_chapter_method_set.add((int(chapter), name))
 
-    doc_name_param_set = set()
+    doc_chapter_name_param_set = set()
     for name, entries in doc_methods.items():
-        for _, pc in entries:
+        for section_id, pc in entries:
             if pc is not None:
-                doc_name_param_set.add((name, pc))
+                chapter = section_id.split(".")[0]
+                if chapter.isdigit():
+                    doc_chapter_name_param_set.add((int(chapter), name, pc))
 
     # Methods that exist in interface but should NOT be documented (design decision)
     SKIP_NEW_API = {"fillAllPattern"}  # ConfigMaintainerService: utility for * pattern, not a capability API
@@ -237,14 +241,15 @@ def main():
     # New APIs: in Java (any chapter) but method name not in doc
     new_by_chapter = {}
     for m in java_methods:
-        if m["name"] not in doc_method_set and m["name"] not in SKIP_NEW_API:
+        if (m["chapter"], m["name"]) not in doc_chapter_method_set and m["name"] not in SKIP_NEW_API:
             ch = m["chapter"]
             new_by_chapter.setdefault(ch, []).append(m)
 
     # New overloads: method name is documented but this (name, param_count) is not
     new_overloads = [
         m for m in java_methods
-        if m["name"] in doc_method_set and (m["name"], m["param_count"]) not in doc_name_param_set
+        if (m["chapter"], m["name"]) in doc_chapter_method_set
+        and (m["chapter"], m["name"], m["param_count"]) not in doc_chapter_name_param_set
     ]
 
     # Removed overloads: (method_name, param_count) in doc but not in interface for that chapter

--- a/.agents/skills/nacos-java-maintainer-sdk/scripts/parse_maintainer_interface.py
+++ b/.agents/skills/nacos-java-maintainer-sdk/scripts/parse_maintainer_interface.py
@@ -163,7 +163,9 @@ def parse_java_interface_content(content: str, source_name: str):
             if not re.match(r"^(default\s+|static\s+)?[\w<>,\s\[\]]+\s+\w+\s*\(", line):
                 continue
             acc = [line]
-            if ")" in line and " {" in line and re.search(r"\)\s+.*\{\s*$", line):
+            if re.search(r"\)\s*;", line) or re.search(r"\)\s*throws\s+[^;]+;\s*$", line):
+                pass
+            elif ")" in line and " {" in line and re.search(r"\)\s+.*\{\s*$", line):
                 acc = [re.sub(r"\s*\{.*", "", line).strip()]
                 depth = 1
                 while i < len(lines) and depth > 0:

--- a/src/content/docs/next/en/manual/admin/maintainer-sdk.md
+++ b/src/content/docs/next/en/manual/admin/maintainer-sdk.md
@@ -4739,6 +4739,507 @@ try {
 
 操作失败时抛出 NacosException 异常。
 
+### 8.10. Get Prompt Governance Detail
+
+#### Description
+
+Get Prompt governance detail by namespace and promptKey, including version governance information and all version summaries.
+
+```java
+PromptMetaInfo getPromptGovernanceDetail(String namespaceId, String promptKey) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+
+#### Response
+
+| Type           | Description |
+|:---------------|:------------|
+| PromptMetaInfo | Prompt governance detail. |
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    PromptMetaInfo detail = promptMaintainerService.getPromptGovernanceDetail("public", "my-prompt");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.11. Get Prompt Version Detail
+
+#### Description
+
+Get Prompt version detail by namespace, promptKey, and version.
+
+```java
+PromptVersionInfo getVersionDetail(String namespaceId, String promptKey, String version) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| version     | string | Prompt version. |
+
+#### Response
+
+| Type              | Description |
+|:------------------|:------------|
+| PromptVersionInfo | Prompt version detail. |
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    PromptVersionInfo detail = promptMaintainerService.getVersionDetail("public", "my-prompt", "1.0.0");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.12. Create Prompt Draft
+
+#### Description
+
+Create a Prompt draft version. It can fork from an existing version and optionally specify the target version, template, variables, commit message, description, and biz tags.
+
+```java
+String createDraft(String namespaceId, String promptKey, String basedOnVersion, String targetVersion, String template, String variables, String commitMsg, String description, String bizTags) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name           | Type   | Description |
+|:---------------|:-------|:------------|
+| namespaceId    | string | Namespace ID. |
+| promptKey      | string | Prompt key. |
+| basedOnVersion | string | Base version to fork from, optional. |
+| targetVersion  | string | Target draft version, optional. |
+| template       | string | Prompt template content. |
+| variables      | string | Variable definition JSON, optional. |
+| commitMsg      | string | Commit message, optional. |
+| description    | string | Prompt description, optional when first created. |
+| bizTags        | string | Biz tags JSON, optional when first created. |
+
+#### Response
+
+| Type   | Description |
+|:-------|:------------|
+| String | Created draft version. |
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    String version = promptMaintainerService.createDraft("public", "my-prompt", "1.0.0", "1.0.1-draft",
+            "Hello {{name}}", "{\"name\":\"string\"}", "update prompt", "desc", "[\"ai\"]");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.13. Update Prompt Draft
+
+#### Description
+
+Update the current Prompt draft content.
+
+```java
+void updateDraft(String namespaceId, String promptKey, String template, String variables, String commitMsg) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| template    | string | Updated template content. |
+| variables   | string | Variable definition JSON, optional. |
+| commitMsg   | string | Commit message, optional. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateDraft("public", "my-prompt", "Hello {{name}}", "{\"name\":\"string\"}", "update template");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.14. Delete Prompt Draft
+
+#### Description
+
+Delete the current draft version of a Prompt.
+
+```java
+void deleteDraft(String namespaceId, String promptKey) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.deleteDraft("public", "my-prompt");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.15. Submit Prompt Version
+
+#### Description
+
+Submit a Prompt version for release review.
+
+```java
+String submit(String namespaceId, String promptKey, String version) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| version     | string | Version to submit, optional; the server may use the current draft. |
+
+#### Response
+
+| Type   | Description |
+|:-------|:------------|
+| String | Submitted version. |
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    String version = promptMaintainerService.submit("public", "my-prompt", "1.0.1");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.16. Publish Prompt Version
+
+#### Description
+
+Publish a reviewed Prompt version, optionally updating the latest label.
+
+```java
+void publish(String namespaceId, String promptKey, String version, Boolean updateLatestLabel) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name              | Type    | Description |
+|:------------------|:--------|:------------|
+| namespaceId       | string  | Namespace ID. |
+| promptKey         | string  | Prompt key. |
+| version           | string  | Version to publish. |
+| updateLatestLabel | boolean | Whether to update the latest label. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.publish("public", "my-prompt", "1.0.1", true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.17. Force Publish Prompt Version
+
+#### Description
+
+Force-publish a Prompt version without release review, optionally updating the latest label.
+
+```java
+void forcePublish(String namespaceId, String promptKey, String version, Boolean updateLatestLabel) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name              | Type    | Description |
+|:------------------|:--------|:------------|
+| namespaceId       | string  | Namespace ID. |
+| promptKey         | string  | Prompt key. |
+| version           | string  | Version to publish. |
+| updateLatestLabel | boolean | Whether to update the latest label. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.forcePublish("public", "my-prompt", "1.0.1", true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.18. Redraft Prompt Version
+
+#### Description
+
+Move a reviewed Prompt version back to draft status for further editing.
+
+```java
+boolean redraft(String namespaceId, String promptKey, String version) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| version     | string | Version to redraft. |
+
+#### Response
+
+| Type    | Description |
+|:--------|:------------|
+| boolean | Whether redraft succeeds. |
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    boolean ok = promptMaintainerService.redraft("public", "my-prompt", "1.0.1");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.19. Change Prompt Online Status
+
+#### Description
+
+Bring a Prompt version online or offline.
+
+```java
+void changeOnlineStatus(String namespaceId, String promptKey, String version, boolean online) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type    | Description |
+|:------------|:--------|:------------|
+| namespaceId | string  | Namespace ID. |
+| promptKey   | string  | Prompt key. |
+| version     | string  | Version. |
+| online      | boolean | `true` to bring online, `false` to take offline. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.changeOnlineStatus("public", "my-prompt", "1.0.1", true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.20. Update Prompt Labels
+
+#### Description
+
+Update Prompt labels JSON to maintain label-to-version mappings.
+
+```java
+void updateLabels(String namespaceId, String promptKey, String labels) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| labels      | string | Labels JSON. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateLabels("public", "my-prompt", "{\"latest\":\"1.0.1\"}");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.21. Update Prompt Description
+
+#### Description
+
+Update Prompt description.
+
+```java
+void updateDescription(String namespaceId, String promptKey, String description) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| description | string | New description. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateDescription("public", "my-prompt", "new desc");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 8.22. Update Prompt Biz Tags
+
+#### Description
+
+Update Prompt biz tags JSON.
+
+```java
+void updateBizTags(String namespaceId, String promptKey, String bizTags) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| promptKey   | string | Prompt key. |
+| bizTags     | string | Biz tags JSON. |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateBizTags("public", "my-prompt", "[\"ai\",\"ops\"]");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
 ## 9. Skill 能力
 
 ### 9.1. 注册 Skill
@@ -4912,9 +5413,13 @@ try {
 List skills with pagination by namespace, name pattern, and search mode.
 
 ```java
-Page<SkillBasicInfo> listSkills(String namespaceId, String skillName, String search, int pageNo, int pageSize) throws NacosException;
+Page<SkillSummary> listSkills(String namespaceId, String skillName, String search, int pageNo, int pageSize) throws NacosException;
 
-Page<SkillBasicInfo> listSkills(String skillName, int pageNo, int pageSize) throws NacosException;
+Page<SkillSummary> listSkills(String namespaceId, String skillName, String search, String orderBy, String owner, String scope, int pageNo, int pageSize) throws NacosException;
+
+Page<SkillSummary> listSkills(String namespaceId, String skillName, String search, String orderBy, String owner, String scope, String bizTag, int pageNo, int pageSize) throws NacosException;
+
+Page<SkillSummary> listSkills(String skillName, int pageNo, int pageSize) throws NacosException;
 ```
 
 #### 请求参数
@@ -4924,6 +5429,10 @@ Page<SkillBasicInfo> listSkills(String skillName, int pageNo, int pageSize) thro
 | namespaceId | string | 命名空间ID。                      |
 | skillName   | string | Skill 名称模式过滤。                 |
 | search      | string | 搜索模式：`accurate` 精确 或 `blur` 模糊。 |
+| orderBy     | string | Optional sort field.               |
+| owner       | string | Optional resource owner filter.     |
+| scope       | string | Optional visibility scope filter.   |
+| bizTag      | string | Optional business tag filter.       |
 | pageNo      | int    | 页码。                          |
 | pageSize    | int    | 每页条数。                        |
 
@@ -4931,14 +5440,17 @@ Page<SkillBasicInfo> listSkills(String skillName, int pageNo, int pageSize) thro
 
 | 参数类型                   | 描述         |
 |:-----------------------|:-----------|
-| Page\<SkillBasicInfo>   | Skill 分页列表。 |
+| Page\<SkillSummary>   | Skill page result. |
 
 #### 请求示例
 
 ```java
 try {
-    Page<SkillBasicInfo> result = aiMaintainerService.listSkills("public", "my-skill", "blur", 1, 100);
-    result = aiMaintainerService.listSkills("my-skill", 1, 100);
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    Page<SkillSummary> result = skillMaintainerService.listSkills("public", "my-skill", "blur", 1, 100);
+    result = skillMaintainerService.listSkills("public", "my-skill", "blur", "download_count", "nacos", "PUBLIC", 1, 100);
+    result = skillMaintainerService.listSkills("public", "my-skill", "blur", "download_count", "nacos", "PUBLIC", "ops", 1, 100);
+    result = skillMaintainerService.listSkills("my-skill", 1, 100);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -4957,6 +5469,10 @@ Upload and register a skill from ZIP bytes in the given namespace.
 ```java
 String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
 
+String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite, String targetVersion) throws NacosException;
+
+String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite, String targetVersion, String commitMsg) throws NacosException;
+
 String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
 
 String uploadSkillFromZip(byte[] zipBytes) throws NacosException;
@@ -4969,6 +5485,8 @@ String uploadSkillFromZip(byte[] zipBytes) throws NacosException;
 | namespaceId | string  | 命名空间ID。     |
 | zipBytes    | byte[]  | Skill 的 ZIP 包字节。 |
 | overwrite   | boolean | Skill 已存在时是否覆盖当前可编辑草稿。 |
+| targetVersion | string | Optional target version, used when the ZIP content has no version. |
+| commitMsg   | string  | Optional version commit message. |
 
 #### 返回参数
 
@@ -4980,10 +5498,13 @@ String uploadSkillFromZip(byte[] zipBytes) throws NacosException;
 
 ```java
 try {
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
     byte[] zipBytes = Files.readAllBytes(Paths.get("my-skill.zip"));
-    String name = aiMaintainerService.uploadSkillFromZip("public", zipBytes, true);
-    String name = aiMaintainerService.uploadSkillFromZip("public", zipBytes);
-    name = aiMaintainerService.uploadSkillFromZip(zipBytes);
+    String name = skillMaintainerService.uploadSkillFromZip("public", zipBytes, true);
+    name = skillMaintainerService.uploadSkillFromZip("public", zipBytes, true, "1.0.1");
+    name = skillMaintainerService.uploadSkillFromZip("public", zipBytes, true, "1.0.1", "upload skill");
+    name = skillMaintainerService.uploadSkillFromZip("public", zipBytes);
+    name = skillMaintainerService.uploadSkillFromZip(zipBytes);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5088,6 +5609,8 @@ String createDraft(String namespaceId, String skillName, String basedOnVersion) 
 String createDraft(String namespaceId, String skillName, String basedOnVersion, String targetVersion) throws NacosException;
 
 String createDraft(String namespaceId, String skillName, String basedOnVersion, String targetVersion, String skillCard) throws NacosException;
+
+String createDraft(String namespaceId, String skillName, String basedOnVersion, String targetVersion, String skillCard, String commitMsg) throws NacosException;
 ```
 
 #### 请求参数
@@ -5099,6 +5622,7 @@ String createDraft(String namespaceId, String skillName, String basedOnVersion, 
 | basedOnVersion | string | fork 基于的版本（可选）。                |
 | targetVersion | string | 目标草稿版本（可选）。                    |
 | skillCard    | string | Skill 完整 JSON（非 fork 场景通常必填）。   |
+| commitMsg    | string | Optional version commit message.        |
 
 #### 返回参数
 
@@ -5110,10 +5634,12 @@ String createDraft(String namespaceId, String skillName, String basedOnVersion, 
 
 ```java
 try {
-    String version = aiMaintainerService.createDraft("public", "{\"name\":\"my-skill\"}");
-    version = aiMaintainerService.createDraft("public", "my-skill", "1.0.0");
-    version = aiMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft");
-    version = aiMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft", "{\"name\":\"my-skill\"}");
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    String version = skillMaintainerService.createDraft("public", "{\"name\":\"my-skill\"}");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft", "{\"name\":\"my-skill\"}");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft", "{\"name\":\"my-skill\"}", "update skill");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5131,6 +5657,8 @@ Update current draft content.
 
 ```java
 boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest) throws NacosException;
+
+boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest, String commitMsg) throws NacosException;
 ```
 
 #### 请求参数
@@ -5140,6 +5668,7 @@ boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest) t
 | namespaceId | string  | 命名空间ID。                 |
 | skillCard   | string  | Skill 完整 JSON。          |
 | setAsLatest | boolean | 是否设为 latest 标签（可选）。     |
+| commitMsg   | string  | Optional version commit message. |
 
 #### 返回参数
 
@@ -5151,7 +5680,9 @@ boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest) t
 
 ```java
 try {
-    boolean ok = aiMaintainerService.updateDraft("public", "{\"name\":\"my-skill\"}", true);
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    boolean ok = skillMaintainerService.updateDraft("public", "{\"name\":\"my-skill\"}", true);
+    ok = skillMaintainerService.updateDraft("public", "{\"name\":\"my-skill\"}", true, "update skill");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5469,6 +6000,88 @@ try {
 
 操作失败时抛出 NacosException 异常。
 
+### 9.19. Batch Upload Skills from ZIP
+
+#### Description
+
+Batch upload Skills from a ZIP package containing multiple Skill directories.
+
+```java
+BatchUploadResult batchUploadSkillsFromZip(byte[] zipBytes) throws NacosException;
+
+BatchUploadResult batchUploadSkillsFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type    | Description |
+|:------------|:--------|:------------|
+| namespaceId | string  | Namespace ID. |
+| zipBytes    | byte[]  | ZIP bytes containing multiple Skill directories. |
+| overwrite   | boolean | Whether to overwrite existing drafts. |
+
+#### Response
+
+| Type              | Description |
+|:------------------|:------------|
+| BatchUploadResult | Batch upload result, including succeeded and failed items. |
+
+#### Example
+
+```java
+try {
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    byte[] zipBytes = Files.readAllBytes(Paths.get("skills.zip"));
+    BatchUploadResult result = skillMaintainerService.batchUploadSkillsFromZip(zipBytes);
+    result = skillMaintainerService.batchUploadSkillsFromZip("public", zipBytes, true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
+### 9.20. Redraft Skill Version
+
+#### Description
+
+Move a reviewed Skill version back to draft status for further editing.
+
+```java
+boolean redraft(String namespaceId, String skillName, String version) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name        | Type   | Description |
+|:------------|:-------|:------------|
+| namespaceId | string | Namespace ID. |
+| skillName   | string | Skill name. |
+| version     | string | Version to redraft. |
+
+#### Response
+
+| Type    | Description |
+|:--------|:------------|
+| boolean | Whether redraft succeeds. |
+
+#### Example
+
+```java
+try {
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    boolean ok = skillMaintainerService.redraft("public", "my-skill", "1.0.1");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when the operation fails.
+
 ## 10. AgentSpec Capabilities
 
 ### 10.1. Get AgentSpec detail
@@ -5661,6 +6274,8 @@ List AgentSpec admin items with pagination.
 
 ```java
 Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentSpecName, String search, int pageNo, int pageSize) throws NacosException;
+
+Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentSpecName, String search, String orderBy, String owner, String scope, int pageNo, int pageSize) throws NacosException;
 ```
 
 #### 请求参数
@@ -5670,6 +6285,9 @@ Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentS
 | namespaceId | string | Namespace ID. |
 | agentSpecName | string | AgentSpec name pattern. |
 | search | string | Search mode: `accurate` or `blur`. |
+| orderBy | string | Optional sort field. |
+| owner | string | Optional resource owner filter. |
+| scope | string | Optional visibility scope filter. |
 | pageNo | int | Page number. |
 | pageSize | int | Page size. |
 
@@ -5685,6 +6303,7 @@ Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentS
 try {
     AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
     Page<AgentSpecSummary> adminList = agentSpecMaintainerService.listAgentSpecAdminItems("public", "test-agent-spec", "blur", 1, 100);
+    adminList = agentSpecMaintainerService.listAgentSpecAdminItems("public", "test-agent-spec", "blur", "download_count", "nacos", "PUBLIC", 1, 100);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5738,6 +6357,8 @@ Create a new draft based on an existing version.
 
 ```java
 String createDraft(String namespaceId, String agentSpecName, String basedOnVersion) throws NacosException;
+
+String createDraft(String namespaceId, String agentSpecName, String basedOnVersion, String targetVersion) throws NacosException;
 ```
 
 #### 请求参数
@@ -5747,6 +6368,7 @@ String createDraft(String namespaceId, String agentSpecName, String basedOnVersi
 | namespaceId | string | Namespace ID. |
 | agentSpecName | string | AgentSpec name. |
 | basedOnVersion | string | Base version (optional). |
+| targetVersion | string | Target draft version, optional; auto-incremented when blank. |
 
 #### 返回参数
 
@@ -5760,6 +6382,7 @@ String createDraft(String namespaceId, String agentSpecName, String basedOnVersi
 try {
     AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
     String version = agentSpecMaintainerService.createDraft("public", "test-agent-spec", "1.0.0");
+    version = agentSpecMaintainerService.createDraft("public", "test-agent-spec", "1.0.0", "1.0.1-draft");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -6079,6 +6702,78 @@ boolean updateScope(String namespaceId, String agentSpecName, String scope) thro
 try {
     AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
     boolean ok = agentSpecMaintainerService.updateScope("public", "test-agent-spec", "PUBLIC");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+### 10.18. Get AgentSpec Version Metadata
+
+#### Description
+
+Get AgentSpec version metadata. The response contains the main content and a resource list with only resource name and type, avoiding full resource content reads.
+
+```java
+AgentSpec getAgentSpecVersionMeta(String namespaceId, String agentSpecName, String version) throws NacosException;
+AgentSpec getAgentSpecVersionMeta(String agentSpecName, String version) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name | Type | Description |
+|:---|:---|:---|
+| namespaceId | string | Namespace ID. |
+| agentSpecName | string | AgentSpec name. |
+| version | string | AgentSpec version. |
+
+#### Response
+
+| Type | Description |
+|:---|:---|
+| AgentSpec | AgentSpec version metadata. |
+
+#### Example
+
+```java
+try {
+    AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
+    AgentSpec meta = agentSpecMaintainerService.getAgentSpecVersionMeta("public", "test-agent-spec", "1.0.0");
+    meta = agentSpecMaintainerService.getAgentSpecVersionMeta("test-agent-spec", "1.0.0");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+### 10.19. Redraft AgentSpec Version
+
+#### Description
+
+Move a reviewed AgentSpec version back to draft status for further editing.
+
+```java
+boolean redraft(String namespaceId, String agentSpecName, String version) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name | Type | Description |
+|:---|:---|:---|
+| namespaceId | string | Namespace ID. |
+| agentSpecName | string | AgentSpec name. |
+| version | string | Version to redraft. |
+
+#### Response
+
+| Type | Description |
+|:---|:---|
+| boolean | Whether redraft succeeds. |
+
+#### Example
+
+```java
+try {
+    AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
+    boolean ok = agentSpecMaintainerService.redraft("public", "test-agent-spec", "1.0.1");
 } catch (NacosException e) {
     e.printStackTrace();
 }

--- a/src/content/docs/next/en/manual/user/java-sdk/usage.md
+++ b/src/content/docs/next/en/manual/user/java-sdk/usage.md
@@ -1803,16 +1803,21 @@ try {
 ```java
 String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification) throws NacosException;
 
+String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification) throws NacosException;
+
 String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException;
+
+String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification) throws NacosException;
 ```
 
 #### 请求参数
 
-| 名称                    | 类型                   | 描述              | 默认值  |
-|:----------------------|:---------------------|-----------------|------|
-| serverSpecification   | McpServerBasicInfo   | MCP服务基本信息       | 无，必填 |
-| toolSpecification     | McpToolSpecification | MCP服务工具信息       | 无，必填 |
-| endpointSpecification | McpEndpointSpec      | MCP服务Endpoint信息 | 无，可选 |
+| 名称                    | 类型                       | 描述                  | 默认值  |
+|:----------------------|:-------------------------|---------------------|------|
+| serverSpecification   | McpServerBasicInfo       | MCP service basic information | 无，必填 |
+| toolSpecification     | McpToolSpecification     | MCP service tool information | 无，必填 |
+| resourceSpecification | McpResourceSpecification | MCP service resource and resource template information | 无，可选 |
+| endpointSpecification | McpEndpointSpec          | MCP service Endpoint information | 无，可选 |
 
 #### 返回参数
 
@@ -1828,6 +1833,9 @@ try {
     McpServerBasicInfo serverSpecification = buildMcpSeverSpec(mcpName, version, isLatest);
     McpToolSpecification toolSpecification = buildTools();
     System.out.println(aiService.releaseMcpServer(serverSpecification, toolSpecification));
+
+    McpResourceSpecification resourceSpecification = buildResources();
+    System.out.println(aiService.releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification, null));
 } catch (Exception e) {
     e.printStackTrace();
 }
@@ -2358,7 +2366,7 @@ try {
 
 ## 8. Skill Capabilities
 
-> Skills are distributed via the Java SDK as ZIP packages containing SKILL.md and all resource files (binary resources are decoded from Base64 back to raw bytes). The SDK currently exposes three download variants: by name, by version, and by label.
+> Skills are distributed via the Java SDK as ZIP packages containing SKILL.md and all resource files (binary resources are decoded from Base64 back to raw bytes). The SDK currently exposes three download variants: by name, by version, and by label, and also supports subscribing to Skill changes.
 
 ### 8.1. Download Skill ZIP
 
@@ -2475,6 +2483,96 @@ try {
 #### Exceptions
 
 Throws NacosException when the skill or specified label is not found, or on query error.
+
+### 8.4. Subscribe Skill
+
+#### Description
+
+Subscribe to Skill changes; the listener is invoked when the Skill ZIP content changes. version and label are optional to narrow the subscription.
+
+```java
+byte[] subscribeSkill(String skillName, String version, String label, AbstractNacosSkillListener skillListener) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name          | Type                       | Description                          | Default     |
+|:--------------|:---------------------------|--------------------------------------|-------------|
+| skillName     | String                     | Skill name                           | — required  |
+| version       | String                     | Target skill version, optional       | —           |
+| label         | String                     | Target label, optional               | —           |
+| skillListener | AbstractNacosSkillListener | Callback listener for Skill changes  | — required  |
+
+#### Response
+
+Returns current Skill ZIP bytes `byte[]` when subscribed successfully; may be null if the skill is not found.
+
+#### Example
+
+```java
+Properties properties = new Properties();
+properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
+AiService aiService = AiFactory.createAiService(properties);
+try {
+    byte[] skillZip = aiService.subscribeSkill("{skillName}", null, "{label}", new AbstractNacosSkillListener() {
+        @Override
+        public void onEvent(NacosSkillEvent event) {
+            System.out.println("skill changed: " + event.getSkillName());
+            System.out.println("resolved version: " + event.getResolvedVersion());
+            System.out.println("md5: " + event.getMd5());
+        }
+    });
+    System.out.println("skill zip bytes: " + (skillZip != null ? skillZip.length : 0));
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when request parameters are invalid or subscription processing fails.
+
+### 8.5. Unsubscribe Skill
+
+#### Description
+
+Unsubscribe from Skill changes. skillName, version, label, and listener must match those used when subscribing.
+
+```java
+void unsubscribeSkill(String skillName, String version, String label, AbstractNacosSkillListener skillListener) throws NacosException;
+```
+
+#### Request Parameters
+
+| Name          | Type                       | Description                       | Default     |
+|:--------------|:---------------------------|-----------------------------------|-------------|
+| skillName     | String                     | Skill name                        | — required  |
+| version       | String                     | Target version, optional          | —           |
+| label         | String                     | Target label, optional            | —           |
+| skillListener | AbstractNacosSkillListener | Listener used when subscribing    | — required  |
+
+#### Response
+
+None.
+
+#### Example
+
+```java
+Properties properties = new Properties();
+properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
+AiService aiService = AiFactory.createAiService(properties);
+AbstractNacosSkillListener listener = new AbstractNacosSkillListener() {};
+try {
+    aiService.subscribeSkill("{skillName}", null, "{label}", listener);
+    aiService.unsubscribeSkill("{skillName}", null, "{label}", listener);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### Exceptions
+
+Throws NacosException when request parameters are invalid or unsubscribe processing fails.
 
 ## 9. Prompt 能力
 

--- a/src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md
+++ b/src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md
@@ -4738,6 +4738,507 @@ try {
 
 操作失败时抛出 NacosException 异常。
 
+### 8.10. 获取 Prompt 治理详情
+
+#### 描述
+
+根据命名空间与 promptKey 获取 Prompt 治理详情，包含版本治理信息与所有版本摘要。
+
+```java
+PromptMetaInfo getPromptGovernanceDetail(String namespaceId, String promptKey) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述           |
+|:------------|:-------|:-------------|
+| namespaceId | string | 命名空间ID。      |
+| promptKey   | string | Prompt 的 key。 |
+
+#### 返回参数
+
+| 参数类型           | 描述              |
+|:---------------|:----------------|
+| PromptMetaInfo | Prompt 治理详情。    |
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    PromptMetaInfo detail = promptMaintainerService.getPromptGovernanceDetail("public", "my-prompt");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.11. 获取 Prompt 指定版本详情
+
+#### 描述
+
+根据命名空间、promptKey 与版本号获取 Prompt 指定版本详情。
+
+```java
+PromptVersionInfo getVersionDetail(String namespaceId, String promptKey, String version) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述           |
+|:------------|:-------|:-------------|
+| namespaceId | string | 命名空间ID。      |
+| promptKey   | string | Prompt 的 key。 |
+| version     | string | Prompt 版本。    |
+
+#### 返回参数
+
+| 参数类型              | 描述                |
+|:------------------|:------------------|
+| PromptVersionInfo | Prompt 指定版本详情。   |
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    PromptVersionInfo detail = promptMaintainerService.getVersionDetail("public", "my-prompt", "1.0.0");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.12. 创建 Prompt 草稿
+
+#### 描述
+
+创建 Prompt 草稿版本，可基于已有版本 fork，并可指定目标草稿版本、模板、变量、提交说明、描述与业务标签。
+
+```java
+String createDraft(String namespaceId, String promptKey, String basedOnVersion, String targetVersion, String template, String variables, String commitMsg, String description, String bizTags) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名            | 参数类型   | 描述                         |
+|:---------------|:-------|:---------------------------|
+| namespaceId    | string | 命名空间ID。                    |
+| promptKey      | string | Prompt 的 key。               |
+| basedOnVersion | string | fork 基于的版本（可选）。           |
+| targetVersion  | string | 目标草稿版本（可选）。               |
+| template       | string | Prompt 模板内容。               |
+| variables      | string | 变量定义 JSON（可选）。             |
+| commitMsg      | string | 提交说明（可选）。                  |
+| description    | string | Prompt 描述（首次创建时可选）。        |
+| bizTags        | string | 业务标签 JSON（首次创建时可选）。        |
+
+#### 返回参数
+
+| 参数类型   | 描述          |
+|:-------|:------------|
+| String | 创建出的草稿版本号。 |
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    String version = promptMaintainerService.createDraft("public", "my-prompt", "1.0.0", "1.0.1-draft",
+            "Hello {{name}}", "{\"name\":\"string\"}", "update prompt", "desc", "[\"ai\"]");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.13. 更新 Prompt 草稿
+
+#### 描述
+
+更新当前 Prompt 草稿内容。
+
+```java
+void updateDraft(String namespaceId, String promptKey, String template, String variables, String commitMsg) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述              |
+|:------------|:-------|:----------------|
+| namespaceId | string | 命名空间ID。         |
+| promptKey   | string | Prompt 的 key。    |
+| template    | string | 更新后的模板内容。       |
+| variables   | string | 变量定义 JSON（可选）。  |
+| commitMsg   | string | 提交说明（可选）。       |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateDraft("public", "my-prompt", "Hello {{name}}", "{\"name\":\"string\"}", "update template");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.14. 删除 Prompt 草稿
+
+#### 描述
+
+删除指定 Prompt 的当前草稿版本。
+
+```java
+void deleteDraft(String namespaceId, String promptKey) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述           |
+|:------------|:-------|:-------------|
+| namespaceId | string | 命名空间ID。      |
+| promptKey   | string | Prompt 的 key。 |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.deleteDraft("public", "my-prompt");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.15. 提交 Prompt 版本审核
+
+#### 描述
+
+提交 Prompt 指定版本进入发布审核流程。
+
+```java
+String submit(String namespaceId, String promptKey, String version) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述                     |
+|:------------|:-------|:-----------------------|
+| namespaceId | string | 命名空间ID。                |
+| promptKey   | string | Prompt 的 key。           |
+| version     | string | 版本号（可选，服务端可自动选择当前草稿）。 |
+
+#### 返回参数
+
+| 参数类型   | 描述          |
+|:-------|:------------|
+| String | 提交后的版本号。    |
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    String version = promptMaintainerService.submit("public", "my-prompt", "1.0.1");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.16. 发布 Prompt 版本
+
+#### 描述
+
+发布审核通过的 Prompt 版本，可选择是否更新 latest 标签。
+
+```java
+void publish(String namespaceId, String promptKey, String version, Boolean updateLatestLabel) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名               | 参数类型    | 描述                 |
+|:------------------|:--------|:-------------------|
+| namespaceId       | string  | 命名空间ID。            |
+| promptKey         | string  | Prompt 的 key。       |
+| version           | string  | 待发布版本。             |
+| updateLatestLabel | boolean | 是否更新 latest 标签。     |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.publish("public", "my-prompt", "1.0.1", true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.17. 强制发布 Prompt 版本
+
+#### 描述
+
+跳过审核流程强制发布 Prompt 版本，可选择是否更新 latest 标签。
+
+```java
+void forcePublish(String namespaceId, String promptKey, String version, Boolean updateLatestLabel) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名               | 参数类型    | 描述                 |
+|:------------------|:--------|:-------------------|
+| namespaceId       | string  | 命名空间ID。            |
+| promptKey         | string  | Prompt 的 key。       |
+| version           | string  | 待发布版本。             |
+| updateLatestLabel | boolean | 是否更新 latest 标签。     |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.forcePublish("public", "my-prompt", "1.0.1", true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.18. 重新编辑 Prompt 版本
+
+#### 描述
+
+将已审核的 Prompt 版本重新转回草稿状态，以便继续编辑。
+
+```java
+boolean redraft(String namespaceId, String promptKey, String version) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述           |
+|:------------|:-------|:-------------|
+| namespaceId | string | 命名空间ID。      |
+| promptKey   | string | Prompt 的 key。 |
+| version     | string | 需要重新编辑的版本。  |
+
+#### 返回参数
+
+| 参数类型    | 描述            |
+|:--------|:--------------|
+| boolean | 重新转草稿是否成功。   |
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    boolean ok = promptMaintainerService.redraft("public", "my-prompt", "1.0.1");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.19. 变更 Prompt 上下线状态
+
+#### 描述
+
+对 Prompt 指定版本进行上线或下线操作。
+
+```java
+void changeOnlineStatus(String namespaceId, String promptKey, String version, boolean online) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型    | 描述                |
+|:------------|:--------|:------------------|
+| namespaceId | string  | 命名空间ID。           |
+| promptKey   | string  | Prompt 的 key。      |
+| version     | string  | 版本号。              |
+| online      | boolean | `true` 上线，`false` 下线。 |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.changeOnlineStatus("public", "my-prompt", "1.0.1", true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.20. 更新 Prompt 标签
+
+#### 描述
+
+更新 Prompt 的 labels JSON，用于维护标签与版本的映射。
+
+```java
+void updateLabels(String namespaceId, String promptKey, String labels) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述           |
+|:------------|:-------|:-------------|
+| namespaceId | string | 命名空间ID。      |
+| promptKey   | string | Prompt 的 key。 |
+| labels      | string | labels JSON。  |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateLabels("public", "my-prompt", "{\"latest\":\"1.0.1\"}");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.21. 更新 Prompt 描述
+
+#### 描述
+
+更新 Prompt 的描述信息。
+
+```java
+void updateDescription(String namespaceId, String promptKey, String description) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述           |
+|:------------|:-------|:-------------|
+| namespaceId | string | 命名空间ID。      |
+| promptKey   | string | Prompt 的 key。 |
+| description | string | 新描述。         |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateDescription("public", "my-prompt", "new desc");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 8.22. 更新 Prompt 业务标签
+
+#### 描述
+
+更新 Prompt 的业务标签（bizTags JSON）。
+
+```java
+void updateBizTags(String namespaceId, String promptKey, String bizTags) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述             |
+|:------------|:-------|:---------------|
+| namespaceId | string | 命名空间ID。        |
+| promptKey   | string | Prompt 的 key。   |
+| bizTags     | string | bizTags JSON。   |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+try {
+    PromptMaintainerService promptMaintainerService = aiMaintainerService.prompt();
+    promptMaintainerService.updateBizTags("public", "my-prompt", "[\"ai\",\"ops\"]");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
 ## 9. Skill 能力
 
 ### 9.1. 注册 Skill
@@ -4911,9 +5412,13 @@ try {
 按命名空间、名称模式、搜索模式分页查询 Skill 列表。
 
 ```java
-Page<SkillBasicInfo> listSkills(String namespaceId, String skillName, String search, int pageNo, int pageSize) throws NacosException;
+Page<SkillSummary> listSkills(String namespaceId, String skillName, String search, int pageNo, int pageSize) throws NacosException;
 
-Page<SkillBasicInfo> listSkills(String skillName, int pageNo, int pageSize) throws NacosException;
+Page<SkillSummary> listSkills(String namespaceId, String skillName, String search, String orderBy, String owner, String scope, int pageNo, int pageSize) throws NacosException;
+
+Page<SkillSummary> listSkills(String namespaceId, String skillName, String search, String orderBy, String owner, String scope, String bizTag, int pageNo, int pageSize) throws NacosException;
+
+Page<SkillSummary> listSkills(String skillName, int pageNo, int pageSize) throws NacosException;
 ```
 
 #### 请求参数
@@ -4923,6 +5428,10 @@ Page<SkillBasicInfo> listSkills(String skillName, int pageNo, int pageSize) thro
 | namespaceId | string | 命名空间ID。                      |
 | skillName   | string | Skill 名称模式过滤。                 |
 | search      | string | 搜索模式：`accurate` 精确 或 `blur` 模糊。 |
+| orderBy     | string | 排序字段（可选）。                    |
+| owner       | string | 资源所有者过滤（可选）。                 |
+| scope       | string | 可见范围过滤（可选）。                  |
+| bizTag      | string | 业务标签过滤（可选）。                  |
 | pageNo      | int    | 页码。                          |
 | pageSize    | int    | 每页条数。                        |
 
@@ -4930,14 +5439,17 @@ Page<SkillBasicInfo> listSkills(String skillName, int pageNo, int pageSize) thro
 
 | 参数类型                   | 描述         |
 |:-----------------------|:-----------|
-| Page\<SkillBasicInfo>   | Skill 分页列表。 |
+| Page\<SkillSummary>   | Skill 分页列表。 |
 
 #### 请求示例
 
 ```java
 try {
-    Page<SkillBasicInfo> result = aiMaintainerService.listSkills("public", "my-skill", "blur", 1, 100);
-    result = aiMaintainerService.listSkills("my-skill", 1, 100);
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    Page<SkillSummary> result = skillMaintainerService.listSkills("public", "my-skill", "blur", 1, 100);
+    result = skillMaintainerService.listSkills("public", "my-skill", "blur", "download_count", "nacos", "PUBLIC", 1, 100);
+    result = skillMaintainerService.listSkills("public", "my-skill", "blur", "download_count", "nacos", "PUBLIC", "ops", 1, 100);
+    result = skillMaintainerService.listSkills("my-skill", 1, 100);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -4956,6 +5468,10 @@ try {
 ```java
 String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
 
+String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite, String targetVersion) throws NacosException;
+
+String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite, String targetVersion, String commitMsg) throws NacosException;
+
 String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
 
 String uploadSkillFromZip(byte[] zipBytes) throws NacosException;
@@ -4968,6 +5484,8 @@ String uploadSkillFromZip(byte[] zipBytes) throws NacosException;
 | namespaceId | string  | 命名空间ID。     |
 | zipBytes    | byte[]  | Skill 的 ZIP 包字节。 |
 | overwrite   | boolean | Skill 已存在时是否覆盖当前可编辑草稿。 |
+| targetVersion | string | 目标版本（可选，当 ZIP 中未包含版本时作为兜底）。 |
+| commitMsg   | string  | 版本提交说明（可选）。 |
 
 #### 返回参数
 
@@ -4979,10 +5497,13 @@ String uploadSkillFromZip(byte[] zipBytes) throws NacosException;
 
 ```java
 try {
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
     byte[] zipBytes = Files.readAllBytes(Paths.get("my-skill.zip"));
-    String name = aiMaintainerService.uploadSkillFromZip("public", zipBytes, true);
-    String name = aiMaintainerService.uploadSkillFromZip("public", zipBytes);
-    name = aiMaintainerService.uploadSkillFromZip(zipBytes);
+    String name = skillMaintainerService.uploadSkillFromZip("public", zipBytes, true);
+    name = skillMaintainerService.uploadSkillFromZip("public", zipBytes, true, "1.0.1");
+    name = skillMaintainerService.uploadSkillFromZip("public", zipBytes, true, "1.0.1", "upload skill");
+    name = skillMaintainerService.uploadSkillFromZip("public", zipBytes);
+    name = skillMaintainerService.uploadSkillFromZip(zipBytes);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5087,6 +5608,8 @@ String createDraft(String namespaceId, String skillName, String basedOnVersion) 
 String createDraft(String namespaceId, String skillName, String basedOnVersion, String targetVersion) throws NacosException;
 
 String createDraft(String namespaceId, String skillName, String basedOnVersion, String targetVersion, String skillCard) throws NacosException;
+
+String createDraft(String namespaceId, String skillName, String basedOnVersion, String targetVersion, String skillCard, String commitMsg) throws NacosException;
 ```
 
 #### 请求参数
@@ -5098,6 +5621,7 @@ String createDraft(String namespaceId, String skillName, String basedOnVersion, 
 | basedOnVersion | string | fork 基于的版本（可选）。                |
 | targetVersion | string | 目标草稿版本（可选）。                    |
 | skillCard    | string | Skill 完整 JSON（非 fork 场景通常必填）。   |
+| commitMsg    | string | 版本提交说明（可选）。                    |
 
 #### 返回参数
 
@@ -5109,10 +5633,12 @@ String createDraft(String namespaceId, String skillName, String basedOnVersion, 
 
 ```java
 try {
-    String version = aiMaintainerService.createDraft("public", "{\"name\":\"my-skill\"}");
-    version = aiMaintainerService.createDraft("public", "my-skill", "1.0.0");
-    version = aiMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft");
-    version = aiMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft", "{\"name\":\"my-skill\"}");
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    String version = skillMaintainerService.createDraft("public", "{\"name\":\"my-skill\"}");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft", "{\"name\":\"my-skill\"}");
+    version = skillMaintainerService.createDraft("public", "my-skill", "1.0.0", "1.0.1-draft", "{\"name\":\"my-skill\"}", "update skill");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5130,6 +5656,8 @@ try {
 
 ```java
 boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest) throws NacosException;
+
+boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest, String commitMsg) throws NacosException;
 ```
 
 #### 请求参数
@@ -5139,6 +5667,7 @@ boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest) t
 | namespaceId | string  | 命名空间ID。                 |
 | skillCard   | string  | Skill 完整 JSON。          |
 | setAsLatest | boolean | 是否设为 latest 标签（可选）。     |
+| commitMsg   | string  | 版本提交说明（可选）。             |
 
 #### 返回参数
 
@@ -5150,7 +5679,9 @@ boolean updateDraft(String namespaceId, String skillCard, Boolean setAsLatest) t
 
 ```java
 try {
-    boolean ok = aiMaintainerService.updateDraft("public", "{\"name\":\"my-skill\"}", true);
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    boolean ok = skillMaintainerService.updateDraft("public", "{\"name\":\"my-skill\"}", true);
+    ok = skillMaintainerService.updateDraft("public", "{\"name\":\"my-skill\"}", true, "update skill");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5468,6 +5999,88 @@ try {
 
 操作失败时抛出 NacosException 异常。
 
+### 9.19. 批量从 ZIP 上传 Skill
+
+#### 描述
+
+从包含多个 Skill 目录的 ZIP 包中批量上传 Skill。
+
+```java
+BatchUploadResult batchUploadSkillsFromZip(byte[] zipBytes) throws NacosException;
+
+BatchUploadResult batchUploadSkillsFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型    | 描述                |
+|:------------|:--------|:------------------|
+| namespaceId | string  | 命名空间ID。           |
+| zipBytes    | byte[]  | 包含多个 Skill 目录的 ZIP 包字节。 |
+| overwrite   | boolean | 是否覆盖已存在的草稿。      |
+
+#### 返回参数
+
+| 参数类型              | 描述             |
+|:------------------|:---------------|
+| BatchUploadResult | 批量上传成功与失败结果。 |
+
+#### 请求示例
+
+```java
+try {
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    byte[] zipBytes = Files.readAllBytes(Paths.get("skills.zip"));
+    BatchUploadResult result = skillMaintainerService.batchUploadSkillsFromZip(zipBytes);
+    result = skillMaintainerService.batchUploadSkillsFromZip("public", zipBytes, true);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
+### 9.20. 重新编辑 Skill 版本
+
+#### 描述
+
+将已审核的 Skill 版本重新转回草稿状态，以便继续编辑。
+
+```java
+boolean redraft(String namespaceId, String skillName, String version) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名         | 参数类型   | 描述          |
+|:------------|:-------|:------------|
+| namespaceId | string | 命名空间ID。     |
+| skillName   | string | Skill 名称。   |
+| version     | string | 需要重新编辑的版本。 |
+
+#### 返回参数
+
+| 参数类型    | 描述            |
+|:--------|:--------------|
+| boolean | 重新转草稿是否成功。   |
+
+#### 请求示例
+
+```java
+try {
+    SkillMaintainerService skillMaintainerService = aiMaintainerService.skill();
+    boolean ok = skillMaintainerService.redraft("public", "my-skill", "1.0.1");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+操作失败时抛出 NacosException 异常。
+
 ## 10. AgentSpec 能力
 
 ### 10.1. 查询 AgentSpec 详情
@@ -5660,6 +6273,8 @@ try {
 
 ```java
 Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentSpecName, String search, int pageNo, int pageSize) throws NacosException;
+
+Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentSpecName, String search, String orderBy, String owner, String scope, int pageNo, int pageSize) throws NacosException;
 ```
 
 #### 请求参数
@@ -5669,6 +6284,9 @@ Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentS
 | namespaceId | string | 命名空间ID。 |
 | agentSpecName | string | AgentSpec 名称模式。 |
 | search | string | 搜索模式：`accurate` 或 `blur`。 |
+| orderBy | string | 排序字段（可选）。 |
+| owner | string | 资源所有者过滤（可选）。 |
+| scope | string | 可见范围过滤（可选）。 |
 | pageNo | int | 页码。 |
 | pageSize | int | 每页条数。 |
 
@@ -5684,6 +6302,7 @@ Page<AgentSpecSummary> listAgentSpecAdminItems(String namespaceId, String agentS
 try {
     AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
     Page<AgentSpecSummary> adminList = agentSpecMaintainerService.listAgentSpecAdminItems("public", "test-agent-spec", "blur", 1, 100);
+    adminList = agentSpecMaintainerService.listAgentSpecAdminItems("public", "test-agent-spec", "blur", "download_count", "nacos", "PUBLIC", 1, 100);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -5737,6 +6356,8 @@ try {
 
 ```java
 String createDraft(String namespaceId, String agentSpecName, String basedOnVersion) throws NacosException;
+
+String createDraft(String namespaceId, String agentSpecName, String basedOnVersion, String targetVersion) throws NacosException;
 ```
 
 #### 请求参数
@@ -5746,6 +6367,7 @@ String createDraft(String namespaceId, String agentSpecName, String basedOnVersi
 | namespaceId | string | 命名空间ID。 |
 | agentSpecName | string | AgentSpec 名称。 |
 | basedOnVersion | string | 基于版本（可选）。 |
+| targetVersion | string | 目标草稿版本（可选，空时自动递增）。 |
 
 #### 返回参数
 
@@ -5759,6 +6381,7 @@ String createDraft(String namespaceId, String agentSpecName, String basedOnVersi
 try {
     AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
     String version = agentSpecMaintainerService.createDraft("public", "test-agent-spec", "1.0.0");
+    version = agentSpecMaintainerService.createDraft("public", "test-agent-spec", "1.0.0", "1.0.1-draft");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -6078,6 +6701,78 @@ boolean updateScope(String namespaceId, String agentSpecName, String scope) thro
 try {
     AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
     boolean ok = agentSpecMaintainerService.updateScope("public", "test-agent-spec", "PUBLIC");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+### 10.18. 查询 AgentSpec 指定版本元信息
+
+#### 描述
+
+查询 AgentSpec 指定版本元信息，返回主配置及仅包含名称和类型的资源列表，避免读取完整资源内容。
+
+```java
+AgentSpec getAgentSpecVersionMeta(String namespaceId, String agentSpecName, String version) throws NacosException;
+AgentSpec getAgentSpecVersionMeta(String agentSpecName, String version) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名 | 参数类型 | 描述 |
+|:---|:---|:---|
+| namespaceId | string | 命名空间ID。 |
+| agentSpecName | string | AgentSpec 名称。 |
+| version | string | AgentSpec 版本。 |
+
+#### 返回参数
+
+| 参数类型 | 描述 |
+|:---|:---|
+| AgentSpec | AgentSpec 指定版本元信息。 |
+
+#### 请求示例
+
+```java
+try {
+    AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
+    AgentSpec meta = agentSpecMaintainerService.getAgentSpecVersionMeta("public", "test-agent-spec", "1.0.0");
+    meta = agentSpecMaintainerService.getAgentSpecVersionMeta("test-agent-spec", "1.0.0");
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+### 10.19. 重新编辑 AgentSpec 版本
+
+#### 描述
+
+将已审核的 AgentSpec 版本重新转回草稿状态，以便继续编辑。
+
+```java
+boolean redraft(String namespaceId, String agentSpecName, String version) throws NacosException;
+```
+
+#### 请求参数
+
+| 参数名 | 参数类型 | 描述 |
+|:---|:---|:---|
+| namespaceId | string | 命名空间ID。 |
+| agentSpecName | string | AgentSpec 名称。 |
+| version | string | 需要重新编辑的版本。 |
+
+#### 返回参数
+
+| 参数类型 | 描述 |
+|:---|:---|
+| boolean | 重新转草稿是否成功。 |
+
+#### 请求示例
+
+```java
+try {
+    AgentSpecMaintainerService agentSpecMaintainerService = aiMaintainerService.agentSpec();
+    boolean ok = agentSpecMaintainerService.redraft("public", "test-agent-spec", "1.0.1");
 } catch (NacosException e) {
     e.printStackTrace();
 }

--- a/src/content/docs/next/zh-cn/manual/user/java-sdk/usage.md
+++ b/src/content/docs/next/zh-cn/manual/user/java-sdk/usage.md
@@ -1803,16 +1803,21 @@ try {
 ```java
 String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification) throws NacosException;
 
+String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification) throws NacosException;
+
 String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException;
+
+String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification) throws NacosException;
 ```
 
 #### 请求参数
 
-| 名称                    | 类型                   | 描述              | 默认值  |
-|:----------------------|:---------------------|-----------------|------|
-| serverSpecification   | McpServerBasicInfo   | MCP服务基本信息       | 无，必填 |
-| toolSpecification     | McpToolSpecification | MCP服务工具信息       | 无，必填 |
-| endpointSpecification | McpEndpointSpec      | MCP服务Endpoint信息 | 无，可选 |
+| 名称                    | 类型                       | 描述                  | 默认值  |
+|:----------------------|:-------------------------|---------------------|------|
+| serverSpecification   | McpServerBasicInfo       | MCP服务基本信息           | 无，必填 |
+| toolSpecification     | McpToolSpecification     | MCP服务工具信息           | 无，必填 |
+| resourceSpecification | McpResourceSpecification | MCP服务资源和资源模板信息      | 无，可选 |
+| endpointSpecification | McpEndpointSpec          | MCP服务Endpoint信息     | 无，可选 |
 
 #### 返回参数
 
@@ -1828,6 +1833,9 @@ try {
     McpServerBasicInfo serverSpecification = buildMcpSeverSpec(mcpName, version, isLatest);
     McpToolSpecification toolSpecification = buildTools();
     System.out.println(aiService.releaseMcpServer(serverSpecification, toolSpecification));
+
+    McpResourceSpecification resourceSpecification = buildResources();
+    System.out.println(aiService.releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification, null));
 } catch (Exception e) {
     e.printStackTrace();
 }
@@ -2358,7 +2366,7 @@ try {
 
 ## 8. Skill 能力
 
-> Skill 在 Java SDK 中以 ZIP 压缩包的形式分发，包含 SKILL.md 和全部资源文件（二进制资源会从 Base64 自动解码为原始字节）。SDK 当前提供按名称、按版本、按标签三种下载方式。
+> Skill 在 Java SDK 中以 ZIP 压缩包的形式分发，包含 SKILL.md 和全部资源文件（二进制资源会从 Base64 自动解码为原始字节）。SDK 当前提供按名称、按版本、按标签三种下载方式，并支持订阅 Skill 变更。
 
 ### 8.1. 下载 Skill ZIP
 
@@ -2475,6 +2483,96 @@ try {
 #### 异常说明
 
 Skill 或指定标签不存在、查询异常时，抛出 NacosException。
+
+### 8.4. 订阅 Skill
+
+#### 描述
+
+订阅 Skill 变更，当 Skill ZIP 内容变化时通过监听器回调。version、label 可选，用于限定订阅范围。
+
+```java
+byte[] subscribeSkill(String skillName, String version, String label, AbstractNacosSkillListener skillListener) throws NacosException;
+```
+
+#### 请求参数
+
+| 名称            | 类型                       | 描述              | 默认值  |
+|:--------------|:-------------------------|-----------------|------|
+| skillName     | String                   | Skill 名称        | 无，必填 |
+| version       | String                   | 目标 Skill 版本，可选 | 无     |
+| label         | String                   | 目标标签，可选        | 无     |
+| skillListener | AbstractNacosSkillListener | Skill 变更回调监听器  | 无，必填 |
+
+#### 返回参数
+
+订阅成功时返回当前 Skill ZIP 压缩包字节数组 `byte[]`，未找到时可为 null。
+
+#### 请求示例
+
+```java
+Properties properties = new Properties();
+properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
+AiService aiService = AiFactory.createAiService(properties);
+try {
+    byte[] skillZip = aiService.subscribeSkill("{skillName}", null, "{label}", new AbstractNacosSkillListener() {
+        @Override
+        public void onEvent(NacosSkillEvent event) {
+            System.out.println("skill changed: " + event.getSkillName());
+            System.out.println("resolved version: " + event.getResolvedVersion());
+            System.out.println("md5: " + event.getMd5());
+        }
+    });
+    System.out.println("skill zip bytes: " + (skillZip != null ? skillZip.length : 0));
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+请求参数不合法或订阅处理异常时，抛出 NacosException。
+
+### 8.5. 取消订阅 Skill
+
+#### 描述
+
+取消对 Skill 的订阅。取消时传入的 skillName、version、label、listener 需与订阅时一致。
+
+```java
+void unsubscribeSkill(String skillName, String version, String label, AbstractNacosSkillListener skillListener) throws NacosException;
+```
+
+#### 请求参数
+
+| 名称            | 类型                       | 描述          | 默认值  |
+|:--------------|:-------------------------|-------------|------|
+| skillName     | String                   | Skill 名称    | 无，必填 |
+| version       | String                   | 目标版本，可选    | 无     |
+| label         | String                   | 目标标签，可选    | 无     |
+| skillListener | AbstractNacosSkillListener | 订阅时使用的监听器 | 无，必填 |
+
+#### 返回参数
+
+无
+
+#### 请求示例
+
+```java
+Properties properties = new Properties();
+properties.setProperty(PropertyKeyConst.SERVER_ADDR, "{serverAddr}");
+AiService aiService = AiFactory.createAiService(properties);
+AbstractNacosSkillListener listener = new AbstractNacosSkillListener() {};
+try {
+    aiService.subscribeSkill("{skillName}", null, "{label}", listener);
+    aiService.unsubscribeSkill("{skillName}", null, "{label}", listener);
+} catch (NacosException e) {
+    e.printStackTrace();
+}
+```
+
+#### 异常说明
+
+请求参数不合法或取消订阅处理异常时，抛出 NacosException。
 
 ## 9. Prompt 能力
 


### PR DESCRIPTION
## Summary
- update next Java SDK usage docs from Nacos Java Client interfaces
- update next Maintainer SDK docs for Prompt, Skill, and AgentSpec APIs
- improve maintainer SDK comparison scripts for chapter-aware API matching and single-line signature parsing

## Validation
- python3 .agents/skills/nacos-java-sdk-doc/scripts/compare_java_api_with_doc.py --nacos-api-dir /Users/xiweng.yy/Documents/java/vibecoding/qoder/nacos/api/src/main/java --usage-md src/content/docs/next/zh-cn/manual/user/java-sdk/usage.md --json
- python3 .agents/skills/nacos-java-sdk-doc/scripts/compare_java_api_with_doc.py --nacos-api-dir /Users/xiweng.yy/Documents/java/vibecoding/qoder/nacos/api/src/main/java --usage-md src/content/docs/next/en/manual/user/java-sdk/usage.md --json
- python3 .agents/skills/nacos-java-maintainer-sdk/scripts/compare_maintainer_api_with_doc.py --nacos-maintainer-dir /Users/xiweng.yy/Documents/java/vibecoding/qoder/nacos/maintainer-client/src/main/java --maintainer-md src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md --json
- python3 .agents/skills/nacos-java-maintainer-sdk/scripts/compare_maintainer_api_with_doc.py --nacos-maintainer-dir /Users/xiweng.yy/Documents/java/vibecoding/qoder/nacos/maintainer-client/src/main/java --maintainer-md src/content/docs/next/en/manual/admin/maintainer-sdk.md --json
- git diff --check

Note: npm run build is blocked locally by missing optional Rollup package @rollup/rollup-darwin-arm64 in node_modules.