### PR TITLE
docs: add experimental features and update console monitoring

### DIFF
--- a/src/content/docs/next/_sidebar.json
+++ b/src/content/docs/next/_sidebar.json
@@ -283,6 +283,16 @@
     }
   },
   {
+    "label": "实验性功能",
+    "translations": {
+      "en": "Experimental Features"
+    },
+    "collapsed": true,
+    "autogenerate": {
+      "directory": "experimental"
+    }
+  },
+  {
     "label": "开源共建",
     "translations": {
       "en": "Contributor Guide"

--- a/src/content/docs/next/en/ecology/use-nacos-prometheus-sd.md
+++ b/src/content/docs/next/en/ecology/use-nacos-prometheus-sd.md
@@ -1,60 +1,108 @@
 ---
-title: 使用Nacos作为Prometheus SD协议提供方
-keywords: [Nacos, Prometheus, Service Discovery]
-description: 本文简单介绍Nacos如何作为Prometheus SD协议提供方
+title: Use Nacos For Prometheus Service Discovery
+keywords: [Nacos, Prometheus, Service Discovery, HTTP SD]
+description: Learn how Prometheus can use Nacos service discovery to dynamically obtain scrape targets for business applications.
 sidebar:
     order: 11
 ---
 
-# 使用Nacos作为Prometheus SD协议提供方
+# Use Nacos For Prometheus Service Discovery
 
-Nacos 支持提供特定 [Prometheus SD](https://prometheus.io/docs/prometheus/latest/http_sd/) 协议的HTTP API，让Prometheus能够自动发现注册在Nacos上的微服务端点，并通过此端点自动获取对应的metrics数据。
+Nacos can convert service instances in service discovery into HTTP Service Discovery data that Prometheus can read. Prometheus can then obtain the latest targets from Nacos instead of maintaining every business application instance statically.
 
-关于如何在Prometheus上配置SD协议，请查询[Prometheus SD](https://prometheus.io/docs/prometheus/latest/http_sd/)相关文档，本文档不再赘述，本文档仅介绍Nacos所提供的HTTP SD API及注意事项。
+:::note
+This page explains how Prometheus discovers business application instances registered in Nacos. It is not the way to enable Nacos Server monitoring metrics. To collect Nacos Server metrics, read the [Monitoring Manual](../manual/admin/monitor.md).
+:::
 
-## 开启Nacos 的 Prometheus SD 支持
+## Before you start
 
-Nacos的Prometheus SD 支持是**默认关闭**的， 当需要使用时，修改配置文件`application.properties`，将`nacos.prometheus.metrics.enabled`设置为`true`后重新启动Nacos Server即可。
+- Business applications have registered instances in Nacos service discovery.
+- Prometheus can access the HTTP port of Nacos Server.
+- Business applications expose metrics ports and paths that Prometheus can scrape.
+- Nacos Server and Prometheus run in a trusted internal network.
 
-> 注意，默认情况下，Nacos的Prometheus SD HTTP API 是**不鉴权**的，即所有请求都允许访问，请参考[Nacos 的 Prometheus SD HTTP API 的鉴权](#nacos-的-prometheus-sd-http-api-的鉴权)开启鉴权或自行限制可访此地址的网络范围。
+## Enable the capability
 
-## Nacos 的 Prometheus SD HTTP API 
+Prometheus service discovery support in Nacos is disabled by default. Enable it in `application.properties`:
 
-Nacos的Prometheus SD HTTP API 提供了以下三个接口：
+```properties
+nacos.prometheus.metrics.enabled=true
+```
 
-- `GET ${nacos.server.contextPath}/prometheus`
-  - 获取当前集群中所有命名空间下的所有服务实例信息
-- `GET ${nacos.server.contextPath}/prometheus/namespaceId/${namespaceId}`
-  - 获取指定命名空间下的所有服务实例信息
-- `GET ${nacos.server.contextPath}/prometheus/namespaceId/{namespaceId}/service/{service}`
-  - 获取指定命名空间下的指定服务实例信息 
+Restart Nacos Server after the change.
 
-其中，`${nacos.server.contextPath}`为Nacos Server的访问路径，默认为`/nacos`。
+This configuration only affects Prometheus service discovery endpoints. It does not enable `/actuator/prometheus`. To collect Nacos Server metrics, configure:
 
-接口的返回内容遵循[Prometheus SD](https://prometheus.io/docs/prometheus/latest/http_sd/)协议，大致内容如下:
+```properties
+management.endpoints.web.exposure.include=prometheus
+```
+
+## Endpoints
+
+`${nacos.server.contextPath}` is the Nacos Server context path. The default value is `/nacos`.
+
+| Endpoint | Description |
+| --- | --- |
+| `GET ${nacos.server.contextPath}/prometheus` | Return service instances from all namespaces in the current cluster. |
+| `GET ${nacos.server.contextPath}/prometheus/namespaceId/{namespaceId}` | Return service instances from a namespace. |
+| `GET ${nacos.server.contextPath}/prometheus/namespaceId/{namespaceId}/service/{service}` | Return service instances from a namespace and service. |
+
+The response follows the Prometheus HTTP Service Discovery format:
 
 ```json
 [
   {
     "targets": [
-      "127.0.0.1:9999"
+      "127.0.0.1:8080"
     ],
     "labels": {
       "__meta_clusterName": "DEFAULT",
-      "__custom_metadata": "false"
+      "env": "prod",
+      "version": "1.0.0"
     }
   }
 ]
 ```
 
-其中`__meta_clusterName` 为实例的集群名称，`__custom_metadata` 为是否自定义元数据，即注册服务实例时填写的实例元数据。
+`targets` are built from the Nacos instance `ip` and `port`. `labels` include the instance cluster name `__meta_clusterName` and instance metadata. Metadata keys containing `.` or `-` are converted to `_` to match Prometheus label naming conventions.
 
-## Nacos 的 Prometheus SD HTTP API 的鉴权
+## Prometheus configuration example
 
-Nacos 的 Prometheus SD HTTP API被定义为`Client`类型的业务API，此类型API默认情况下**不开启鉴权**，需参考[鉴权文档](../manual/admin/auth.mdx) 开启鉴权。
+The following example lets Prometheus obtain business application instances from a namespace in Nacos:
 
-开启鉴权后，需通过`Basic Auth`方案进行身份信息的传递, 如：
+```yaml
+scrape_configs:
+  - job_name: nacos-services
+    http_sd_configs:
+      - url: http://127.0.0.1:8848/nacos/prometheus/namespaceId/public
+        refresh_interval: 30s
+```
+
+If business applications use a metrics path other than the Prometheus default path, configure `metrics_path` or relabeling rules in Prometheus.
+
+## Authentication and network boundary
+
+Do not expose Prometheus service discovery endpoints to the public Internet. Restrict access by internal network, gateway, network policy, or firewall.
+
+After Nacos authentication is enabled, protected Prometheus service discovery endpoints need Basic Auth credentials:
 
 ```shell
-curl "localhost:8848/nacos/prometheus" -H "Authorization: Basic [base64_encode(username:password)]"
+curl "http://127.0.0.1:8848/nacos/prometheus" \
+  -H "Authorization: Basic ${base64_encode_username_password}"
 ```
+
+For authentication configuration, read the [Authorization Manual](../manual/admin/auth.mdx).
+
+## FAQ
+
+**Why are Nacos Server metrics still unavailable after `nacos.prometheus.metrics.enabled=true` is enabled?**
+
+This is expected. That configuration only enables Prometheus service discovery endpoints. For Nacos Server metrics, read the [Monitoring Manual](../manual/admin/monitor.md).
+
+**Prometheus gets targets, but scraping fails. What should I check?**
+
+Check the business application instance `ip`, `port`, metrics path, and network connectivity. Nacos only provides instance addresses from service discovery. It does not expose metrics for business applications.
+
+**The response is empty. What should I check?**
+
+Check the namespace, service name, instance registration state, and whether the Nacos Server accessed by Prometheus belongs to the expected cluster.

--- a/src/content/docs/next/en/experimental/distributed-lock.md
+++ b/src/content/docs/next/en/experimental/distributed-lock.md
@@ -1,0 +1,74 @@
+---
+title: Distributed Lock
+keywords: [Nacos, Experimental Features, Distributed Lock, LockService]
+description: Understand the experimental positioning, usage, and boundary of the Nacos distributed lock.
+sidebar:
+    order: 2
+---
+
+# Distributed Lock
+
+The Nacos distributed lock is an experimental capability in 3.x. It is designed for simple and short mutual exclusion control, such as preventing multiple processes from running a lightweight task at the same time.
+
+:::caution
+Distributed Lock is currently experimental. Its APIs, lease semantics, authentication model, operations capabilities, and SDK support may change. If community feedback is limited, it may later be moved to an ecosystem repository under `nacos-group` for separate maintenance.
+:::
+
+## Suitable scenarios
+
+- Only one application instance should run a short task at a time.
+- A lightweight operation should not be triggered repeatedly.
+- You want to validate Nacos lock behavior and SDK behavior in a test environment.
+
+## Unsuitable scenarios
+
+- Critical business transactions that need a strong production-grade lock service.
+- Scenarios that require fencing tokens, owner tokens, reentrant locks, fairness queues, or automatic renewal.
+- Scenarios that require multi-language SDKs, complete management APIs, query APIs, or watch APIs.
+- Untrusted networks where the lock is expected to act as a security boundary.
+
+## Current boundary
+
+| Capability | Current state |
+| --- | --- |
+| Lock type | The built-in type is `NACOS_LOCK`. |
+| Lock identity | Mainly identified by `lockType` and `key`. |
+| Lease | The client passes a lease duration, and the server calculates the expiration time from the current time. |
+| Default lease | When the requested lease is negative, `nacos.lock.default_expire_time` is used. |
+| Maximum lease | `nacos.lock.max_expire_time` limits the maximum requested lease duration. |
+| SDK | It is mainly used through the Java SDK `LockService`. |
+| Operations | Complete query, watch, and operations APIs are not provided yet. |
+| Authentication | It is not recommended for untrusted networks. |
+
+## Java SDK example
+
+```java
+Properties properties = new Properties();
+properties.put("serverAddr", "127.0.0.1:8848");
+
+LockService lockService = NacosLockFactory.createLockService(properties);
+LockInstance lock = NLockFactory.getLock("demo-lock", 5000L);
+
+try {
+    if (lockService.lock(lock)) {
+        // Execute a short critical section.
+    }
+} finally {
+    lockService.unLock(lock);
+}
+```
+
+In a mixed-version cluster, the client may fail to create or use a lock if some server nodes do not support distributed lock capability. During upgrade or canary rollout, confirm that all target nodes support this capability first.
+
+## Operations suggestions
+
+- Use it only in trusted internal networks, and control which clients can call it.
+- Use a short lease duration to avoid long lock occupation.
+- Handle failures and timeouts in your business code. Do not assume that acquiring a lock always succeeds.
+- Watch lock-related metrics, including lock success, unlock success, and alive lock count.
+
+## Related documents
+
+- [Java SDK Usage](../manual/user/java-sdk/usage.md)
+- [Monitor Manual](../manual/admin/monitor.md)
+- [Experimental Features Overview](./overview.md)

--- a/src/content/docs/next/en/experimental/ecosystem-integrations.md
+++ b/src/content/docs/next/en/experimental/ecosystem-integrations.md
@@ -1,0 +1,40 @@
+---
+title: Kubernetes Ecosystem Experimental Capabilities
+keywords: [Nacos, Experimental Features, Kubernetes Sync, Nacos Controller]
+description: Understand the experimental boundary of Nacos Kubernetes ecosystem sync capabilities.
+sidebar:
+    order: 3
+---
+
+# Kubernetes Ecosystem Experimental Capabilities
+
+The Nacos ecosystem includes several sync and controller capabilities for Kubernetes. They are usually used to validate integration between Kubernetes service discovery and Nacos service discovery.
+
+:::caution
+This page treats these capabilities as experimental features or ecosystem experimental capabilities. They may depend on specific versions, external components, or community maintenance rhythm. Their APIs, configuration, and maintenance location may change. If community feedback is limited, some capabilities may later be moved to `nacos-group` ecosystem repositories for separate maintenance.
+:::
+
+NacosSync and the Prometheus Service Discovery helper are long-standing ecosystem capabilities. They are not treated as experimental features. For NacosSync, read the [NacosSync User Manual](../ecology/use-nacos-sync.md). For the Prometheus Service Discovery helper, read the [Monitoring Manual](../manual/admin/monitor.md) and [Nacos With Prometheus Service Discovery](../ecology/use-nacos-prometheus-sd.md).
+
+## Kubernetes service sync
+
+Kubernetes service sync listens to changes in Kubernetes resources such as Services and Pods, then syncs service and instance information into Nacos service discovery.
+
+The current document mainly describes one-way sync. It is suitable for validating integration between Kubernetes service discovery and Nacos service discovery. Before production use, confirm the Kubernetes version, sync direction, conflict handling, and failure recovery strategy.
+
+Read: [Nacos Supports Syncing Service Metadata From Kubernetes Service Discovery](../ecology/use-nacos-with-k8s-sync.md)
+
+## Nacos Controller service sync
+
+Nacos Controller can be used for integration between Kubernetes and Nacos service discovery. It is suitable for validating service sync and controller mode in Kubernetes environments.
+
+Before production use, confirm the controller version, permission scope, sync direction, and rollback plan.
+
+Read: [Use Nacos Controller To Sync Service](../ecology/use-nacos-controller-to-sync-service.md)
+
+## Suggestions
+
+- Define the sync direction, authoritative data source, and conflict handling rules first.
+- Verify on a small set of services before syncing large production services.
+- Configure monitoring and alerts for sync tasks to avoid unnoticed data drift.
+- Before upgrading Nacos or external systems, validate sync behavior in a test environment.

--- a/src/content/docs/next/en/experimental/overview.md
+++ b/src/content/docs/next/en/experimental/overview.md
@@ -1,0 +1,41 @@
+---
+title: Experimental Features Overview
+keywords: [Nacos, Experimental Features, Distributed Lock, Kubernetes Sync, Nacos Controller]
+description: Understand the positioning, usage boundary, and reading entry points for Nacos experimental features.
+sidebar:
+    order: 1
+---
+
+# Experimental Features Overview
+
+Experimental features carry new capabilities, ecosystem experimental capabilities, or auxiliary tools that are still being validated. They let the community try new directions early, but they are not the same as stable Nacos core capabilities.
+
+:::caution
+Features in this section are experimental features or ecosystem experimental capabilities. Their APIs, configuration, data models, and maintenance model may change significantly. If community feedback is limited, some capabilities may later be moved out of the Nacos main repository and maintained separately under `nacos-group`.
+:::
+
+## How to use them
+
+- Verify them in a test environment or a small traffic environment first.
+- Read the boundary section of each feature before using it.
+- Record versions, configuration, and usage details so upgrades can be checked later.
+- If a feature is useful to your business, share scenarios, issues, and suggestions with the community.
+
+## Current content
+
+| Feature | Suitable scenario | Document |
+| --- | --- | --- |
+| Distributed Lock | Simple and short mutual exclusion control | [Distributed Lock](./distributed-lock.md) |
+| Kubernetes Service Sync | Sync Kubernetes service and instance information into Nacos service discovery | [Kubernetes Ecosystem Experimental Capabilities](./ecosystem-integrations.md) |
+| Nacos Controller service sync | Validate Kubernetes and Nacos service discovery integration | [Kubernetes Ecosystem Experimental Capabilities](./ecosystem-integrations.md) |
+
+## Relationship with core capabilities
+
+The stable core capabilities of Nacos remain service discovery, configuration management, and AI Registry. Experimental features may reuse these capabilities, but their own resource models, APIs, and maintenance rhythm are not fully stable yet.
+
+If you need stable service registration, configuration publishing, AI resource management, authentication, visibility, deployment, or monitoring, start with the official manuals:
+
+- [Configuration Overview](../manual/user/config/overview.md)
+- [Service Discovery Overview](../manual/user/naming/overview.md)
+- [AI Registry Overview](../manual/user/ai/ai-registry-overview.md)
+- [Deployment Best Practices](../manual/admin/deployment/deployment-best-practices.md)

--- a/src/content/docs/next/en/manual/admin/console.md
+++ b/src/content/docs/next/en/manual/admin/console.md
@@ -1,185 +1,149 @@
 ---
-title: Console Usage
-keywords: [Console,Usage]
-description: The Nacos Console is primarily designed to enhance control and management capabilities in areas such as service list management, health status monitoring, service governance, and distributed configuration management.
+title: Console Manual
+keywords: [Nacos, Console, Operations]
+description: Learn how to access and use the Nacos 3.x new console, including navigation, permissions, and common issues.
 sidebar:
     order: 12
 ---
 
-# 控制台手册
+# Console Manual
 
-[Nacos 控制台](http://console.nacos.io/)主要旨在于增强对于服务列表，健康状态管理，服务治理，分布式配置管理等方面的管控能力，以便进一步帮助用户降低管理微服务应用架构的成本，将提供包括下列基本功能:
+The Nacos console is the visual operations entry for users, operators, and platform administrators. It is suitable for daily viewing, publishing, rollback, troubleshooting, and permission management. It is not recommended as the integration interface for automation systems.
 
-:::note
-- [控制台样例](http://console.nacos.io/)的默认用户名密码为`nacos/nacos@demo`。
-- 此控制台样例仅用于展示控制台使用，为公开DEMO，请勿将敏感数据及生产环境相关内容写入其中。
-- 此控制台样例仅用于展示控制台使用，不提供OpenAPI访问，且未开启鉴权，如需测试OpenAPI，请参考[文档](../../quickstart/quick-start.mdx)部署。
-- 此控制台样例仅用于展示控制台使用，不支持修改用户名密码。
-:::
+For automation, use [Admin API](./admin-api.md), [Maintainer SDK](./maintainer-sdk.md), or the corresponding business OpenAPI first. Console API mainly serves page interactions, so its interfaces and fields may change when the console is upgraded.
 
-* 服务管理
-  * 服务列表及服务健康状态展示
-  * 服务元数据存储及编辑
-  * 服务流量权重的调整
-  * 服务优雅上下线
-* 配置管理
-  * 多种配置格式编辑
-  * 编辑DIFF
-  * 示例代码
-  * 推送状态查询
-  * 配置版本及一键回滚
-* 命名空间
-* 登录管理
-* MCP管理
+## Access the console
 
-## 1. 特性详解
+Nacos 3.x uses the new console by default. After startup, visit:
 
-### 1.1. 服务管理
+```text
+http://{console-host}:8080/
+```
 
-开发者或者运维人员往往需要在服务注册后，通过友好的界面来查看服务的注册情况，包括当前系统注册的所有服务和每个服务的详情。并在有权限控制的情况下，进行服务的一些配置的编辑操作。Nacos在这个版本开放的控制台的服务发现部分，主要就是提供用户一个基本的运维页面，能够查看、编辑当前注册的服务。
+By default, the root path redirects to `/next/`. If `nacos.console.contextPath` is configured, include that context path in the URL.
 
-#### 1.1.1. 服务列表管理
+Common configuration:
 
-服务列表帮助用户以统一的视图管理其所有的微服务以及服务健康状态。整体界面布局是左上角有服务的搜索框和搜索按钮，页面中央是服务列表的展示。服务列表主要展示服务名、集群数目、实例数目、健康实例数目和详情按钮五个栏目。
+| Configuration | Description |
+| --- | --- |
+| `nacos.console.port` | Console port. The default is `8080`. |
+| `nacos.console.contextPath` | Console context path. The default is empty. |
+| `nacos.console.ui.enabled` | Whether the default console is enabled. Enabled by default. |
+| `nacos.console.ui.default` | Default console version. The default is `next`. |
 
-![image.png | left | 747x281](https://cdn.nlark.com/lark/0/2018/png/15356/1540536911804-3660f0e9-855f-4439-ac23-e76f6f644360.png "")
+If you deploy the console independently, it is enough to know here that the console and Nacos Server can run separately. For deployment steps, read [Independent Console](./deployment/deployment-independent.md).
 
-在服务列表页面点击详情，可以看到服务的详情。可以查看服务、集群和实例的基本信息。
+## Login and permissions
 
-#### 1.1.2. 服务流量权重支持及流量保护
+After authentication is enabled, the console enters the login flow. When the default authentication implementation is used, the administrator password must be initialized the first time authentication is enabled.
 
-Nacos 为用户提供了流量权重控制的能力，同时开放了服务流量的阈值保护，以帮助用户更好的保护服务服务提供者集群不被意外打垮。如下图所以，可以点击实例的编辑按钮，修改实例的权重。如果想增加实例的流量，可以将权重调大，如果不想实例接收流量，则可以将权重设为0。
+If authentication is not enabled, the console does not pretend that a login page is a security boundary. Always run Nacos in a trusted internal network, and do not expose it to the public Internet.
 
-![image.png | left | 747x266](https://cdn.nlark.com/lark/0/2018/png/15356/1540537029452-dffbb078-4ae5-4397-9f70-083e0ebbb5be.png "")
+Related documents:
 
-#### 1.1.3. 服务元数据管理
+- [Authorization Manual](./auth.mdx)
+- [Access Credentials](../user/auth.mdx)
+- [OIDC/OAuth2 Authentication](./oidc-auth.md)
 
-Nacos提供多个维度的服务元数据的暴露，帮助用户存储自定义的信息。这些信息都是以K-V的数据结构存储，在控制台上，会以k1=v1,k2=v2这样的格式展示。类似的，编辑元数据可以通过相同的格式进行。例如服务的元数据编辑，首先点击服务详情页右上角的“编辑服务”按钮，然后在元数据输入框输入：version=1.0,env=prod。
+## Namespace selection
 
-![image.png | left | 747x271](https://cdn.nlark.com/lark/0/2018/png/15356/1540537359751-217d7500-c19c-4bad-8508-27f347f48a2f.png "")
+The namespace selected in the console affects resource lists. Configurations, services, AI resources, and other resources are shown by namespace.
 
-点击确认，就可以在服务详情页面，看到服务的元数据已经更新了。
+When troubleshooting a missing resource, check the current namespace first. Then check permissions, visibility, and resource state.
 
-![image.png | left | 747x145](https://cdn.nlark.com/lark/0/2018/png/15356/1540537452673-01dc6c92-329a-4b6f-a616-36dc546c3355.png "")
+## AI Registry
 
-#### 1.1.4. 服务优雅上下线
+AI Registry manages resources used by AI applications. The new console shows this menu group when AI capability is enabled and the current startup mode allows it.
 
-Nacos还提供服务实例的上下线操作，在服务详情页面，可以点击实例的“上线”或者“下线”按钮，被下线的实例，将不会包含在健康的实例列表里。
+Common entries:
 
-![image.png | left | 747x142](https://cdn.nlark.com/lark/0/2018/png/15356/1540537640435-b28cb279-75af-4965-8a9a-54cee213f1a5.png "")
+| Entry | Purpose |
+| --- | --- |
+| Skill Registry | Manage Skill metadata, versions, packages, and publish state. |
+| Prompt Registry | Manage Prompt templates, versions, and variables. |
+| Agent Registry | Manage A2A Agent registration and discovery information. |
+| AgentSpecs Registry | Manage AgentSpec resources and versions. |
+| MCP Registry | Manage MCP Servers, tools, endpoints, and API conversion. |
 
-### 1.2. 配置管理
+For complete guidance, read [AI Registry Overview](../user/ai/ai-registry-overview.md).
 
-Nacos支持基于Namespace和Group的配置分组管理，以便用户更灵活的根据自己的需要按照环境或者应用、模块等分组管理微服务以及Spring的大量配置，在配置管理中主要提供了配置历史版本、回滚、订阅者查询等核心管理能力。
+## Configuration Center
 
-![image.png | left | 747x297](https://cdn.nlark.com/lark/0/2018/png/9687/1540458893745-219a46a8-ebd9-405b-9e8f-226f3f0c7e76.png "")
+The Configuration Center menu manages config publishing, query, listening, and rollback.
 
-#### 1.2.1. 多配置格式编辑器
+Common operations:
 
-Nacos支持 YAML、Properties、TEXT、JSON、XML、HTML 等常见配置格式在线编辑、语法高亮、格式校验，帮助用户高效编辑的同时大幅降低格式错误带来的风险。
+- Query configurations by `Data ID`, `Group`, and namespace.
+- Create, edit, and publish configurations.
+- View history versions and roll back when needed.
+- Query listeners to confirm whether clients have received config changes.
+- When importing, exporting, or cloning configurations, pay attention to file size and target namespace.
 
-Nacos支持配置标签的能力，帮助用户更好、更灵活的做到基于标签的配置分类及管理。同时支持用户对配置及其变更进行描述，方便多人或者跨团队协作管理配置。
+To understand the configuration model, gray release, import and export, and troubleshooting, read [Configuration Overview](../user/config/overview.md).
 
-![image.png | left | 747x426](https://cdn.nlark.com/lark/0/2018/png/9687/1540458995051-b3e67fd4-c905-4552-9e52-f54b6ef59941.png "")
+## Service Registry
 
-#### 1.2.2. 编辑DIFF
+The Service Registry menu is used to view services, instances, and subscription relationships.
 
-Nacos支持编辑DIFF能力，帮助用户校验修改内容，降低改错带来的风险。
+Common operations:
 
-![image.png | left | 747x338](https://cdn.nlark.com/lark/0/2018/png/9687/1540457990344-a60e1db3-ca1a-47ed-a03e-f92e37745247.png "")
+- Query services and healthy instance counts in the service list.
+- Open service details to view clusters, instances, metadata, and weight.
+- Adjust instance weight or online and offline state.
+- Query subscribers to confirm whether consumers subscribe to the target service.
 
-#### 1.2.3. 示例代码
+Console operations may affect service discovery results. Before changing weight, metadata, or online state for production services, confirm the change window and rollback plan.
 
-Nacos提供示例代码能力，能够让新手快速使用客户端编程消费该配置，大幅降低新手使用门槛。
+For complete guidance, read [Service Discovery Overview](../user/naming/overview.md).
 
-![image.png | left | 747x223](https://cdn.nlark.com/lark/0/2018/png/9687/1540456991412-01acc11c-8b48-48d8-9032-589ebb9388d9.png "")
+## Platform management
 
-![image.png | left | 747x380](https://cdn.nlark.com/lark/0/2018/png/9687/1540532899571-ccea6b6f-a1e1-44d1-a130-f9afaba01c51.png "")
+Platform management usually serves administrators. Menus may differ under different startup modes and permissions.
 
-#### 1.2.4. 监听者查询
+| Entry | Purpose |
+| --- | --- |
+| Namespace | Create, edit, and delete namespaces. |
+| Cluster Management | View cluster nodes and basic status. |
+| Plugin Management | View loaded plugins and plugin state. |
+| User List | Manage console users. |
+| Role Management | Manage roles and user relationships. |
+| Privilege Management | Manage resource permissions. |
 
-Nacos提供配置订阅者即监听者查询能力，同时提供客户端当前配置的MD5校验值，以便帮助用户更好的检查配置变更是否推送到 Client 端。
+If a menu is missing, the common causes are that the current user is not an administrator, the function mode hides the module, or the related capability is not enabled.
 
-![image.png | left | 747x185](https://cdn.nlark.com/lark/0/2018/png/9687/1540459212236-0abdc558-68b9-4585-b11e-c9a1924ce7ef.png "")
+## Legacy console
 
-#### 1.2.5. 配置的版本及一键回滚
+The legacy console can still be used as the default entry by setting `nacos.console.ui.default=legacy`. You can also visit `/legacy/` directly.
 
-Nacos通过提供配置版本管理及其一键回滚能力，帮助用户改错配置的时候能够快速恢复，降低微服务系统在配置管理上的一定会遇到的可用性风险。
+The legacy console uses older frontend styles and dependencies. It is recommended only for compatibility with existing habits. New deployments should use the new console. The legacy console may be removed in a later version.
 
-![image.png | left | 747x242](https://cdn.nlark.com/lark/0/2018/png/9687/1540459226967-a258b9a7-f95f-41b0-874f-2a0a5da2fc5c.png "")
+When you prepare a new deployment, verify an upgrade, or take documentation screenshots, use the new console first.
 
-![image.png | left | 747x493](https://cdn.nlark.com/lark/0/2018/png/9687/1540459237821-d4c06d16-b356-4953-a6e7-da949b1f3aec.png "")
+## FAQ
 
-## 2. 命名空间管理
+**Why does the root path enter `/next/`?**
 
-Nacos 基于Namespace 帮助用户逻辑隔离多个命名空间，这可以帮助用户更好的管理测试、预发、生产等多环境服务和配置，让每个环境的同一个配置（如数据库数据源）可以定义不同的值。
+This is the default behavior of Nacos 3.x. The new console is the default console.
 
-![image.png | left | 747x298](https://cdn.nlark.com/lark/0/2018/png/9687/1540519411777-74908cc2-29bc-4270-be58-aed62605228f.png "")
+**Why is there no login page?**
 
-![image.png | left | 747x206](https://cdn.nlark.com/lark/0/2018/png/9687/1540519427066-effd5153-02c9-4e21-ae9f-1a2e9ae7713e.png "")
+Usually authentication is not enabled. In this case, the console has no login protection. Use it only in a trusted internal network.
 
-## 3. 登录管理
+**Why can I not see AI Registry, Configuration Center, or Service Registry?**
 
-Nacos支持简单登录功能，在开启[鉴权](./auth.mdx)功能后启用，管理员用户名为： `nacos`, 密码需要在首次开启控制台时进行初始化。
+Check `nacos.functionMode`, `nacos.extension.ai.enabled`, and current user permissions first. Different startup modes hide unrelated menus.
 
-![login](https://cdn.nlark.com/yuque/0/2019/jpeg/338441/1561262748106-4fc05174-bf70-4806-bcbd-90296c5bcbaa.jpeg)
+**Why does independent console access fail?**
 
-### 3.1. 修改默认用户名/密码方法
+Check the address from console to Nacos Server, `nacos.console.remote.server.context-path`, the server context path, and server identity authentication. For detailed steps, read [Independent Console](./deployment/deployment-independent.md).
 
-#### 3.1.1. 初始化时生成
+**What should I do if file upload fails?**
 
-当Nacos集群开启鉴权后访问Nacos控制台时，会校验是否已经初始化过管理员用户`nacos`的密码，若发现未初始化密码时，则会跳转至初始化密码的页面进行初始化。在该页面密码文本框内输入自定义密码，然后点击提交即可；
+Check whether the file exceeds `spring.servlet.multipart.max-file-size` or `spring.servlet.multipart.max-request-size`. The default value is `10MB`.
 
-> 注意：若密码文本框内未输入自定义密码或输入空白密码，Nacos将会生成随机密码，请保存好生成的随机密码。
+## Continue reading
 
-初始化成功后会弹窗提示初始化成功，并展示指定的密码或随机生成的密码，请保存好此密码。
-
-#### 3.1.2. 控制台上修改
-
-1. 登录控制台，选择`权限控制` -> `用户列表`。
-2. 找到nacos用户，并在该用户对应的`操作`列表中点击`修改`按钮，进行密码修改
-
-### 3.2. 关闭登录功能
-
-Nacos默认控制台在`2.2.2`版本前，无论是否开启[鉴权](../../manual/admin/auth.mdx)功能，默认控制台都会跳转到登录页，导致用户被误导认为控制台存在鉴权功能，实际没有开启鉴权，存在安全隐患。
-
-经过社区和安全工程师协商讨论，需要在使用Nacos默认控制台时，鉴权开关关闭时将会自动关闭控制台登录功能。
-
-当鉴权开关`nacos.core.auth.enabled`关闭时，Nacos默认控制台将不再跳转登录页，同时添加页面提示，提示当前集群未开启鉴权功能。
-
-同时针对自定义的[鉴权插件](../../plugin/auth-plugin.md)添加新接口`com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService#isLoginEnabled(默认返回false)`来对自定义插件进行登录页控制。
-
-### 3.3. 关闭默认控制台
-
-部分公司或用户希望关闭默认控制台，使用公司的统一平台进行Nacos的配置和服务管理；或将控制台鉴权和客户端访问的鉴权分离，即控制台操作进行鉴权但客户端请求不进行鉴权。
-
-可以通过`${nacoshome}/conf/application.properties`中的`nacos.console.ui.enabled`来开启或关闭Nacos默认控制台，默认为开启。
-
-同时在关闭默认控制台时，默认控制台会读取`${nacoshome}/conf/console-guide.conf`文件中的内容，并在默认控制台中生成引导页，让维护者自定义将使用默认控制台的用户引导向自定义的统一平台上进行操作。
-
-### 3.4. 会话时间
-
-默认会话保持时间为30分钟。30分钟后需要重新登录认证。可通过`${nacoshome}/conf/application.properties`中的`nacos.core.auth.plugin.nacos.token.expire.seconds`来设置会话保持时间。
-
-## 4. 社区参与的前端共建
-
-在Nacos前端风格、布局的讨论中，社区踊跃投票，最终选择了这套经典黑白蓝风格的皮肤，并且通过我们UED程瑶同学的设计，布局，让交互变得十分自然流畅。 后续又由社区添加了深色主题风格，可以让Nacos控制台在两种样式主题中切换。
-
-在控制台的开发之前，我们通过社区招募到了很多前端同学一起参与了前端代码的开发，在此尤其感谢李晨、王庆、王彦民等同学在Nacos前端开发过程中的大力支持！
-
-## 5. 坚持社区化发展，欢迎加入并贡献社区
-
-> 比吐槽更重要的是搭把手，参与社区一起发展Nacos！
-
-要加入Nacos 社区群进行讨论和参与贡献，请扫描下方二维码加入社区群。
-
-![image.png](https://cdn.nlark.com/yuque/0/2023/png/1577777/1679276899363-83081d59-67c6-4501-9cf8-0d84ba7c6d7e.png#averageHue=%23c1c2c2&clientId=u9dfeac18-3281-4&from=paste&height=551&id=ubcf45e51&name=image.png&originHeight=1102&originWidth=854&originalType=binary&ratio=2&rotation=0&showTitle=false&size=155261&status=done&style=none&taskId=ud6bea1fe-b003-441b-a810-84435d2aeff&title=&width=427)
-
-更多与 Nacos 相关的开源项目信息：
-
-* [Nacos](https://github.com/alibaba/nacos)
-* [Nacos Spring Project](https://github.com/nacos-group/nacos-spring-project)
-* [Nacos Spring Boot](https://github.com/nacos-group/nacos-spring-boot-project)
-* [Spring Cloud Alibaba](https://github.com/alibaba/spring-cloud-alibaba)
-* [Dubbo](https://github.com/apache/dubbo)
-* [Sentinel](https://github.com/alibaba/Sentinel
+- [Deployment Overview](./deployment/deployment-overview.md)
+- [Deployment Best Practices](./deployment/deployment-best-practices.md)
+- [System Configurations](./system-configurations.md)
+- [Console API](./console-api.md)

--- a/src/content/docs/next/en/manual/admin/monitor.md
+++ b/src/content/docs/next/en/manual/admin/monitor.md
@@ -1,170 +1,177 @@
 ---
-title: Monitor Manual
-keywords: [Nacos,Monitor]
-description: How to enabled and deployment with Nacos monitor
+title: Monitoring Manual
+keywords: [Nacos, Monitoring, Prometheus, Grafana, Metrics]
+description: Learn how to expose Nacos 3.x metrics, scrape them with Prometheus, use health checks, and design basic alerts.
 sidebar:
     order: 9
 ---
 
-# 监控手册
+# Monitoring Manual
 
-## 1. Nacos 集群监控
+Nacos monitoring focuses on two kinds of information:
 
-Nacos 支持通过暴露metrics数据接入第三方监控系统监控Nacos运行状态，目前支持prometheus、elastic search和influxdb，下面结合prometheus和grafana为例，介绍如何监控Nacos。与elastic search和influxdb结合可自己查找相关资料。
+- Nacos Server metrics, such as JVM, HTTP, gRPC, configuration management, and service discovery metrics.
+- Health check endpoints, such as liveness and readiness.
 
-### 1.1. 开启Nacos集群metrics数据暴露
+## Expose Nacos Server metrics
 
-按照[部署文档](./deployment/deployment-overview.md)搭建好Nacos集群后，需要在Nacos集群的每个节点上修改如下参数：
+Nacos exposes Prometheus metrics through Spring Boot Actuator. In the default configuration file, this capability is commented out. Enable it on every Nacos Server node:
 
-`application.properties`文件，暴露metrics数据
-
-```
+```properties
 management.endpoints.web.exposure.include=prometheus
 ```
 
-重启后，访问`{ip}:8848/nacos/actuator/prometheus`，即可访问到Nacos集群的metrics数据。
+If you already expose other Actuator endpoints, add `prometheus` to that list.
 
-### 1.2. 搭建prometheus采集Nacos metrics数据
+After restarting the node, visit:
 
-请参考[FIRST STEPS WITH PROMETHEUS](https://prometheus.io/docs/introduction/first_steps/)部署prometheus
-
-其中，需要将prometheus的配置文件`prometheus.yml`关于采集目标相关的配置，修改为如下内容
+```text
+http://{nacos-server-host}:8848/nacos/actuator/prometheus
 ```
-    metrics_path: '/nacos/actuator/prometheus'
+
+The `/nacos` prefix comes from the default `nacos.server.contextPath`. If you change the server context path, adjust the URL accordingly.
+
+:::caution
+Nacos is an internal microservice component and should not be exposed to the public Internet. `/actuator/**` is usually used by monitoring systems. Keep it in a trusted internal network, and restrict access by network policy, gateway, or Prometheus scrape source.
+:::
+
+## Prometheus scrape example
+
+Prometheus can scrape every Nacos Server node directly:
+
+```yaml
+scrape_configs:
+  - job_name: nacos
+    metrics_path: /nacos/actuator/prometheus
     static_configs:
-      - targets: ['{nacos.ip1}:8848','{nacos.ip2}:8848','{nacos.ip3}:8848',...]
+      - targets:
+          - 10.0.0.1:8848
+          - 10.0.0.2:8848
+          - 10.0.0.3:8848
 ```
 
-搭建并启动完成prometheus后，即可通过浏览器访问`http://{prometheus_ip}:9090/graph`可以看到prometheus的采集数据，在搜索栏搜索nacos_monitor可以搜索到Nacos数据说明采集数据成功。
+If Nacos Server uses a different port or context path, change `targets` and `metrics_path`.
 
-### 1.3. 搭建grafana图形化展示Nacos metrics数据
+Grafana can use Prometheus as the datasource. Community dashboard templates are available in [nacos-template](https://github.com/nacos-group/nacos-template).
 
-参考[Install Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) 部署grafana。
+## Health checks
 
-之后在浏览器中访问 `http://{grafana_ip}:3000`
+Nacos 3.x provides v3 health check endpoints. They are suitable for load balancers, Kubernetes probes, or inspection systems.
 
-然后参考[Configure Prometheus](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/)，将刚才部署的prometheus作为Grafana的数据源。
+| Target | Endpoint |
+| --- | --- |
+| Nacos Server state | `/nacos/v3/admin/core/state` |
+| Nacos Server liveness | `/nacos/v3/admin/core/state/liveness` |
+| Nacos Server readiness | `/nacos/v3/admin/core/state/readiness` |
+| Independent console liveness | `/v3/console/health/liveness` |
+| Independent console readiness | `/v3/console/health/readiness` |
 
-随后参考[Import dashboards](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/)导入Nacos grafana监控[模版](https://github.com/nacos-group/nacos-template/blob/master/nacos-grafana-upper-2.4.json)
+If you change `nacos.server.contextPath` or `nacos.console.contextPath`, add the corresponding context path to the endpoint URL.
 
-导入后可看见Nacos监控模版，Nacos监控主要分为三个模块:
+## Key metrics
 
-1. nacos overview: 展示Nacos集群当前的概览信息，如节点个数，服务数，服务提供者数、配置数、连接数，CPU使用率等。
-![nacos overview](/img/doc/manual/admin/monitor-overview.jpg)
-   
-2. nacos core monitor: 展示Nacos集群核心的监控指标，如服务提供者数，配置数，ops，rt等，并能够查看一定时间内的变化趋势。
-![nacos core monitor](/img/doc/manual/admin/monitor-core-monitor.jpg)
+Prometheus metric names may include suffixes based on Micrometer type. For example, timers usually export series such as `_seconds_count` and `_seconds_sum`. When troubleshooting, search the base name first, then inspect its labels.
 
-3. nacos basic monitor: 展示Nacos集群基础的监控指标，如CPU使用率，内存使用率，线程池使用情况等，并能够查看一定时间内的变化趋势。
-![nacos basic monitor](/img/doc/manual/admin/monitor-basic-monitor.jpg)
-   
-### 1.4. 配置Nacos集群告警
+### Basic resource and request metrics
 
-#### 1.4.1. 配置Grafana告警
+| Metric | Description |
+| --- | --- |
+| `system_cpu_usage` | System CPU usage. |
+| `system_load_average_1m` | System load average over 1 minute. |
+| `jvm_memory_used_bytes` | JVM used memory. |
+| `jvm_memory_max_bytes` | JVM max memory. |
+| `jvm_gc_pause_seconds` | GC count and duration. |
+| `jvm_threads_daemon` | JVM daemon thread count. |
+| `http_server_requests_seconds` | HTTP request count and latency. |
+| `grpc_server_requests` | gRPC request latency with labels such as `requestClass`, `success`, `errorCode`, and `module`. |
+| `grpc_server_executor` | gRPC server executor status, including active count, pool size, and queued tasks. |
 
-可以参考[Configure Grafana-managed alert rules](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/)，配置自定义的Nacos相关告警。
+### Core metrics
 
-也可以通过大盘中的对应指标内容，快速配置告警：
+| Metric | Description |
+| --- | --- |
+| `nacos_monitor{module="core",name="longConnection"}` | Long connection count by module. |
+| `nacos_monitor_summary` | Summary metrics for Raft read index, leader read, apply log, and apply read. |
 
-1. 选择需要配置告警的指标，例如`cpu usage`;
-2. 在指标的右上角，点击`Menu`（展示为竖直的3个`.`)，选择`编辑（Edit）`;
-   ![nacos grafana edit](/img/doc/manual/admin/monitor-fast-alert-edit.jpg)
-3. 在Panel页面中，选择`Alert`，点击`New alert rule`，配置告警规则。
-   ![nacos grafana alert](/img/doc/manual/admin/monitor-fast-alert-new.jpg)
-4. 之后同样参考[Configure Grafana-managed alert rules](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/)，配置自定义的Nacos相关告警。
+### Configuration management metrics
 
-#### 1.4.2. 配置Grafana告警通知
+| Metric | Description |
+| --- | --- |
+| `nacos_monitor{module="config",name="getConfig"}` | Config query statistics. |
+| `nacos_monitor{module="config",name="publish"}` | Config publish statistics. |
+| `nacos_monitor{module="config",name="longPolling"}` | Config long polling count. |
+| `nacos_monitor{module="config",name="configCount"}` | Config count. |
+| `nacos_monitor{module="config",name="notifyTask"}` | Config notify task backlog. |
+| `nacos_monitor{module="config",name="notifyClientTask"}` | Client notify task backlog. |
+| `nacos_monitor{module="config",name="dumpTask"}` | Config dump task backlog. |
+| `nacos_monitor{module="config",name="fuzzySearch"}` | Fuzzy search statistics. |
+| `nacos_config_subscriber{version="v1"}` / `nacos_config_subscriber{version="v2"}` | Config listener count. |
+| `nacos_timer{module="config",name="readConfigRt"}` | Read config latency. |
+| `nacos_timer{module="config",name="writeConfigRt"}` | Write config latency. |
+| `nacos_timer{module="config",name="notifyRt"}` | Notify latency. |
+| `nacos_timer{module="config",name="dumpRt"}` | Dump latency. |
+| `nacos_exception{module="config",name="illegalArgument"}` | Config illegal argument exception statistics. |
+| `config_change_count` | TopN config change statistics. |
 
-参考[Configure contact points](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/) 来配置Grafana告警时的通知方式。例如配置邮件通知、钉钉WebHook通知等。
+### Service discovery metrics
 
-### 1.5. Nacos 指标含义
+| Metric | Description |
+| --- | --- |
+| `nacos_monitor{module="naming",name="serviceCount"}` | Service count. |
+| `nacos_monitor{module="naming",name="ipCount"}` | Instance count. |
+| `nacos_monitor{module="naming",name="subscriberCount"}` | Subscriber count. |
+| `nacos_monitor{module="naming",name="totalPush"}` | Total push count. |
+| `nacos_monitor{module="naming",name="failedPush"}` | Failed push count. |
+| `nacos_monitor{module="naming",name="emptyPush"}` | Empty push count. |
+| `nacos_monitor{module="naming",name="avgPushCost"}` | Average push latency. |
+| `nacos_monitor{module="naming",name="maxPushCost"}` | Maximum push latency. |
+| `nacos_monitor{module="naming",name="leaderStatus"}` | Leader state of the service discovery module. |
+| `nacos_monitor{module="naming",name="serviceSubscribedEventQueueSize"}` | Service subscribed event queue size. |
+| `nacos_monitor{module="naming",name="serviceChangedEventQueueSize"}` | Service changed event queue size. |
+| `nacos_monitor{module="naming",name="pushPendingTaskCount"}` | Pending push task count. |
+| `nacos_naming_subscriber{version="v1"}` / `nacos_naming_subscriber{version="v2"}` | Service subscriber count. |
+| `nacos_naming_publisher{version="v1"}` / `nacos_naming_publisher{version="v2"}` | Service provider count. |
+| `service_change_count` | TopN service change statistics. |
 
-#### 1.5.1. Nacos 系统基础资源指标
+### Experimental distributed lock metrics
 
-指标|含义
----|---
-system_cpu_usage|CPU使用率
-system_load_average_1m|load
-jvm_memory_used_bytes|JVM内存使用字节，包含各种内存区
-jvm_memory_max_bytes|JVM内存最大字节，包含各种内存区
-jvm_gc_pause_seconds_count|gc次数，包含各种gc
-jvm_gc_pause_seconds_sum|gc耗时，包含各种gc
-jvm_threads_daemon|线程数
+Distributed Lock is an [experimental feature](../../experimental/distributed-lock.md). If you use it, watch these metrics:
 
-#### 1.5.2. Nacos 集群应用指标
+| Metric | Description |
+| --- | --- |
+| `nacos_monitor{module="lock",name="grpcLockTotal"}` | Total gRPC lock requests. |
+| `nacos_monitor{module="lock",name="grpcLockSuccess"}` | Successful gRPC lock requests. |
+| `nacos_monitor{module="lock",name="grpcUnLockTotal"}` | Total gRPC unlock requests. |
+| `nacos_monitor{module="lock",name="grpcUnLockSuccess"}` | Successful gRPC unlock requests. |
+| `nacos_monitor{module="lock",name="aliveLockCount"}` | Current alive lock count. |
+| `nacos_timer{module="lock",name="lockHandlerRt"}` | Lock request handling latency. |
 
-指标|含义
----|---
-http_server_requests_seconds_count|http请求次数，包括多种(url,方法,code)
-http_server_requests_seconds_sum|http请求总耗时，包括多种(url,方法,code)
-grpc_server_requests_seconds_count|Nacos grpc请求次数，包括多种（requestClass,code)
-grpc_server_requests_seconds_sum|Nacos grpc请求总耗时，包括多种（requestClass,code)
-nacos_timer_seconds_sum|Nacos config水平通知耗时
-nacos_timer_seconds_count|Nacos config水平通知次数
-grpc_server_executor{name='maximumPoolSize'}|Nacos grpc服务器线程池的最大线程数
-grpc_server_executor{name='corePoolSize'}|Nacos grpc服务器线程池的核心线程数
-grpc_server_executor{name='taskCount'}|Nacos grpc服务器线程池的任务数量
-grpc_server_executor{name='poolSize'}|Nacos grpc服务器线程池当前线程数量
-grpc_server_executor{name='activeCount'}|Nacos grpc服务器线程池当前活跃的线程数量
-grpc_server_executor{name='completedTaskCount'}|Nacos grpc服务器线程池完成的任务数量
-grpc_server_executor{name='inQueueTaskCount'}|Nacos grpc服务器线程池在任务队列中的任务数量
-nacos_monitor{name='longPolling'}|Nacos config长连接数
-nacos_monitor{name='configCount'}|Nacos config配置个数
-nacos_monitor{name='dumpTask'}|Nacos config配置落盘任务堆积数
-nacos_monitor{name='notifyTask'}|Nacos config配置水平通知任务堆积数
-nacos_monitor{name='getConfig'}|Nacos config读配置统计数
-nacos_monitor{name='publish'}|Nacos config写配置统计数
-nacos_monitor{name='ipCount'}|Nacos naming ip个数
-nacos_monitor{name='serviceCount'}|Nacos naming域名个数
-nacos_monitor{name='failedPush'}|Nacos naming推送失败数
-nacos_monitor{name='avgPushCost'}|Nacos naming平均推送耗时(ms)
-nacos_monitor{name='leaderStatus'}|Nacos naming角色状态
-nacos_monitor{name='maxPushCost'}|Nacos naming最大推送耗时(ms)
-nacos_monitor{name='mysqlhealthCheck'}|Nacos naming mysql健康检查次数
-nacos_monitor{name='httpHealthCheck'}|Nacos naming http健康检查次数
-nacos_monitor{name='tcpHealthCheck'}|Nacos naming tcp健康检查次数
-nacos_monitor{name='longConnection'}|Nacos基于模块划分的连接数量
-nacos_naming_subscriber{version='v1/v2'}|Nacos naming服务订阅者数量，v1/v2表示订阅者的客户端版本
-nacos_config_subscriber{version='v1/v2'}|Nacos config配置监听者数量，v1/v2表示订阅者的客户端版本
-nacos_naming_publisher{version='v1/v2'}|Nacos naming服务提供者数量，v1/v2表示订阅者的客户端版本
+## Alert suggestions
 
-## 2. Nacos-Sync监控
+| Scenario | Watch |
+| --- | --- |
+| Node unavailable | Readiness failure, HTTP/gRPC request error rate, JVM resources, process liveness. |
+| gRPC backlog | `grpc_server_executor` active count, queue, and completed task changes. |
+| Config push delay | `notifyTask`, `notifyClientTask`, `notifyRt`, and `dumpTask`. |
+| Config publish exception | `publish`, `writeConfigRt`, and `nacos_exception{module="config"}`. |
+| Service push exception | `failedPush`, `pushPendingTaskCount`, `avgPushCost`, and `maxPushCost`. |
+| Abnormal connection change | `longConnection`, `nacos_config_subscriber`, and `nacos_naming_subscriber`. |
+| Lock usage exception | Lock success rate, unlock success rate, and `aliveLockCount`. |
 
-Nacos-Sync 同样支持了第三方监控系统，能通过metrics数据观察Nacos-Sync服务的运行状态，提升了Nacos-Sync的在生产环境的监控能力。
-整体的监控体系的搭建参考上文的[Nacos 集群监控](#1-nacos-集群监控)，进行prometheus和grafana的部署即可。
+## Troubleshooting
 
-### 2.1. grafana监控Nacos-Sync
-和Nacos监控一样，Nacos-Sync也提供了监控模版，导入监控[模版](https://github.com/nacos-group/nacos-template/blob/master/nacos-sync-grafana)
+**`/actuator/prometheus` returns 404 or no data**
 
-Nacos-Sync监控同样也分为三个模块:
-- nacos-sync monitor展示核心监控项
-  ![monitor](https://img.alicdn.com/tfs/TB1GeNWKmzqK1RjSZFHXXb3CpXa-2834-1588.png)
-- nacos-sync detail和alert展示监控曲线和告警
-  ![detail](https://img.alicdn.com/tfs/TB1kP8UKbvpK1RjSZPiXXbmwXXa-2834-1570.png)
+Check whether `management.endpoints.web.exposure.include` contains `prometheus`, confirm that the node has been restarted, and verify `nacos.server.contextPath`.
 
-### 2.2. Nacos-Sync 指标含义
+**`nacos.prometheus.metrics.enabled=true` is configured, but Nacos Server metrics are still unavailable**
 
-Nacos-Sync的metrics分为jvm层和应用层
+This is expected. That configuration belongs to the [Prometheus service discovery ecology document](../../ecology/use-nacos-prometheus-sd.md). It does not enable Nacos Server metrics.
 
-#### 2.2.1. jvm 指标
+**Prometheus fails to scrape some nodes**
 
-指标|含义
----|---
-system_cpu_usage|CPU使用率
-system_load_average_1m|load
-jvm_memory_used_bytes|内存使用字节，包含各种内存区
-jvm_memory_max_bytes|内存最大字节，包含各种内存区
-jvm_gc_pause_seconds_count|gc次数，包含各种gc
-jvm_gc_pause_seconds_sum|gc耗时，包含各种gc
-jvm_threads_daemon|线程数
+Check node ports, context path, network policy, and Prometheus scrape configuration. Every cluster node must expose metrics and be scraped separately.
 
-#### 2.2.2. 应用层 指标
+**A module metric is missing**
 
-指标|含义
----|---
-nacosSync_task_size|同步任务数
-nacosSync_cluster_size|集群数
-nacosSync_add_task_rt|同步任务执行耗时
-nacosSync_delete_task_rt|删除任务耗时
-nacosSync_dispatcher_task|从数据库中分发任务
-nacosSync_sync_task_error|所有同步执行时的异常
+Confirm whether the corresponding module is enabled. For example, if only the configuration module is started, service discovery metrics will not be complete. Experimental distributed lock metrics are meaningful only when the related capability is used.

--- a/src/content/docs/next/zh-cn/ecology/use-nacos-prometheus-sd.md
+++ b/src/content/docs/next/zh-cn/ecology/use-nacos-prometheus-sd.md
@@ -1,60 +1,108 @@
 ---
-title: 使用Nacos作为Prometheus SD协议提供方
-keywords: [Nacos, Prometheus, Service Discovery]
-description: 本文简单介绍Nacos如何作为Prometheus SD协议提供方
+title: 使用 Nacos 提供 Prometheus 服务发现
+keywords: [Nacos, Prometheus, Service Discovery, HTTP SD]
+description: 了解如何让 Prometheus 通过 Nacos 服务发现动态获取业务应用抓取目标。
 sidebar:
     order: 11
 ---
 
-# 使用Nacos作为Prometheus SD协议提供方
+# 使用 Nacos 提供 Prometheus 服务发现
 
-Nacos 支持提供特定 [Prometheus SD](https://prometheus.io/docs/prometheus/latest/http_sd/) 协议的HTTP API，让Prometheus能够自动发现注册在Nacos上的微服务端点，并通过此端点自动获取对应的metrics数据。
+Nacos 可以把服务发现中的实例列表转换为 Prometheus 可读取的 HTTP Service Discovery 数据。这样 Prometheus 不需要静态维护每个业务应用实例地址，可以定期从 Nacos 获取最新 target。
 
-关于如何在Prometheus上配置SD协议，请查询[Prometheus SD](https://prometheus.io/docs/prometheus/latest/http_sd/)相关文档，本文档不再赘述，本文档仅介绍Nacos所提供的HTTP SD API及注意事项。
+:::note
+本文说明的是“Prometheus 如何发现注册在 Nacos 上的业务应用实例”。它不是 Nacos Server 自身监控指标的开启方式。采集 Nacos Server 指标请阅读[监控手册](../manual/admin/monitor.md)。
+:::
 
-## 开启Nacos 的 Prometheus SD 支持
+## 使用前确认
 
-Nacos的Prometheus SD 支持是**默认关闭**的， 当需要使用时，修改配置文件`application.properties`，将`nacos.prometheus.metrics.enabled`设置为`true`后重新启动Nacos Server即可。
+- 业务应用已经注册到 Nacos 服务发现。
+- Prometheus 能访问 Nacos Server 的 HTTP 端口。
+- 业务应用自身已经暴露 Prometheus 可抓取的 metrics 端口和路径。
+- Nacos Server 与 Prometheus 都运行在可信内部网络中。
 
-> 注意，默认情况下，Nacos的Prometheus SD HTTP API 是**不鉴权**的，即所有请求都允许访问，请参考[Nacos 的 Prometheus SD HTTP API 的鉴权](#nacos-的-prometheus-sd-http-api-的鉴权)开启鉴权或自行限制可访此地址的网络范围。
+## 开启能力
 
-## Nacos 的 Prometheus SD HTTP API 
+Nacos 的 Prometheus 服务发现能力默认关闭。需要在 `application.properties` 中开启：
 
-Nacos的Prometheus SD HTTP API 提供了以下三个接口：
+```properties
+nacos.prometheus.metrics.enabled=true
+```
 
-- `GET ${nacos.server.contextPath}/prometheus`
-  - 获取当前集群中所有命名空间下的所有服务实例信息
-- `GET ${nacos.server.contextPath}/prometheus/namespaceId/${namespaceId}`
-  - 获取指定命名空间下的所有服务实例信息
-- `GET ${nacos.server.contextPath}/prometheus/namespaceId/{namespaceId}/service/{service}`
-  - 获取指定命名空间下的指定服务实例信息 
+修改后重启 Nacos Server。
 
-其中，`${nacos.server.contextPath}`为Nacos Server的访问路径，默认为`/nacos`。
+这个配置只影响 Prometheus 服务发现接口，不会开启 `/actuator/prometheus`。如果你要采集 Nacos Server 自身指标，需要配置：
 
-接口的返回内容遵循[Prometheus SD](https://prometheus.io/docs/prometheus/latest/http_sd/)协议，大致内容如下:
+```properties
+management.endpoints.web.exposure.include=prometheus
+```
+
+## 接口列表
+
+`${nacos.server.contextPath}` 为 Nacos Server 的访问路径，默认是 `/nacos`。
+
+| 接口 | 说明 |
+| --- | --- |
+| `GET ${nacos.server.contextPath}/prometheus` | 返回当前集群中全部命名空间下的服务实例。 |
+| `GET ${nacos.server.contextPath}/prometheus/namespaceId/{namespaceId}` | 返回指定命名空间下的服务实例。 |
+| `GET ${nacos.server.contextPath}/prometheus/namespaceId/{namespaceId}/service/{service}` | 返回指定命名空间和服务下的服务实例。 |
+
+返回内容是 Prometheus HTTP Service Discovery 格式：
 
 ```json
 [
   {
     "targets": [
-      "127.0.0.1:9999"
+      "127.0.0.1:8080"
     ],
     "labels": {
       "__meta_clusterName": "DEFAULT",
-      "__custom_metadata": "false"
+      "env": "prod",
+      "version": "1.0.0"
     }
   }
 ]
 ```
 
-其中`__meta_clusterName` 为实例的集群名称，`__custom_metadata` 为是否自定义元数据，即注册服务实例时填写的实例元数据。
+`targets` 来自 Nacos 实例的 `ip` 和 `port`。`labels` 中包含实例集群名 `__meta_clusterName`，也会包含实例元数据。元数据 key 中的 `.` 和 `-` 会被转换为 `_`，以便符合 Prometheus label 命名习惯。
 
-## Nacos 的 Prometheus SD HTTP API 的鉴权
+## Prometheus 配置示例
 
-Nacos 的 Prometheus SD HTTP API被定义为`Client`类型的业务API，此类型API默认情况下**不开启鉴权**，需参考[鉴权文档](../manual/admin/auth.mdx) 开启鉴权。
+下面示例让 Prometheus 从 Nacos 获取指定命名空间中的业务应用实例：
 
-开启鉴权后，需通过`Basic Auth`方案进行身份信息的传递, 如：
+```yaml
+scrape_configs:
+  - job_name: nacos-services
+    http_sd_configs:
+      - url: http://127.0.0.1:8848/nacos/prometheus/namespaceId/public
+        refresh_interval: 30s
+```
+
+如果业务应用的 metrics 路径不是 Prometheus 默认路径，需要在 Prometheus 中继续配置 `metrics_path` 或 relabel 规则。
+
+## 鉴权和网络边界
+
+默认情况下，不应把 Prometheus 服务发现接口暴露给公网。请通过内网、网关、网络策略或防火墙限制访问来源。
+
+开启 Nacos 鉴权后，受保护的 Prometheus 服务发现接口需要使用 Basic Auth 传递身份信息：
 
 ```shell
-curl "localhost:8848/nacos/prometheus" -H "Authorization: Basic [base64_encode(username:password)]"
+curl "http://127.0.0.1:8848/nacos/prometheus" \
+  -H "Authorization: Basic ${base64_encode_username_password}"
 ```
+
+鉴权配置请阅读[鉴权手册](../manual/admin/auth.mdx)。
+
+## 常见问题
+
+**开启 `nacos.prometheus.metrics.enabled=true` 后，为什么没有 Nacos Server 指标？**
+
+这是预期行为。该配置只开启 Prometheus 服务发现接口。Nacos Server 自身指标请阅读[监控手册](../manual/admin/monitor.md)。
+
+**Prometheus 能拿到 target，但抓取失败怎么办？**
+
+检查业务应用实例的 `ip`、`port`、metrics 路径和网络连通性。Nacos 只提供服务发现中的实例地址，不会替业务应用暴露 metrics。
+
+**返回结果为空怎么办？**
+
+检查命名空间、服务名、实例是否已注册，以及 Prometheus 访问的 Nacos Server 是否连接到同一个集群。

--- a/src/content/docs/next/zh-cn/experimental/distributed-lock.md
+++ b/src/content/docs/next/zh-cn/experimental/distributed-lock.md
@@ -1,0 +1,74 @@
+---
+title: 分布式锁
+keywords: [Nacos, 实验性功能, 分布式锁, LockService]
+description: 了解 Nacos 分布式锁的实验性定位、使用方式和能力边界。
+sidebar:
+    order: 2
+---
+
+# 分布式锁
+
+Nacos 分布式锁是 3.x 中的实验性能力。它面向简单、短时的互斥控制，例如避免多个进程同时执行一段轻量级任务。
+
+:::caution
+分布式锁当前属于实验性功能。接口、租约语义、鉴权方式、运维能力和 SDK 支持范围都可能调整。若社区反馈较少，后续可能剥离到 `nacos-group` 生态仓库独立维护。
+:::
+
+## 适合的场景
+
+- 多个应用实例中，只希望一个实例短时间执行某个任务。
+- 控制一次轻量级运维动作，避免重复触发。
+- 在测试环境验证 Nacos 锁能力和 SDK 行为。
+
+## 不适合的场景
+
+- 需要强生产级锁服务的关键业务事务。
+- 需要 fencing token、owner token、可重入、公平队列或自动续约的场景。
+- 需要跨语言 SDK、完整管理 API、查询 API 或监听 API 的场景。
+- 运行在不可信网络中，并把锁作为安全边界的场景。
+
+## 当前能力边界
+
+| 能力 | 当前状态 |
+| --- | --- |
+| 锁类型 | 内置类型为 `NACOS_LOCK`。 |
+| 锁标识 | 主要由 `lockType` 和 `key` 标识。 |
+| 租约 | 客户端传入租约时长，服务端按当前时间计算过期时间。 |
+| 默认租约 | 请求租约为负数时，使用 `nacos.lock.default_expire_time`。 |
+| 最大租约 | 使用 `nacos.lock.max_expire_time` 限制最大租约时长。 |
+| SDK | 当前主要通过 Java SDK 的 `LockService` 使用。 |
+| 管理能力 | 暂不提供完整的查询、监听和运维管理 API。 |
+| 鉴权 | 当前不建议在不可信网络中使用。 |
+
+## Java SDK 使用示例
+
+```java
+Properties properties = new Properties();
+properties.put("serverAddr", "127.0.0.1:8848");
+
+LockService lockService = NacosLockFactory.createLockService(properties);
+LockInstance lock = NLockFactory.getLock("demo-lock", 5000L);
+
+try {
+    if (lockService.lock(lock)) {
+        // Execute a short critical section.
+    }
+} finally {
+    lockService.unLock(lock);
+}
+```
+
+混合版本集群中，如果服务端不支持分布式锁能力，客户端可能无法成功创建或使用锁。升级和灰度验证时，请先确认所有目标节点都支持该能力。
+
+## 运维建议
+
+- 只在可信内部网络中使用，并控制调用方范围。
+- 为锁设置较短租约，避免长时间占用。
+- 在业务侧做好失败和超时处理，不要假设加锁一定成功。
+- 关注锁相关指标，观察加锁成功率、解锁成功率和存活锁数量。
+
+## 相关文档
+
+- [Java SDK 使用手册](../manual/user/java-sdk/usage.md)
+- [监控手册](../manual/admin/monitor.md)
+- [实验性功能概览](./overview.md)

--- a/src/content/docs/next/zh-cn/experimental/ecosystem-integrations.md
+++ b/src/content/docs/next/zh-cn/experimental/ecosystem-integrations.md
@@ -1,0 +1,40 @@
+---
+title: Kubernetes 生态实验能力
+keywords: [Nacos, 实验性功能, K8S Sync, Nacos Controller]
+description: 了解 Nacos Kubernetes 生态同步能力的实验性边界。
+sidebar:
+    order: 3
+---
+
+# Kubernetes 生态实验能力
+
+Nacos 生态中存在一些连接 Kubernetes 的同步和控制器能力。它们通常用于验证 Kubernetes 服务发现与 Nacos 服务发现之间的联动。
+
+:::caution
+本页内容按实验性功能或生态实验能力处理。它们可能依赖特定版本、外部组件或社区维护节奏。接口、配置和维护位置可能调整。若社区反馈较少，部分能力后续可能剥离到 `nacos-group` 生态仓库独立维护。
+:::
+
+NacosSync 和 Prometheus 服务发现辅助能力是长期存在的生态能力，不按实验性功能处理。NacosSync 请阅读[生态融合中的 NacosSync 用户手册](../ecology/use-nacos-sync.md)，Prometheus 服务发现辅助能力请阅读[监控手册](../manual/admin/monitor.md)和[生态融合中的 Prometheus SD 文档](../ecology/use-nacos-prometheus-sd.md)。
+
+## Kubernetes 服务同步
+
+Kubernetes 服务同步用于监听 Kubernetes 中的 Service、Pod 等资源变化，并将服务和实例信息同步到 Nacos 服务发现中。
+
+当前文档中记录的能力以单向同步为主，适合做 Kubernetes 服务发现与 Nacos 服务发现的联动验证。正式生产使用前，需要确认 Kubernetes 版本、同步方向、冲突处理和失败恢复策略。
+
+阅读：[Nacos 支持从 K8S 服务发现中同步服务元数据](../ecology/use-nacos-with-k8s-sync.md)
+
+## Nacos Controller 服务同步
+
+Nacos Controller 可用于 Kubernetes 与 Nacos 服务发现的联动场景。它更适合在 Kubernetes 环境中验证服务同步和控制器模式。
+
+在生产环境使用前，请先确认控制器版本、权限范围、同步方向和回滚方案。
+
+阅读：[使用 Nacos Controller 同步服务](../ecology/use-nacos-controller-to-sync-service.md)
+
+## 使用建议
+
+- 先把同步方向、权威数据源和冲突处理规则写清楚。
+- 在小范围服务上验证，不要一次性同步大规模生产服务。
+- 为同步任务配置监控和告警，避免无感知的数据漂移。
+- 升级 Nacos 或外部系统前，先在测试环境验证同步行为。

--- a/src/content/docs/next/zh-cn/experimental/overview.md
+++ b/src/content/docs/next/zh-cn/experimental/overview.md
@@ -1,0 +1,41 @@
+---
+title: 实验性功能概览
+keywords: [Nacos, 实验性功能, 分布式锁, K8S Sync, Nacos Controller]
+description: 了解 Nacos 实验性功能的定位、使用边界和当前推荐阅读入口。
+sidebar:
+    order: 1
+---
+
+# 实验性功能概览
+
+实验性功能用于承载仍在验证中的新能力、生态实验能力或辅助工具。它们可以帮助社区更早试用新方向，但不等同于 Nacos 的稳定核心能力。
+
+:::caution
+本章节中的功能属于实验性功能或生态实验能力。接口、配置、数据模型和维护方式都可能发生较大修改。若社区反馈较少，部分能力后续可能从 Nacos 主仓库剥离到 `nacos-group` 生态仓库独立维护。
+:::
+
+## 适合如何使用
+
+- 先在测试环境或小流量环境验证，不建议直接承担关键生产链路。
+- 使用前阅读对应功能页中的边界说明，确认它是否满足当前场景。
+- 记录版本、配置和使用方式，方便升级时核对兼容性变化。
+- 如果功能对业务有价值，建议在社区反馈场景、问题和改进建议。
+
+## 当前内容
+
+| 功能 | 适合场景 | 文档 |
+| --- | --- | --- |
+| 分布式锁 | 简单、短时的互斥控制 | [分布式锁](./distributed-lock.md) |
+| Kubernetes 服务同步 | 将 Kubernetes 中的服务和实例信息同步到 Nacos 服务发现 | [Kubernetes 生态实验能力](./ecosystem-integrations.md) |
+| Nacos Controller 服务同步 | Kubernetes 与 Nacos 服务发现的联动验证 | [Kubernetes 生态实验能力](./ecosystem-integrations.md) |
+
+## 和核心功能的关系
+
+Nacos 的稳定核心能力仍然是服务发现、配置管理和 AI 管理中心。实验性功能可能复用这些能力，但它们自身的资源模型、接口和维护节奏还没有完全稳定。
+
+如果你需要稳定的服务注册、配置发布、AI 资源管理、鉴权、可见性、部署和监控能力，请优先阅读对应的正式文档：
+
+- [配置管理概览](../manual/user/config/overview.md)
+- [服务发现概览](../manual/user/naming/overview.md)
+- [AI 管理中心概述](../manual/user/ai/ai-registry-overview.md)
+- [部署最佳实践](../manual/admin/deployment/deployment-best-practices.md)

--- a/src/content/docs/next/zh-cn/manual/admin/console.md
+++ b/src/content/docs/next/zh-cn/manual/admin/console.md
@@ -1,185 +1,149 @@
 ---
 title: 控制台手册
-keywords: [控制台,手册]
-description: Nacos 控制台主要旨在于增强对于服务列表，健康状态管理，服务治理，分布式配置管理等方面的管控能力。
+keywords: [Nacos, 控制台, Console, 运维]
+description: 了解 Nacos 3.x 新控制台的访问入口、功能导航和常见使用问题。
 sidebar:
     order: 12
 ---
 
 # 控制台手册
 
-[Nacos 控制台](http://console.nacos.io/)主要旨在于增强对于服务列表，健康状态管理，服务治理，分布式配置管理等方面的管控能力，以便进一步帮助用户降低管理微服务应用架构的成本，将提供包括下列基本功能:
+Nacos 控制台是面向用户、运维人员和平台管理员的可视化操作入口。它适合日常查看、发布、回滚、排障和权限管理，不建议作为自动化系统的调用接口。
 
-:::note
-- [控制台样例](http://console.nacos.io/)的默认用户名密码为`nacos/nacos@demo`。
-- 此控制台样例仅用于展示控制台使用，为公开DEMO，请勿将敏感数据及生产环境相关内容写入其中。
-- 此控制台样例仅用于展示控制台使用，不提供OpenAPI访问，且未开启鉴权，如需测试OpenAPI，请参考[文档](../../quickstart/quick-start.mdx)部署。
-- 此控制台样例仅用于展示控制台使用，不支持修改用户名密码。
-:::
+自动化操作请优先使用 [Admin API](./admin-api.md)、[Maintainer SDK](./maintainer-sdk.md) 或对应业务 OpenAPI。控制台 API 主要服务于页面交互，接口和字段可能随控制台升级调整。
 
-* 服务管理
-  * 服务列表及服务健康状态展示
-  * 服务元数据存储及编辑
-  * 服务流量权重的调整
-  * 服务优雅上下线
-* 配置管理
-  * 多种配置格式编辑
-  * 编辑DIFF
-  * 示例代码
-  * 推送状态查询
-  * 配置版本及一键回滚
-* 命名空间
-* 登录管理
-* MCP管理
+## 进入控制台
 
-## 1. 特性详解
+Nacos 3.x 默认使用新控制台。启动后访问：
 
-### 1.1. 服务管理
+```text
+http://{console-host}:8080/
+```
 
-开发者或者运维人员往往需要在服务注册后，通过友好的界面来查看服务的注册情况，包括当前系统注册的所有服务和每个服务的详情。并在有权限控制的情况下，进行服务的一些配置的编辑操作。Nacos在这个版本开放的控制台的服务发现部分，主要就是提供用户一个基本的运维页面，能够查看、编辑当前注册的服务。
+默认情况下，根路径会跳转到 `/next/`。如果配置了 `nacos.console.contextPath`，需要在地址中带上对应上下文路径。
 
-#### 1.1.1. 服务列表管理
+常见配置如下：
 
-服务列表帮助用户以统一的视图管理其所有的微服务以及服务健康状态。整体界面布局是左上角有服务的搜索框和搜索按钮，页面中央是服务列表的展示。服务列表主要展示服务名、集群数目、实例数目、健康实例数目和详情按钮五个栏目。
+| 配置项 | 说明 |
+| --- | --- |
+| `nacos.console.port` | 控制台端口，默认 `8080`。 |
+| `nacos.console.contextPath` | 控制台上下文路径，默认空。 |
+| `nacos.console.ui.enabled` | 是否启用默认控制台，默认启用。 |
+| `nacos.console.ui.default` | 默认控制台版本，默认 `next`。 |
 
-![image.png | left | 747x281](https://cdn.nlark.com/lark/0/2018/png/15356/1540536911804-3660f0e9-855f-4439-ac23-e76f6f644360.png "")
+如果你采用控制台独立部署，只需要知道控制台和 Nacos Server 可以分开运行。具体部署步骤请阅读[控制台独立部署](./deployment/deployment-independent.md)。
 
-在服务列表页面点击详情，可以看到服务的详情。可以查看服务、集群和实例的基本信息。
+## 登录和权限
 
-#### 1.1.2. 服务流量权重支持及流量保护
+开启鉴权后，控制台会进入登录流程。使用默认鉴权实现时，首次启用鉴权需要初始化管理员用户密码。
 
-Nacos 为用户提供了流量权重控制的能力，同时开放了服务流量的阈值保护，以帮助用户更好的保护服务服务提供者集群不被意外打垮。如下图所以，可以点击实例的编辑按钮，修改实例的权重。如果想增加实例的流量，可以将权重调大，如果不想实例接收流量，则可以将权重设为0。
+如果未开启鉴权，控制台不会把登录页伪装成安全边界。请务必把 Nacos 放在可信内部网络中，不要暴露到公网。
 
-![image.png | left | 747x266](https://cdn.nlark.com/lark/0/2018/png/15356/1540537029452-dffbb078-4ae5-4397-9f70-083e0ebbb5be.png "")
+权限相关文档：
 
-#### 1.1.3. 服务元数据管理
+- [鉴权手册](./auth.mdx)
+- [访问凭据](../user/auth.mdx)
+- [OIDC/OAuth2 认证](./oidc-auth.md)
 
-Nacos提供多个维度的服务元数据的暴露，帮助用户存储自定义的信息。这些信息都是以K-V的数据结构存储，在控制台上，会以k1=v1,k2=v2这样的格式展示。类似的，编辑元数据可以通过相同的格式进行。例如服务的元数据编辑，首先点击服务详情页右上角的“编辑服务”按钮，然后在元数据输入框输入：version=1.0,env=prod。
+## 命名空间选择
 
-![image.png | left | 747x271](https://cdn.nlark.com/lark/0/2018/png/15356/1540537359751-217d7500-c19c-4bad-8508-27f347f48a2f.png "")
+控制台顶部或页面上下文中的命名空间会影响资源列表。配置、服务、AI 资源等都会按命名空间隔离展示。
 
-点击确认，就可以在服务详情页面，看到服务的元数据已经更新了。
+排查“资源不存在”时，先确认当前命名空间是否正确，再检查权限、可见性和资源状态。
 
-![image.png | left | 747x145](https://cdn.nlark.com/lark/0/2018/png/15356/1540537452673-01dc6c92-329a-4b6f-a616-36dc546c3355.png "")
+## AI 管理中心
 
-#### 1.1.4. 服务优雅上下线
+AI 管理中心用于管理 AI 应用依赖的资源。新控制台会在 AI 功能启用且当前启动模式允许时展示这一组菜单。
 
-Nacos还提供服务实例的上下线操作，在服务详情页面，可以点击实例的“上线”或者“下线”按钮，被下线的实例，将不会包含在健康的实例列表里。
+常见入口包括：
 
-![image.png | left | 747x142](https://cdn.nlark.com/lark/0/2018/png/15356/1540537640435-b28cb279-75af-4965-8a9a-54cee213f1a5.png "")
+| 入口 | 用途 |
+| --- | --- |
+| Skill 管理 | 管理 Skill 元数据、版本、包文件和发布状态。 |
+| Prompt 管理 | 管理 Prompt 模板、版本和变量。 |
+| Agent 管理 | 管理 A2A Agent 的注册和发现信息。 |
+| AgentSpecs 管理 | 管理 AgentSpec 资源和版本。 |
+| MCP 管理 | 管理 MCP Server、工具列表、端点和 API 转换。 |
 
-### 1.2. 配置管理
+完整说明请阅读 [AI 管理中心概述](../user/ai/ai-registry-overview.md)。
 
-Nacos支持基于Namespace和Group的配置分组管理，以便用户更灵活的根据自己的需要按照环境或者应用、模块等分组管理微服务以及Spring的大量配置，在配置管理中主要提供了配置历史版本、回滚、订阅者查询等核心管理能力。
+## 配置中心
 
-![image.png | left | 747x297](https://cdn.nlark.com/lark/0/2018/png/9687/1540458893745-219a46a8-ebd9-405b-9e8f-226f3f0c7e76.png "")
+配置中心菜单用于管理配置的发布、查询、监听和回滚。
 
-#### 1.2.1. 多配置格式编辑器
+常见操作包括：
 
-Nacos支持 YAML、Properties、TEXT、JSON、XML、HTML 等常见配置格式在线编辑、语法高亮、格式校验，帮助用户高效编辑的同时大幅降低格式错误带来的风险。
+- 在配置列表中按 `Data ID`、`Group` 和命名空间查询配置。
+- 新建、编辑和发布配置。
+- 查看历史版本，并在需要时回滚。
+- 查询监听者，确认客户端是否收到配置变更。
+- 导入、导出或克隆配置时，注意文件大小和目标命名空间。
 
-Nacos支持配置标签的能力，帮助用户更好、更灵活的做到基于标签的配置分类及管理。同时支持用户对配置及其变更进行描述，方便多人或者跨团队协作管理配置。
+如果需要了解配置模型、灰度发布、导入导出和排障方式，请阅读[配置管理概览](../user/config/overview.md)。
 
-![image.png | left | 747x426](https://cdn.nlark.com/lark/0/2018/png/9687/1540458995051-b3e67fd4-c905-4552-9e52-f54b6ef59941.png "")
+## 注册中心
 
-#### 1.2.2. 编辑DIFF
+注册中心菜单用于查看服务、实例和订阅关系。
 
-Nacos支持编辑DIFF能力，帮助用户校验修改内容，降低改错带来的风险。
+常见操作包括：
 
-![image.png | left | 747x338](https://cdn.nlark.com/lark/0/2018/png/9687/1540457990344-a60e1db3-ca1a-47ed-a03e-f92e37745247.png "")
+- 在服务列表中查询服务和健康实例数量。
+- 进入服务详情查看集群、实例、元数据和权重。
+- 调整实例权重或上下线状态。
+- 查询订阅者，确认消费者是否订阅到目标服务。
 
-#### 1.2.3. 示例代码
+控制台操作会影响服务发现结果。对生产服务调整权重、元数据或上下线状态前，请先确认变更窗口和回滚方案。
 
-Nacos提供示例代码能力，能够让新手快速使用客户端编程消费该配置，大幅降低新手使用门槛。
+完整说明请阅读[服务发现概览](../user/naming/overview.md)。
 
-![image.png | left | 747x223](https://cdn.nlark.com/lark/0/2018/png/9687/1540456991412-01acc11c-8b48-48d8-9032-589ebb9388d9.png "")
+## 平台管理
 
-![image.png | left | 747x380](https://cdn.nlark.com/lark/0/2018/png/9687/1540532899571-ccea6b6f-a1e1-44d1-a130-f9afaba01c51.png "")
+平台管理通常面向管理员。不同启动模式和权限下，菜单可能不同。
 
-#### 1.2.4. 监听者查询
+| 入口 | 用途 |
+| --- | --- |
+| 命名空间 | 创建、编辑和删除命名空间。 |
+| 集群管理 | 查看集群节点和基础状态。 |
+| 插件管理 | 查看已加载插件和插件状态。 |
+| 用户列表 | 管理控制台用户。 |
+| 角色管理 | 管理角色和用户关系。 |
+| 权限管理 | 管理资源权限。 |
 
-Nacos提供配置订阅者即监听者查询能力，同时提供客户端当前配置的MD5校验值，以便帮助用户更好的检查配置变更是否推送到 Client 端。
+如果看不到某些菜单，通常是当前用户不是管理员、功能模式限制了模块，或相关功能未启用。
 
-![image.png | left | 747x185](https://cdn.nlark.com/lark/0/2018/png/9687/1540459212236-0abdc558-68b9-4585-b11e-c9a1924ce7ef.png "")
+## 旧控制台
 
-#### 1.2.5. 配置的版本及一键回滚
+旧控制台仍可通过配置 `nacos.console.ui.default=legacy` 作为默认入口，也可以直接访问 `/legacy/`。
 
-Nacos通过提供配置版本管理及其一键回滚能力，帮助用户改错配置的时候能够快速恢复，降低微服务系统在配置管理上的一定会遇到的可用性风险。
+旧控制台使用的前端风格和依赖组件较旧，只建议用于兼容存量使用习惯。新版本推荐使用新控制台。后续版本中，旧控制台可能被移除。
 
-![image.png | left | 747x242](https://cdn.nlark.com/lark/0/2018/png/9687/1540459226967-a258b9a7-f95f-41b0-874f-2a0a5da2fc5c.png "")
+如果你在做新部署、升级验证或文档截图，请优先使用新控制台。
 
-![image.png | left | 747x493](https://cdn.nlark.com/lark/0/2018/png/9687/1540459237821-d4c06d16-b356-4953-a6e7-da949b1f3aec.png "")
+## 常见问题
 
-## 2. 命名空间管理
+**访问根路径后为什么进入 `/next/`？**
 
-Nacos 基于Namespace 帮助用户逻辑隔离多个命名空间，这可以帮助用户更好的管理测试、预发、生产等多环境服务和配置，让每个环境的同一个配置（如数据库数据源）可以定义不同的值。
+这是 Nacos 3.x 的默认行为。新控制台是默认控制台。
 
-![image.png | left | 747x298](https://cdn.nlark.com/lark/0/2018/png/9687/1540519411777-74908cc2-29bc-4270-be58-aed62605228f.png "")
+**为什么没有登录页？**
 
-![image.png | left | 747x206](https://cdn.nlark.com/lark/0/2018/png/9687/1540519427066-effd5153-02c9-4e21-ae9f-1a2e9ae7713e.png "")
+通常是因为未开启鉴权。此时控制台不提供登录保护，请只在可信内部网络中使用。
 
-## 3. 登录管理
+**为什么看不到 AI 管理中心、配置中心或注册中心？**
 
-Nacos支持简单登录功能，在开启[鉴权](./auth.mdx)功能后启用，管理员用户名为： `nacos`, 密码需要在首次开启控制台时进行初始化。
+先检查 `nacos.functionMode`、`nacos.extension.ai.enabled` 和当前用户权限。不同启动模式会隐藏不相关菜单。
 
-![login](https://cdn.nlark.com/yuque/0/2019/jpeg/338441/1561262748106-4fc05174-bf70-4806-bcbd-90296c5bcbaa.jpeg)
+**控制台独立部署后为什么访问失败？**
 
-### 3.1. 修改默认用户名/密码方法
+检查控制台到 Nacos Server 的地址、`nacos.console.remote.server.context-path`、服务端上下文路径，以及服务端身份认证配置。详细步骤请阅读[控制台独立部署](./deployment/deployment-independent.md)。
 
-#### 3.1.1. 初始化时生成
+**上传文件失败怎么办？**
 
-当Nacos集群开启鉴权后访问Nacos控制台时，会校验是否已经初始化过管理员用户`nacos`的密码，若发现未初始化密码时，则会跳转至初始化密码的页面进行初始化。在该页面密码文本框内输入自定义密码，然后点击提交即可；
+检查文件大小是否超过 `spring.servlet.multipart.max-file-size` 或 `spring.servlet.multipart.max-request-size`。默认值为 `10MB`。
 
-> 注意：若密码文本框内未输入自定义密码或输入空白密码，Nacos将会生成随机密码，请保存好生成的随机密码。
+## 继续阅读
 
-初始化成功后会弹窗提示初始化成功，并展示指定的密码或随机生成的密码，请保存好此密码。
-
-#### 3.1.2. 控制台上修改
-
-1. 登录控制台，选择`权限控制` -> `用户列表`。
-2. 找到nacos用户，并在该用户对应的`操作`列表中点击`修改`按钮，进行密码修改
-
-### 3.2. 关闭登录功能
-
-Nacos默认控制台在`2.2.2`版本前，无论是否开启[鉴权](../../manual/admin/auth.mdx)功能，默认控制台都会跳转到登录页，导致用户被误导认为控制台存在鉴权功能，实际没有开启鉴权，存在安全隐患。
-
-经过社区和安全工程师协商讨论，需要在使用Nacos默认控制台时，鉴权开关关闭时将会自动关闭控制台登录功能。
-
-当鉴权开关`nacos.core.auth.enabled`关闭时，Nacos默认控制台将不再跳转登录页，同时添加页面提示，提示当前集群未开启鉴权功能。
-
-同时针对自定义的[鉴权插件](../../plugin/auth-plugin.md)添加新接口`com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService#isLoginEnabled(默认返回false)`来对自定义插件进行登录页控制。
-
-### 3.3. 关闭默认控制台
-
-部分公司或用户希望关闭默认控制台，使用公司的统一平台进行Nacos的配置和服务管理；或将控制台鉴权和客户端访问的鉴权分离，即控制台操作进行鉴权但客户端请求不进行鉴权。
-
-可以通过`${nacoshome}/conf/application.properties`中的`nacos.console.ui.enabled`来开启或关闭Nacos默认控制台，默认为开启。
-
-同时在关闭默认控制台时，默认控制台会读取`${nacoshome}/conf/console-guide.conf`文件中的内容，并在默认控制台中生成引导页，让维护者自定义将使用默认控制台的用户引导向自定义的统一平台上进行操作。
-
-### 3.4. 会话时间
-
-默认会话保持时间为30分钟。30分钟后需要重新登录认证。可通过`${nacoshome}/conf/application.properties`中的`nacos.core.auth.plugin.nacos.token.expire.seconds`来设置会话保持时间。
-
-## 4. 社区参与的前端共建
-
-在Nacos前端风格、布局的讨论中，社区踊跃投票，最终选择了这套经典黑白蓝风格的皮肤，并且通过我们UED程瑶同学的设计，布局，让交互变得十分自然流畅。 后续又由社区添加了深色主题风格，可以让Nacos控制台在两种样式主题中切换。
-
-在控制台的开发之前，我们通过社区招募到了很多前端同学一起参与了前端代码的开发，在此尤其感谢李晨、王庆、王彦民等同学在Nacos前端开发过程中的大力支持！
-
-## 5. 坚持社区化发展，欢迎加入并贡献社区
-
-> 比吐槽更重要的是搭把手，参与社区一起发展Nacos！
-
-要加入Nacos 社区群进行讨论和参与贡献，请扫描下方二维码加入社区群。
-
-![image.png](https://cdn.nlark.com/yuque/0/2023/png/1577777/1679276899363-83081d59-67c6-4501-9cf8-0d84ba7c6d7e.png#averageHue=%23c1c2c2&clientId=u9dfeac18-3281-4&from=paste&height=551&id=ubcf45e51&name=image.png&originHeight=1102&originWidth=854&originalType=binary&ratio=2&rotation=0&showTitle=false&size=155261&status=done&style=none&taskId=ud6bea1fe-b003-441b-a810-84435d2aeff&title=&width=427)
-
-更多与 Nacos 相关的开源项目信息：
-
-* [Nacos](https://github.com/alibaba/nacos)
-* [Nacos Spring Project](https://github.com/nacos-group/nacos-spring-project)
-* [Nacos Spring Boot](https://github.com/nacos-group/nacos-spring-boot-project)
-* [Spring Cloud Alibaba](https://github.com/alibaba/spring-cloud-alibaba)
-* [Dubbo](https://github.com/apache/dubbo)
-* [Sentinel](https://github.com/alibaba/Sentinel)
+- [部署手册概览](./deployment/deployment-overview.md)
+- [部署最佳实践](./deployment/deployment-best-practices.md)
+- [系统参数](./system-configurations.md)
+- [控制台 API](./console-api.md)

--- a/src/content/docs/next/zh-cn/manual/admin/monitor.md
+++ b/src/content/docs/next/zh-cn/manual/admin/monitor.md
@@ -1,170 +1,177 @@
 ---
 title: 监控手册
-keywords: [Nacos,监控]
-description: Nacos 如何开启和部署监控
+keywords: [Nacos, 监控, Prometheus, Grafana, 指标]
+description: 了解 Nacos 3.x 的指标暴露、Prometheus 抓取、健康检查和常用告警建议。
 sidebar:
     order: 9
 ---
 
 # 监控手册
 
-## 1. Nacos 集群监控
+Nacos 监控主要关注两类信息：
 
-Nacos 支持通过暴露metrics数据接入第三方监控系统监控Nacos运行状态，目前支持prometheus、elastic search和influxdb，下面结合prometheus和grafana为例，介绍如何监控Nacos。与elastic search和influxdb结合可自己查找相关资料。
+- Nacos Server 自身指标，例如 JVM、HTTP、gRPC、配置管理和服务发现指标。
+- 健康检查入口，例如 liveness 和 readiness。
 
-### 1.1. 开启Nacos集群metrics数据暴露
+## 暴露 Nacos Server 指标
 
-按照[部署文档](./deployment/deployment-overview.md)搭建好Nacos集群后，需要在Nacos集群的每个节点上修改如下参数：
+Nacos 通过 Spring Boot Actuator 暴露 Prometheus 指标。默认配置文件中该能力是注释状态。需要在每个 Nacos Server 节点上开启：
 
-`application.properties`文件，暴露metrics数据
-
-```
+```properties
 management.endpoints.web.exposure.include=prometheus
 ```
 
-重启后，访问`{ip}:8848/nacos/actuator/prometheus`，即可访问到Nacos集群的metrics数据。
+如果你已经暴露了其他 Actuator endpoint，请把 `prometheus` 加入列表。
 
-### 1.2. 搭建prometheus采集Nacos metrics数据
+重启节点后，访问：
 
-请参考[FIRST STEPS WITH PROMETHEUS](https://prometheus.io/docs/introduction/first_steps/)部署prometheus
-
-其中，需要将prometheus的配置文件`prometheus.yml`关于采集目标相关的配置，修改为如下内容
+```text
+http://{nacos-server-host}:8848/nacos/actuator/prometheus
 ```
-    metrics_path: '/nacos/actuator/prometheus'
+
+其中 `/nacos` 来自默认的 `nacos.server.contextPath`。如果你修改了服务端上下文路径，请同步调整访问地址。
+
+:::caution
+Nacos 是内部微服务组件，不应暴露在公网。`/actuator/**` 通常用于监控系统抓取，请放在可信内部网络中，并通过网络策略、网关或 Prometheus 抓取端限制访问来源。
+:::
+
+## Prometheus 抓取示例
+
+Prometheus 可以直接抓取每个 Nacos Server 节点：
+
+```yaml
+scrape_configs:
+  - job_name: nacos
+    metrics_path: /nacos/actuator/prometheus
     static_configs:
-      - targets: ['{nacos.ip1}:8848','{nacos.ip2}:8848','{nacos.ip3}:8848',...]
+      - targets:
+          - 10.0.0.1:8848
+          - 10.0.0.2:8848
+          - 10.0.0.3:8848
 ```
 
-搭建并启动完成prometheus后，即可通过浏览器访问`http://{prometheus_ip}:9090/graph`可以看到prometheus的采集数据，在搜索栏搜索nacos_monitor可以搜索到Nacos数据说明采集数据成功。
+如果 Nacos Server 使用了不同端口或上下文路径，请修改 `targets` 和 `metrics_path`。
 
-### 1.3. 搭建grafana图形化展示Nacos metrics数据
+Grafana 可以使用 Prometheus 作为数据源。社区维护的 Dashboard 模板可参考 [nacos-template](https://github.com/nacos-group/nacos-template)。
 
-参考[Install Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) 部署grafana。
+## 健康检查
 
-之后在浏览器中访问 `http://{grafana_ip}:3000`
+Nacos 3.x 提供 v3 健康检查接口。它们适合给负载均衡、Kubernetes 探针或巡检系统使用。
 
-然后参考[Configure Prometheus](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/)，将刚才部署的prometheus作为Grafana的数据源。
+| 对象 | 接口 |
+| --- | --- |
+| Nacos Server 状态 | `/nacos/v3/admin/core/state` |
+| Nacos Server liveness | `/nacos/v3/admin/core/state/liveness` |
+| Nacos Server readiness | `/nacos/v3/admin/core/state/readiness` |
+| 独立控制台 liveness | `/v3/console/health/liveness` |
+| 独立控制台 readiness | `/v3/console/health/readiness` |
 
-随后参考[Import dashboards](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/)导入Nacos grafana监控[模版](https://github.com/nacos-group/nacos-template/blob/master/nacos-grafana-upper-2.4.json)
+如果修改了 `nacos.server.contextPath` 或 `nacos.console.contextPath`，请把对应上下文路径加入接口地址。
 
-导入后可看见Nacos监控模版，Nacos监控主要分为三个模块:
+## 关键指标
 
-1. nacos overview: 展示Nacos集群当前的概览信息，如节点个数，服务数，服务提供者数、配置数、连接数，CPU使用率等。
-![nacos overview](/img/doc/manual/admin/monitor-overview.jpg)
-   
-2. nacos core monitor: 展示Nacos集群核心的监控指标，如服务提供者数，配置数，ops，rt等，并能够查看一定时间内的变化趋势。
-![nacos core monitor](/img/doc/manual/admin/monitor-core-monitor.jpg)
+Prometheus 中的指标名称会根据 Micrometer 类型带上后缀。例如 timer 通常会导出 `_seconds_count`、`_seconds_sum` 等序列。排查时可以先搜索基础名称，再查看具体标签。
 
-3. nacos basic monitor: 展示Nacos集群基础的监控指标，如CPU使用率，内存使用率，线程池使用情况等，并能够查看一定时间内的变化趋势。
-![nacos basic monitor](/img/doc/manual/admin/monitor-basic-monitor.jpg)
-   
-### 1.4. 配置Nacos集群告警
+### 基础资源和请求
 
-#### 1.4.1. 配置Grafana告警
+| 指标 | 说明 |
+| --- | --- |
+| `system_cpu_usage` | 系统 CPU 使用率。 |
+| `system_load_average_1m` | 1 分钟系统负载。 |
+| `jvm_memory_used_bytes` | JVM 已使用内存。 |
+| `jvm_memory_max_bytes` | JVM 最大内存。 |
+| `jvm_gc_pause_seconds` | GC 次数和耗时。 |
+| `jvm_threads_daemon` | JVM daemon 线程数。 |
+| `http_server_requests_seconds` | HTTP 请求次数和耗时。 |
+| `grpc_server_requests` | gRPC 请求耗时，包含 `requestClass`、`success`、`errorCode`、`module` 等标签。 |
+| `grpc_server_executor` | gRPC 服务端线程池状态，包含 active、pool size、queue task 等标签。 |
 
-可以参考[Configure Grafana-managed alert rules](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/)，配置自定义的Nacos相关告警。
+### Core 指标
 
-也可以通过大盘中的对应指标内容，快速配置告警：
+| 指标 | 说明 |
+| --- | --- |
+| `nacos_monitor{module="core",name="longConnection"}` | 按模块统计的长连接数量。 |
+| `nacos_monitor_summary` | Raft read index、leader read、apply log、apply read 等摘要指标。 |
 
-1. 选择需要配置告警的指标，例如`cpu usage`;
-2. 在指标的右上角，点击`Menu`（展示为竖直的3个`.`)，选择`编辑（Edit）`;
-   ![nacos grafana edit](/img/doc/manual/admin/monitor-fast-alert-edit.jpg)
-3. 在Panel页面中，选择`Alert`，点击`New alert rule`，配置告警规则。
-   ![nacos grafana alert](/img/doc/manual/admin/monitor-fast-alert-new.jpg)
-4. 之后同样参考[Configure Grafana-managed alert rules](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/)，配置自定义的Nacos相关告警。
+### 配置管理指标
 
-#### 1.4.2. 配置Grafana告警通知
+| 指标 | 说明 |
+| --- | --- |
+| `nacos_monitor{module="config",name="getConfig"}` | 配置查询统计。 |
+| `nacos_monitor{module="config",name="publish"}` | 配置发布统计。 |
+| `nacos_monitor{module="config",name="longPolling"}` | 配置长轮询数量。 |
+| `nacos_monitor{module="config",name="configCount"}` | 配置数量。 |
+| `nacos_monitor{module="config",name="notifyTask"}` | 配置通知任务堆积。 |
+| `nacos_monitor{module="config",name="notifyClientTask"}` | 客户端通知任务堆积。 |
+| `nacos_monitor{module="config",name="dumpTask"}` | 配置 dump 任务堆积。 |
+| `nacos_monitor{module="config",name="fuzzySearch"}` | 模糊查询统计。 |
+| `nacos_config_subscriber{version="v1"}` / `nacos_config_subscriber{version="v2"}` | 配置监听者数量。 |
+| `nacos_timer{module="config",name="readConfigRt"}` | 读配置耗时。 |
+| `nacos_timer{module="config",name="writeConfigRt"}` | 写配置耗时。 |
+| `nacos_timer{module="config",name="notifyRt"}` | 通知耗时。 |
+| `nacos_timer{module="config",name="dumpRt"}` | dump 耗时。 |
+| `nacos_exception{module="config",name="illegalArgument"}` | 配置参数异常统计。 |
+| `config_change_count` | 配置变更 TopN 统计。 |
 
-参考[Configure contact points](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/manage-contact-points/) 来配置Grafana告警时的通知方式。例如配置邮件通知、钉钉WebHook通知等。
+### 服务发现指标
 
-### 1.5. Nacos 指标含义
+| 指标 | 说明 |
+| --- | --- |
+| `nacos_monitor{module="naming",name="serviceCount"}` | 服务数量。 |
+| `nacos_monitor{module="naming",name="ipCount"}` | 实例数量。 |
+| `nacos_monitor{module="naming",name="subscriberCount"}` | 订阅者数量。 |
+| `nacos_monitor{module="naming",name="totalPush"}` | 推送总数。 |
+| `nacos_monitor{module="naming",name="failedPush"}` | 推送失败数。 |
+| `nacos_monitor{module="naming",name="emptyPush"}` | 空推送数。 |
+| `nacos_monitor{module="naming",name="avgPushCost"}` | 平均推送耗时。 |
+| `nacos_monitor{module="naming",name="maxPushCost"}` | 最大推送耗时。 |
+| `nacos_monitor{module="naming",name="leaderStatus"}` | 服务发现模块 leader 状态。 |
+| `nacos_monitor{module="naming",name="serviceSubscribedEventQueueSize"}` | 服务订阅事件队列长度。 |
+| `nacos_monitor{module="naming",name="serviceChangedEventQueueSize"}` | 服务变更事件队列长度。 |
+| `nacos_monitor{module="naming",name="pushPendingTaskCount"}` | 待推送任务数量。 |
+| `nacos_naming_subscriber{version="v1"}` / `nacos_naming_subscriber{version="v2"}` | 服务订阅者数量。 |
+| `nacos_naming_publisher{version="v1"}` / `nacos_naming_publisher{version="v2"}` | 服务提供者数量。 |
+| `service_change_count` | 服务变更 TopN 统计。 |
 
-#### 1.5.1. Nacos 系统基础资源指标
+### 实验性分布式锁指标
 
-指标|含义
----|---
-system_cpu_usage|CPU使用率
-system_load_average_1m|load
-jvm_memory_used_bytes|JVM内存使用字节，包含各种内存区
-jvm_memory_max_bytes|JVM内存最大字节，包含各种内存区
-jvm_gc_pause_seconds_count|gc次数，包含各种gc
-jvm_gc_pause_seconds_sum|gc耗时，包含各种gc
-jvm_threads_daemon|线程数
+分布式锁属于[实验性功能](../../experimental/distributed-lock.md)。如果使用该能力，可以关注：
 
-#### 1.5.2. Nacos 集群应用指标
+| 指标 | 说明 |
+| --- | --- |
+| `nacos_monitor{module="lock",name="grpcLockTotal"}` | gRPC 加锁请求总数。 |
+| `nacos_monitor{module="lock",name="grpcLockSuccess"}` | gRPC 加锁成功数。 |
+| `nacos_monitor{module="lock",name="grpcUnLockTotal"}` | gRPC 解锁请求总数。 |
+| `nacos_monitor{module="lock",name="grpcUnLockSuccess"}` | gRPC 解锁成功数。 |
+| `nacos_monitor{module="lock",name="aliveLockCount"}` | 当前存活锁数量。 |
+| `nacos_timer{module="lock",name="lockHandlerRt"}` | 锁请求处理耗时。 |
 
-指标|含义
----|---
-http_server_requests_seconds_count|http请求次数，包括多种(url,方法,code)
-http_server_requests_seconds_sum|http请求总耗时，包括多种(url,方法,code)
-grpc_server_requests_seconds_count|Nacos grpc请求次数，包括多种（requestClass,code)
-grpc_server_requests_seconds_sum|Nacos grpc请求总耗时，包括多种（requestClass,code)
-nacos_timer_seconds_sum|Nacos config水平通知耗时
-nacos_timer_seconds_count|Nacos config水平通知次数
-grpc_server_executor{name='maximumPoolSize'}|Nacos grpc服务器线程池的最大线程数
-grpc_server_executor{name='corePoolSize'}|Nacos grpc服务器线程池的核心线程数
-grpc_server_executor{name='taskCount'}|Nacos grpc服务器线程池的任务数量
-grpc_server_executor{name='poolSize'}|Nacos grpc服务器线程池当前线程数量
-grpc_server_executor{name='activeCount'}|Nacos grpc服务器线程池当前活跃的线程数量
-grpc_server_executor{name='completedTaskCount'}|Nacos grpc服务器线程池完成的任务数量
-grpc_server_executor{name='inQueueTaskCount'}|Nacos grpc服务器线程池在任务队列中的任务数量
-nacos_monitor{name='longPolling'}|Nacos config长连接数
-nacos_monitor{name='configCount'}|Nacos config配置个数
-nacos_monitor{name='dumpTask'}|Nacos config配置落盘任务堆积数
-nacos_monitor{name='notifyTask'}|Nacos config配置水平通知任务堆积数
-nacos_monitor{name='getConfig'}|Nacos config读配置统计数
-nacos_monitor{name='publish'}|Nacos config写配置统计数
-nacos_monitor{name='ipCount'}|Nacos naming ip个数
-nacos_monitor{name='serviceCount'}|Nacos naming域名个数
-nacos_monitor{name='failedPush'}|Nacos naming推送失败数
-nacos_monitor{name='avgPushCost'}|Nacos naming平均推送耗时(ms)
-nacos_monitor{name='leaderStatus'}|Nacos naming角色状态
-nacos_monitor{name='maxPushCost'}|Nacos naming最大推送耗时(ms)
-nacos_monitor{name='mysqlhealthCheck'}|Nacos naming mysql健康检查次数
-nacos_monitor{name='httpHealthCheck'}|Nacos naming http健康检查次数
-nacos_monitor{name='tcpHealthCheck'}|Nacos naming tcp健康检查次数
-nacos_monitor{name='longConnection'}|Nacos基于模块划分的连接数量
-nacos_naming_subscriber{version='v1/v2'}|Nacos naming服务订阅者数量，v1/v2表示订阅者的客户端版本
-nacos_config_subscriber{version='v1/v2'}|Nacos config配置监听者数量，v1/v2表示订阅者的客户端版本
-nacos_naming_publisher{version='v1/v2'}|Nacos naming服务提供者数量，v1/v2表示订阅者的客户端版本
+## 告警建议
 
-## 2. Nacos-Sync监控
+| 场景 | 建议关注 |
+| --- | --- |
+| 节点不可用 | readiness 失败、HTTP/gRPC 请求错误率、JVM 资源、进程存活。 |
+| gRPC 堆积 | `grpc_server_executor` 的 active、queue、completed task 变化。 |
+| 配置推送延迟 | `notifyTask`、`notifyClientTask`、`notifyRt`、`dumpTask`。 |
+| 配置发布异常 | `publish`、`writeConfigRt`、`nacos_exception{module="config"}`。 |
+| 服务推送异常 | `failedPush`、`pushPendingTaskCount`、`avgPushCost`、`maxPushCost`。 |
+| 连接异常变化 | `longConnection`、`nacos_config_subscriber`、`nacos_naming_subscriber`。 |
+| 锁使用异常 | 加锁成功率、解锁成功率、`aliveLockCount`。 |
 
-Nacos-Sync 同样支持了第三方监控系统，能通过metrics数据观察Nacos-Sync服务的运行状态，提升了Nacos-Sync的在生产环境的监控能力。
-整体的监控体系的搭建参考上文的[Nacos 集群监控](#1-nacos-集群监控)，进行prometheus和grafana的部署即可。
+## 常见排查
 
-### 2.1. grafana监控Nacos-Sync
-和Nacos监控一样，Nacos-Sync也提供了监控模版，导入监控[模版](https://github.com/nacos-group/nacos-template/blob/master/nacos-sync-grafana)
+**访问 `/actuator/prometheus` 返回 404 或没有数据**
 
-Nacos-Sync监控同样也分为三个模块:
-- nacos-sync monitor展示核心监控项
-  ![monitor](https://img.alicdn.com/tfs/TB1GeNWKmzqK1RjSZFHXXb3CpXa-2834-1588.png)
-- nacos-sync detail和alert展示监控曲线和告警
-  ![detail](https://img.alicdn.com/tfs/TB1kP8UKbvpK1RjSZPiXXbmwXXa-2834-1570.png)
+检查 `management.endpoints.web.exposure.include` 是否包含 `prometheus`，确认节点已重启，并核对 `nacos.server.contextPath`。
 
-### 2.2. Nacos-Sync 指标含义
+**配置了 `nacos.prometheus.metrics.enabled=true`，但仍没有 Nacos Server 指标**
 
-Nacos-Sync的metrics分为jvm层和应用层
+这是预期行为。该配置属于 [Prometheus 服务发现生态文档](../../ecology/use-nacos-prometheus-sd.md)，不用于开启 Nacos Server 自身指标。
 
-#### 2.2.1. jvm 指标
+**Prometheus 抓取部分节点失败**
 
-指标|含义
----|---
-system_cpu_usage|CPU使用率
-system_load_average_1m|load
-jvm_memory_used_bytes|内存使用字节，包含各种内存区
-jvm_memory_max_bytes|内存最大字节，包含各种内存区
-jvm_gc_pause_seconds_count|gc次数，包含各种gc
-jvm_gc_pause_seconds_sum|gc耗时，包含各种gc
-jvm_threads_daemon|线程数
+检查节点端口、上下文路径、网络策略和 Prometheus 抓取配置。集群每个节点都需要单独暴露并被抓取。
 
-#### 2.2.2. 应用层 指标
+**指标中没有某个模块**
 
-指标|含义
----|---
-nacosSync_task_size|同步任务数
-nacosSync_cluster_size|集群数
-nacosSync_add_task_rt|同步任务执行耗时
-nacosSync_delete_task_rt|删除任务耗时
-nacosSync_dispatcher_task|从数据库中分发任务
-nacosSync_sync_task_error|所有同步执行时的异常
+确认对应模块是否启用。例如仅启动配置模块时，服务发现相关指标不会完整出现。实验性分布式锁指标也只有使用相关能力后才有意义。


### PR DESCRIPTION
## Summary
- Add an Experimental Features section with distributed lock and Kubernetes ecosystem experimental capabilities.
- Rewrite the new console manual for Nacos 3.x and keep legacy console guidance scoped.
- Rewrite the monitoring manual around Nacos Server metrics and health checks, and move Prometheus service discovery details to the ecology document.
- Refresh Prometheus service discovery docs in Chinese and English.

## Validation
- JSON sidebar parse passed.
- Relative link check passed for changed docs.
- English pages checked for Chinese residue.
- git diff --check passed.

## Note
- npm run build did not complete locally because Rollup's darwin optional native package failed to load due to a local macOS code signature issue in node_modules before Astro content build started.