### PR TITLE
docs: align English admin API templates

### DIFF
--- a/src/content/docs/latest/en/manual/admin/admin-api.md
+++ b/src/content/docs/latest/en/manual/admin/admin-api.md
@@ -690,7 +690,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=
 
 `POST`
 
-请求体Type：`application/json`，参数放在请求体中。
+请求体类型：`application/json`，参数放在请求体中。
 
 #### Authorization
 
@@ -757,7 +757,7 @@ curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/
 
 `PUT`
 
-请求体Type：`application/json`，参数放在请求体中。
+请求体类型：`application/json`，参数放在请求体中。
 
 #### Authorization
 
@@ -1046,7 +1046,7 @@ Administrator permissions required.
 |--------|----------|------|
 | namespace | `string` | 命名空间 ID |
 | namespaceShowName | `string` | 命名空间展示名 |
-| namespaceDesc | `string` | 命名空间Description |
+| namespaceDesc | `string` | 命名空间描述 |
 | quota | `integer` | 配置数量配额 |
 | configCount | `integer` | 当前配置数量 |
 | type | `integer` | Type |
@@ -1104,7 +1104,7 @@ Administrator permissions required.
 |--------|------|------|----------|
 | `namespaceId` | `string` | **Yes** | 命名空间 ID |
 | `namespaceName` | `string` | **Yes** | 命名空间展示名 |
-| `namespaceDesc` | `string` | No | 命名空间Description |
+| `namespaceDesc` | `string` | No | 命名空间描述 |
 
 #### Response Data
 
@@ -1157,7 +1157,7 @@ Administrator permissions required.
 |--------|------|------|----------|
 | `namespaceId` | `string` | No | 命名空间 ID，不传则由服务端生成 |
 | `namespaceName` | `string` | **Yes** | 命名空间展示名 |
-| `namespaceDesc` | `string` | No | 命名空间Description |
+| `namespaceDesc` | `string` | No | 命名空间描述 |
 
 #### Response Data
 
@@ -1498,7 +1498,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 #### Description
 
-通过该接口，可以更新插件的配置。需要提供插件Type、Name及配置内容。支持 localOnly 仅作用于当前节点。
+通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。支持 localOnly 仅作用于当前节点。
 
 #### Since
 
@@ -1508,7 +1508,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 `PUT`
 
-请求体Type：`application/json`。
+请求体类型：`application/json`。
 
 #### Authorization
 
@@ -1524,8 +1524,8 @@ Administrator permissions required.
 
 | Name         | Type       | Required | Description           |
 |-------------|----------|----|----------------|
-| `pluginType` | `string` | **Yes** | 插件Type，如 auth。 |
-| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `pluginType` | `string` | **Yes** | 插件类型，如 auth。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
 | `config` | `string` | **Yes** | 插件配置项。 |
 | `localOnly` | `boolean` | No | 是否仅写本地，不持久化。 |
 
@@ -1556,7 +1556,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
 
 #### Description
 
-通过该接口，可以按Type和Name获取指定插件的详情信息。
+通过该接口，可以按类型和名称获取指定插件的详情信息。
 
 #### Since
 
@@ -1578,8 +1578,8 @@ Administrator permissions required.
 
 | Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **Yes** | 插件Type，如 auth |
-| `pluginName` | `string` | **Yes** | 插件Name |
+| `pluginType` | `string` | **Yes** | 插件类型，如 auth |
+| `pluginName` | `string` | **Yes** | 插件名称 |
 
 #### Response Data
 
@@ -1588,8 +1588,8 @@ Administrator permissions required.
 | Name | Type | Description |
 |--------|----------|------|
 | pluginId | `string` | 插件 ID |
-| pluginType | `string` | 插件Type |
-| pluginName | `string` | 插件Name |
+| pluginType | `string` | 插件类型 |
+| pluginName | `string` | 插件名称 |
 | enabled | `boolean` | 是否启用 |
 | critical | `boolean` | 是否关键插件 |
 | configurable | `boolean` | 是否可配置 |
@@ -1627,7 +1627,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=
 
 #### Description
 
-通过该接口，可以获取所有插件列表，可按插件Type筛选。
+通过该接口，可以获取所有插件列表，可按插件类型筛选。
 
 #### Since
 
@@ -1649,7 +1649,7 @@ Administrator permissions required.
 
 | Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | No | 插件Type，不传则返回全部 |
+| `pluginType` | `string` | No | 插件类型，不传则返回全部 |
 
 #### Response Data
 
@@ -1697,7 +1697,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 `PUT`
 
-请求体Type：`application/json`。
+请求体类型：`application/json`。
 
 #### Authorization
 
@@ -1713,8 +1713,8 @@ Administrator permissions required.
 
 | Name         | Type        | Required | Description       |
 |-------------|-----------|----|------------|
-| `pluginType` | `string` | **Yes** | 插件Type。 |
-| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `pluginType` | `string` | **Yes** | 插件类型。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
 | `enabled` | `boolean` | **Yes** | 是否启用。 |
 | `localOnly` | `boolean` | No | 是否仅写本地。 |
 
@@ -1792,7 +1792,7 @@ Administrator permissions required.
 * Request example
 
 ```shell
-curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' 
+curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches'
 ```
 
 * Response example
@@ -1994,7 +1994,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/metrics?onlyStatus=fals
 
 `PUT`
 
-请求体Type：`application/json`。
+请求体类型：`application/json`。
 
 #### Authorization
 
@@ -2131,7 +2131,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/list'
 | `lastUpdatedTime` | `integer` | 客户端的最后更新时间（时间戳）    |
 | `clientType`      | `string` | 客户端Type              |
 | `connectType`     | `string` | 连接Type（仅适用于 2.x 客户端） |
-| `appName`         | `string` | 客户端所属的应用Name         |
+| `appName`         | `string` | 客户端所属的应用名称         |
 | `version`         | `string` | 客户端的版本号            |
 | `clientIp`        | `string` | 客户端的 IP 地址         |
 | `clientPort`      | `string` | 客户端的端口号            |
@@ -2552,7 +2552,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/distro?ip=127.0.0.1&
 | Name                     | Type                  | Required  | Description                |
 |-------------------------|-----------------------|-------|-------------------|
 | `namespaceId` | `string` | No | 命名空间ID |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `clusterName` | `string` | **Yes** | 集群Name |
 | `checkPort` | `integer` | No | 健康检查端口 |
 | `useInstancePort4Check` | `boolean` | No | 是否使用实例端口进行健康检查 |
@@ -2614,7 +2614,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/cluster' -d 'serviceName=te
 | Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2735,7 +2735,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/checkers'
 | Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2798,7 +2798,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 | Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2864,7 +2864,7 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=pub
 | Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2927,7 +2927,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 | Name               | Type                  | Required  | Description                                                                                           |
 |-------------------|-----------------------|-------|----------------------------------------------------------------------------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `instances` | `string` | No | 实例列表（JSON数组 字符串）默认为`""`表示所有实例更新；若指定时，每个元素代表一个需要更新的实例，必须需要包含`ip`和`port`字段，`clusterName`字段为可选, |
 | `metadata` | `string` | **Yes** | 元数据 |
@@ -2989,7 +2989,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch' \
 | Name               | Type                  | Required  | Description                      |
 |-------------------|-----------------------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `instances` | `string` | No | 实例列表（JSON 字符串），默认为`""` |
 | `metadata` | `string` | **Yes** | 元数据 |
@@ -3054,7 +3054,7 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch?
 | **Name**       | **Type**  | **Required** | **Description**             |
 |---------------|-----------|----------|--------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `ip` | `string` | **Yes** | 实例IP |
 | `port` | `integer` | **Yes** | 实例端口 |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
@@ -3117,7 +3117,7 @@ curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'names
 |---------------|-----------|----------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认`public` |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `clusterName` | `string` | No | Cluster name. If not provided, instances of all clusters will be returned. |
 | `healthyOnly` | `boolean` | No | 是否只返回健康实例，默认为`false` |
 
@@ -3653,7 +3653,7 @@ curl -d 'serviceName=nacos.test.1' \
 | **Name**       | **Type**  | **Required** | **Description**                  |
 |---------------|-----------|----------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认是`DEFAULT_GROUP` |
 | `pageNo` | `integer` | **Yes** | 页码 |
 | `pageSize` | `integer` | **Yes** | 每页大小 |
@@ -3671,7 +3671,7 @@ curl -d 'serviceName=nacos.test.1' \
 | `pageItems`                  | `array`    | Service list.                |
 | `pageItems`[i].`ip`          | `string` | 订阅者IP。               |
 | `pageItems`[i].`port`        | `integer` | 订阅者端口。               |
-| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 | 
+| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 |
 | `pageItems`[i].`agent`       | `string` | 订阅者客户端版本。            |
 | `pageItems`[i].`appName`     | `string` | 订阅者所属应用。             |
 | `pageItems`[i].`namespaceId` | `string` | 订阅者所属命名空间。           |
@@ -3803,17 +3803,17 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/selector/types'
 
 | Name                | Type     | Description                         |
 |--------------------|----------|----------------------------|
-| `id`               | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
+| `id`               | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `dataId`           | `string` | 配置ID。                      |
 | `groupName`        | `string` | 配置分组。                      |
 | `namespaceId`      | `string` | 命名空间ID。                    |
 | `content`          | `string` | 配置内容。                      |
-| `desc`             | `string` | 配置Description。                      |
+| `desc`             | `string` | 配置描述。                      |
 | `md5`              | `string` | 配置内容的MD5值。                 |
 | `configTags`       | `string` | 配置的标签。                     |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。     |
-| `appName`          | `string` | 配置所属的应用Name。                 |
-| `type`             | `string` | 配置Type。                      |
+| `appName`          | `string` | 配置所属的应用名称。                 |
+| `type`             | `string` | 配置类型。                      |
 | `createTime`       | `integer` | 配置创建时间。                    |
 | `modifyTime`       | `integer` | 配置修改时间。                    |
 | `createUser`       | `string` | 配置创建人。                     |
@@ -4137,13 +4137,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/listener?namespaceId
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `array`   | Configurations matching the query criteria. |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
 | `pageItems`[i].`md5`         | `string` | 配置内容的MD5值。                 |
-| `pageItems`[i].`appName`     | `string` | 配置所属的应用Name。                 |
-| `pageItems`[i].`type`        | `string` | 配置Type。                      |
+| `pageItems`[i].`appName`     | `string` | 配置所属的应用名称。                 |
+| `pageItems`[i].`type`        | `string` | 配置类型。                      |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
@@ -4291,17 +4291,17 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=
 | `dataId`           | `string` | 配置的dataId。                          |
 | `groupName`        | `string` | 配置的groupName。                       |
 | `namespaceId`      | `string` | 配置所属的命名空间。                          |
-| `desc`             | `string` | 配置Description。                               |
+| `desc`             | `string` | 配置描述。                               |
 | `md5`              | `string` | 配置内容的MD5值。                          |
 | `configTags`       | `string` | 配置的标签。                              |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。              |
-| `appName`          | `string` | 配置所属的应用Name。                          |
-| `type`             | `string` | 配置Type。                               |
+| `appName`          | `string` | 配置所属的应用名称。                          |
+| `type`             | `string` | 配置类型。                               |
 | `createTime`       | `integer` | 配置创建时间。                             |
 | `modifyTime`       | `integer` | 配置修改时间。                             |
 | `createUser`       | `string` | 配置创建人。                              |
 | `createIp`         | `string` | 配置创建IP。                             |
-| `grayName`         | `string` | 灰度发布规则Name, 固定为`beta`。                |
+| `grayName`         | `string` | 灰度发布规则名称, 固定为`beta`。                |
 | `grayRule`         | `string` | 灰度发布规则，格式为JSON，其中的`expr`为beta的ip列表。 |
 
 #### Examples
@@ -4481,7 +4481,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/export?namespaceId=p
 
 #### Request Parameters
 
-请求体Type为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
+请求体类型为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
 
 #### Response Data
 
@@ -4562,8 +4562,8 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 | `pageItems`[i].`groupName`   | `string` | 配置的groupName。                     |
 | `pageItems`[i].`namespaceId` | `string` | 配置所属的命名空间。                        |
 | `pageItems`[i].`appName`     | `string` | 配置所属的appName。                     |
-| `pageItems`[i].`opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。        |
-| `pageItems`[i].`publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。 |
+| `pageItems`[i].`opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。        |
+| `pageItems`[i].`publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。 |
 | `pageItems`[i].`srcIp`       | `string` | 发布的来源IP。                          |
 | `pageItems`[i].`srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。       |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                           |
@@ -4666,13 +4666,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.e
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
 #### Examples
@@ -4754,13 +4754,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupN
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
 #### Examples
@@ -5215,7 +5215,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby?sql=SELECT%20*%20
 
 `POST`
 
-请求体Type：`multipart/form-data`，参数放在请求体中。
+请求体类型：`multipart/form-data`，参数放在请求体中。
 
 #### Authorization
 
@@ -5876,7 +5876,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&nam
 | `namespaceId`        | `string` | MCP服务所属的命名空间ID。                                                                                 |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的Description。                                                                                       |
+| `description`        | `string` | MCP服务的描述。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |                                                                                          |
 | `versionDetail`      | `object`              | Queried version information of the MCP service.                                                        |
 | `localServerConfig`  | `map<string, object>` | Startup information for a local MCP service when the MCP service type is **stdio**.                    |
@@ -5967,8 +5967,8 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 | Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
 | `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
-| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `serverSpecification` | `string` | **Yes** | MCP服务的描述详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具描述详情 |
 | `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 | `overrideExisting` | `boolean` | No | MCP服务更新时是否覆盖原 endpointSpecification，仅在非`stdio`协议时生效 |
 | `latest` | `boolean` | No | - |
@@ -5983,7 +5983,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的Description。                                                                                       |
+| `description`        | `string` | MCP服务的描述。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -6012,8 +6012,8 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 | Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的Name                                     |
-| `description` | `string` | MCP 工具的Description                                     |
+| `name`        | `string` | MCP 工具的名称                                     |
+| `description` | `string` | MCP 工具的描述                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
@@ -6029,17 +6029,17 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 | Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
+| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
 | Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
 #### Response Data
@@ -6097,8 +6097,8 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 | Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
 | `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
-| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `serverSpecification` | `string` | **Yes** | MCP服务的描述详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具描述详情 |
 | `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
@@ -6111,7 +6111,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的Description。                                                                                       |
+| `description`        | `string` | MCP服务的描述。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -6140,8 +6140,8 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 | Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的Name                                     |
-| `description` | `string` | MCP 工具的Description                                     |
+| `name`        | `string` | MCP 工具的名称                                     |
+| `description` | `string` | MCP 工具的描述                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
@@ -6157,17 +6157,17 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 | Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
+| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
 | Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
 #### Response Data
@@ -6283,7 +6283,7 @@ curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=
 | Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
 | `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **Yes** | AgentCard的Name                |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
 
 #### Response Data
 
@@ -6347,7 +6347,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=publi
 | `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
 | `pageSize` | `integer` | **Yes** | 页条目数，默认为`100` |
 | `namespaceId` | `string` | No | AgentCard的命名空间ID，默认为`public` |
-| `agentName` | `string` | No | AgentCard的Name，为空是查询所有AgentCard |
+| `agentName` | `string` | No | AgentCard的名称，为空是查询所有AgentCard |
 | `search` | `string` | No | blur or accurate |
 
 #### Response Data
@@ -6466,9 +6466,9 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | Name                | Type     | Required  | Description                                                                                 |
 |--------------------|----------|-------|------------------------------------------------------------------------------------|
 | `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                        |
-| `agentName`        | `string` | **Yes** | AgentCard的Name                                                                       |
+| `agentName`        | `string` | **Yes** | AgentCard的名称                                                                       |
 | `version`          | `string` | No     | AgentCard的版本号，为空时返回最新版本详情                                                          |
-| `registrationType` | `string` | No     | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 
 #### Response Data
 
@@ -6477,8 +6477,8 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | Name                                 | Type                              | Description                                                                                                       |
 |-------------------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `protocolVersion`                   | `string` | AgentCard的A2A协议版本。                                                                                       |
-| `name`                              | `string` | AgentCard的Name。                                                                                            |
-| `description`                       | `string` | AgentCard的Description。                                                                                            |
+| `name`                              | `string` | AgentCard的名称。                                                                                            |
+| `description`                       | `string` | AgentCard的描述。                                                                                            |
 | `version`                           | `string` | AgentCard的版本号。                                                                                           |
 | `iconUrl`                           | `string` | AgentCard的iconURL。                                                                                       |
 | `capabilities`                      | `object`                         | AgentCard capabilities, matching [A2A standard capabilities](https://a2a-protocol.org/latest/specification/#552-agentcapabilities-object). |
@@ -6493,7 +6493,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | `defaultInputModes`                 | `array`                          | All default input modes of the AgentCard. |
 | `defaultOutputModes`                | `array`                          | All default output modes of the AgentCard. |
 | `supportsAuthenticatedExtendedCard` | `string` | AgentCard是否支持认证的扩展卡。                                                                                     |
-| `registrationType`                  | `string` | AgentCard的默认注册Type，可选`URL`和`SERVICE`。                                                                      |
+| `registrationType`                  | `string` | AgentCard的默认注册类型，可选`URL`和`SERVICE`。                                                                      |
 | `latestVersion`                     | `string` | AgentCard当前版本时否为最新版本。                                                                                    |
 
 #### Examples
@@ -6601,7 +6601,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
 | `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
 | `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `registrationType` | `string` | No | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 | `setAsLatest` | `boolean` | No | 是否设置此版本为最新发布版本，默认为false |
 
 #### Response Data
@@ -6619,7 +6619,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 ```shell
 curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'namespaceId=public' \
--d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \ 
+-d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \
 -d 'registrationType=SERVICE' \
 -d 'setAsLatest=true'
 ```
@@ -6661,7 +6661,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
 | `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
 | `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, Default为`URL` |
+| `registrationType` | `string` | No | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认为`URL` |
 
 #### Response Data
 
@@ -6678,7 +6678,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 ```shell
 curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'namespaceId=public' \
--d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \ 
+-d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \
 -d 'registrationType=SERVICE'
 ```
 * Response example
@@ -6718,7 +6718,7 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 | Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
 | `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **Yes** | AgentCard的Name                |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
 | `version`     | `string` | No     | AgentCard的版本号，为空时返回最新版本详情   |
 
 #### Response Data
@@ -8014,7 +8014,7 @@ This API uploads a ZIP package in multipart/form-data format and registers the s
 
 `POST`
 
-请求体Type：`multipart/form-data`，参数放在请求体中。
+请求体类型：`multipart/form-data`，参数放在请求体中。
 
 #### Authorization
 

--- a/src/content/docs/latest/en/manual/admin/admin-api.md
+++ b/src/content/docs/latest/en/manual/admin/admin-api.md
@@ -54,35 +54,35 @@ Nacos 3.X Admin APIs also provide Swagger-style documentation. You can view it a
 
 ### 1.1. 获取当前节点连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取连接到当前Nacos Server节点中的gRPC连接详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/current`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                     | 参数类型         | 描述                                                                                      |
+| Name                                     | Type         | Description                                                                                      |
 |-----------------------------------------|--------------|-----------------------------------------------------------------------------------------|
 | ${connectionId}                         | `object` | 每条 gRPC connection ID. |
 | ${connectionId}.abilityTable            | `object` | Capability list supported by the gRPC connection, namely the client. |
@@ -95,15 +95,15 @@ Nacos 3.X Admin APIs also provide Swagger-style documentation. You can view it a
 | ${connectionId}.metaInfo.clusterSource  | `boolean` | Whether the gRPC connection is an inter-cluster connection. When `true`, `${connectionId}.metaInfo.labels.source` is `cluster`. |
 | ${connectionId}.metaInfo.sdkSource      | `boolean` | Whether the gRPC connection comes from a client. When `true`, `${connectionId}.metaInfo.labels.source` is `naming` or `config`. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/current'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -161,46 +161,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/current'
 
 ### 1.2. 均衡指定数量的连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以指定一定数量的连接到当前Nacos Server节点中的gRPC连接，将这部分连接断开后迁移到其他Nacos Server节点中。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/reloadCurrent`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 类型        | 必填    | 参数描述                           |
+| Name               | Type        | Required    | Description                           |
 |-------------------|-----------|-------|--------------------------------|
-| `count`           | `integer` | **是** | 需要均衡的连接个数                      |
-| `redirectAddress` | `string` | 否     | 预期均衡的Nacos Server目标，仅提供给客户端参考。 |
+| `count`           | `integer` | **Yes** | 需要均衡的连接个数                      |
+| `redirectAddress` | `string` | No     | 预期均衡的Nacos Server目标，仅提供给客户端参考。 |
 
-#### 返回数据
+#### Response Data
 
-成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)
+成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadCurrent' -d "count=100"
 ```
 
-* 返回示例
+* Response example
 
 ```text
 success
@@ -208,46 +208,46 @@ success
 
 ### 1.3. 均衡指定的单个连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将指定的客户端连接(gRPC连接)迁移到其他Nacos Server节点中。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/reloadClient`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 类型       | 必填    | 参数描述                 |
+| Name               | Type       | Required    | Description                 |
 |-------------------|----------|-------|----------------------|
-| `connectionId`    | `string` | **是** | 需要均衡的连接Id            |
-| `redirectAddress` | `string` | 否     | 预期均衡的Nacos Server目标。 |
+| `connectionId`    | `string` | **Yes** | 需要均衡的连接Id            |
+| `redirectAddress` | `string` | No     | 预期均衡的Nacos Server目标。 |
 
-#### 返回数据
+#### Response Data
 
-成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)
+成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadClient' -d "connectionId=1709273546779_127.0.0.1_35042"
 ```
 
-* 返回示例
+* Response example
 
 成功则返回:
 
@@ -271,35 +271,35 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadClient' -d 
 
 ### 1.4. 获取集群连接概览信息
 
-#### 接口描述
+#### Description
 
 通过该接口，查看Nacos Server集群中各节点的连接数概览。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/cluster`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                           | 参数类型        | 描述                        |
+| Name                           | Type        | Description                        |
 |-------------------------------|-------------|---------------------------|
 | `total`                       | `integer` | 该集群中所有节点的连接数总和            |
 | `min`                         | `integer` | 该集群中所有节点的最小连接数            |
@@ -314,15 +314,15 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadClient' -d 
 | `detail[].metric.conCount`    | `integer` | 连接到该节点的总连接数，包含了SDK和集群间的连接 |
 | `detail[].metric.cpu`         | `number` | 节点的CPU使用率，参考值             |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/cluster'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -352,31 +352,31 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/cluster'
 
 ### 1.5. 获取本节点信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos Server集群当前节点的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/node/self`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                           | 参数类型         | 描述                                             |
+| Name                           | Type         | Description                                             |
 |-------------------------------|--------------|------------------------------------------------|
 | `ip`                          | `string` | 节点IP                                           |
 | `port`                        | `integer` | 节点端口                                           |
@@ -393,15 +393,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/cluster'
 | `grpcReportEnabled`           | `boolean` | 标记节点是否支持grpc上报心跳能力，用于适配老版本升级，后续将移除             |
 | ~~extendInfo.readyToUpgrade~~ | `boolean` | 是否ready升级到Nacos2.0，于2.2版本后废弃，即将移除              |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/self'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -478,46 +478,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/self'
 
 ### 1.6. 获取集群所有节点信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos Server集群中所有节点的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/node/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `address` | `string` | 否 | 节点地址，支持按地址过滤。 |
-| `state` | `string` | 否 | Node state: UP/DOWN/SUSPICIOUS |
+| `address` | `string` | No | 节点地址，支持按地址过滤。 |
+| `state` | `string` | No | Node state: UP/DOWN/SUSPICIOUS |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data`字段为[获取本节点信息](#返回数据-4)的返回数据的列表。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data`字段为[获取本节点信息](#返回数据-4)的返回数据的列表。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -623,50 +623,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list'
 
 ### 1.7. 动态修改Server集群地址发现方式
 
-#### 接口描述
+#### Description
 
 通过该接口，可以在不重启Nacos Server的情况下，动态切换Nacos Server集群地址发现的方式，目前支持两种方式：`file`
 和`address-server`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/lookup`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名    | 类型       | 必填 | 参数描述                                  |
+| Name    | Type       | Required | Description                                  |
 |--------|----------|----|---------------------------------------|
-| `type` | `string` | 是 | address-server/file/standalone |
+| `type` | `string` | Yes | address-server/file/standalone |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名    | 参数类型      | 描述                          |
+| Name    | Type      | Description                          |
 |--------|-----------|-----------------------------|
 | `data` | `boolean` | `true`表示更新成功，`false`表示更新失败。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=file"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -678,35 +678,35 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=
 
 ### 1.8. Raft 相关操作
 
-#### 接口描述
+#### Description
 
 通过该接口，可以对Nacos Server集群中的Raft协议进行部分运维操作，如执行快照，主动选主等。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-请求体类型：`application/json`，参数放在请求体中。
+请求体Type：`application/json`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/ops/raft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名       | 类型       | 必填    | 参数描述                                 |
+| Name       | Type       | Required    | Description                                 |
 |-----------|----------|-------|--------------------------------------|
-| `command` | `string` | **是** | Raft运维操作指令，具体的命令请参考下表。 |
-| `value` | `string` | **是** | 命令的参数，具体的命令内容请参考下表。 |
-| `groupId` | `string` | 否 | Raft集群的groupId，如果不输入则对所有Raft Group生效 |
+| `command` | `string` | **Yes** | Raft运维操作指令，具体的命令请参考下表。 |
+| `value` | `string` | **Yes** | 命令的参数，具体的命令内容请参考下表。 |
+| `groupId` | `string` | No | Raft集群的groupId，如果不输入则对所有Raft Group生效 |
 
 命令说明（Swagger 暂不支持该子参数结构，文档保留）：
 
@@ -717,23 +717,23 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=
 - `removePeers`: `${nacos-server-address}:${raft-port}[,${nacos-server-address}:${raft-port}]`
 - `changePeers`: `${nacos-server-address}:${raft-port}[,${nacos-server-address}:${raft-port}]`
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 固定为`null`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/admin/core/ops/raft' -d '{"command":"doSnapshot","value":"nacos-node-0:7848"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -745,34 +745,34 @@ curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/
 
 ### 1.9. 动态修改Nacos Core相关日志级别
 
-#### 接口描述
+#### Description
 
 通过该接口，可以在不重启Nacos Server的情况下，动态修改Nacos Core相关日志级别的配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`，参数放在请求体中。
+请求体Type：`application/json`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/ops/log`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 类型       | 必填    | 参数描述                                                         |
+| Name        | Type       | Required    | Description                                                         |
 |------------|----------|-------|--------------------------------------------------------------|
-| `logName` | `string` | **是** | 具体的日志文件的名称，具体支持的日志名称见下表。 |
-| `logLevel` | `string` | **是** | 日志的级别，可选值为`ALL`、`TRACE`、`DEBUG`、`INFO`、`WARN`、`ERROR`、`OFF`。 |
+| `logName` | `string` | **Yes** | 具体的日志文件的Name，具体支持的日志Name见下表。 |
+| `logLevel` | `string` | **Yes** | 日志的级别，可选值为`ALL`、`TRACE`、`DEBUG`、`INFO`、`WARN`、`ERROR`、`OFF`。 |
 
 | logName        | 对应的具体日志文件             |
 |----------------|-----------------------|
@@ -781,23 +781,23 @@ curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/
 | `core-distro`  | `protocol-distro.log` |
 | `core-cluster` | `nacos-cluster.log`   |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 固定为`null`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/admin/core/ops/log' -d '{"logName":"core-distro","logLevel":"DEBUG"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -809,7 +809,7 @@ curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/a
 
 ### 1.10. 自动均衡指定数量的连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以根据负载因子(loaderFactor)自动均衡整个集群的客户端连接。
 
@@ -819,29 +819,29 @@ curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/a
    1-loaderFactor))、节点连接数上限阈值`overLimitCount`(=avg * (1+loaderFactor))
 2. 将高负载节点的部分客户端连接重定向到低负载节点。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/smartReloadCluster`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型       | 必填    | 参数描述           |
+| Name                | Type       | Required    | Description           |
 |--------------------|----------|-------|----------------|
-| `loaderFactor` | `number` | 否 | - |
+| `loaderFactor` | `number` | No | - |
 
-#### 返回数据
+#### Response Data
 
 成功则返回:
 
@@ -863,15 +863,15 @@ curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/a
 }
 ```
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/smartReloadCluster' -d "loaderFactor=0.1"
 ```
 
-* 返回示例
+* Response example
 
 ```text
 success
@@ -879,37 +879,37 @@ success
 
 ### 1.11. 获取ID生成器信息
 
-#### 接口描述
+#### Description
 
 通过该接口，获取ID生成器的当前ID,workerId. 只有使用内置数据库时该接口才会返回有效数据.
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/ops/ids`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名              | 参数类型     | 描述       |
+| Name              | Type     | Description       |
 |------------------|----------|----------|
-| `resource`       | `string` | 生产器名称    |
+| `resource`       | `string` | 生产器Name    |
 | `info`           | `object` | 生产器详情    |
 | `info.currentId` | `integer` | 当前ID     |
 | `info.workerId`  | `integer` | workerID |
@@ -942,15 +942,15 @@ success
 }
 ```
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/ops/ids'
 ```
 
-* 返回示例
+* Response example
 
 ```text
 success
@@ -958,41 +958,41 @@ success
 
 ### 1.12. 更新集群节点信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新当前节点中的Nacos节点列表的详细信息。**注意：** 该接口会覆盖当前节点中列表中的详细信息，仅更新传入的节点中存在于集群中的节点，并`不能`通过此接口添加和减少集群中的节点。同时，Nacos自身的健康探测`report`任务也会对当前节点中列表中的节点进行健康探测及更新详细信息，若调用此接口后，探测任务发现节点信息有变更，则任务也会覆盖当前节点中列表中的节点信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/node/list`
 
-#### 请求参数
+#### Request Parameters
 
 请求体为 JSON 数组，数组元素为节点信息（Member），包含 ip、port、state、extendInfo 等字段。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | 是否更新成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list' \
@@ -1000,7 +1000,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list' \
   -d '[{"ip":"127.0.0.1","port":8848,"state":"UP","address":"127.0.0.1:8848"}]'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1012,54 +1012,54 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list' \
 
 ### 1.13. 获取命名空间详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定命名空间的详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | 命名空间 ID |
+| `namespaceId` | `string` | **Yes** | 命名空间 ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | namespace | `string` | 命名空间 ID |
 | namespaceShowName | `string` | 命名空间展示名 |
-| namespaceDesc | `string` | 命名空间描述 |
+| namespaceDesc | `string` | 命名空间Description |
 | quota | `integer` | 配置数量配额 |
 | configCount | `integer` | 当前配置数量 |
-| type | `integer` | 类型 |
+| type | `integer` | Type |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1078,48 +1078,48 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=pub
 
 ### 1.14. 更新命名空间
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的名称和描述。
+通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的Name和Description。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | 命名空间 ID |
-| `namespaceName` | `string` | **是** | 命名空间展示名 |
-| `namespaceDesc` | `string` | 否 | 命名空间描述 |
+| `namespaceId` | `string` | **Yes** | 命名空间 ID |
+| `namespaceName` | `string` | **Yes** | 命名空间展示名 |
+| `namespaceDesc` | `string` | No | 命名空间Description |
 
-#### 返回数据
+#### Response Data
 
-成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
   -d 'namespaceId=test' -d 'namespaceName=test' -d 'namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1131,48 +1131,48 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
 
 ### 1.15. 创建新命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建新的命名空间。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | 命名空间 ID，不传则由服务端生成 |
-| `namespaceName` | `string` | **是** | 命名空间展示名 |
-| `namespaceDesc` | `string` | 否 | 命名空间描述 |
+| `namespaceId` | `string` | No | 命名空间 ID，不传则由服务端生成 |
+| `namespaceName` | `string` | **Yes** | 命名空间展示名 |
+| `namespaceDesc` | `string` | No | 命名空间Description |
 
-#### 返回数据
+#### Response Data
 
-成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
   -d 'namespaceName=test' -d 'namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1184,45 +1184,45 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
 
 ### 1.16. 删除命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除命名空间。默认命名空间`public`无法被删除。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | 命名空间 ID |
+| `namespaceId` | `string` | **Yes** | 命名空间 ID |
 
-#### 返回数据
+#### Response Data
 
-成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1234,45 +1234,45 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=
 
 ### 1.17. 检查命名空间是否存在
 
-#### 接口描述
+#### Description
 
 通过该接口，可以检查命名空间ID是否存在。应该在创建命名空间前调用，确认自定义的命名空间ID是否已经存在，以防冲突。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace/check`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | - |
+| `namespaceId` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为 `true` 表示已存在，`false` 表示不存在。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为 `true` 表示已存在，`false` 表示不存在。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/check?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1284,43 +1284,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/check?namespace
 
 ### 1.18. 获取Nacos命名空间列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取当前Nacos集群的命名空间列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace/list`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。`data` 为命名空间对象数组，每项包含 namespace、namespaceShowName、namespaceDesc、quota、configCount、type 等字段。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。`data` 为命名空间对象数组，每项包含 namespace、namespaceShowName、namespaceDesc、quota、configCount、type 等字段。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1341,43 +1341,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/list'
 
 ### 1.19. 获取Nacos集群状态信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取到Nacos 集群的基础状态和开关信息，例如：版本号，运行模式，鉴权是否开启等；该接口不会返回Nacos 集群的节点信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/state`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为键值对，包含版本号（version）、运行模式（startup_mode）、鉴权开关（auth_enabled）等集群状态与配置项。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为键值对，包含版本号（version）、运行模式（startup_mode）、鉴权开关（auth_enabled）等集群状态与配置项。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1392,47 +1392,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state'
 
 ### 1.20. 获取Nacos集群的存活状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos集群的存活状态，Nacos集群是否可正常接受和响应请求。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/state/liveness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 存活状态，如 "ok" |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/liveness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1444,47 +1444,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/liveness'
 
 ### 1.21. 获取Nacos集群的可读状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos集群的是否处于可读取状态，即Nacos集群是否可以读取到数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/state/readiness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 可读状态，如 "ok" |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1496,53 +1496,53 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 ### 1.22. 更新插件配置
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。支持 localOnly 仅作用于当前节点。
+通过该接口，可以更新插件的配置。需要提供插件Type、Name及配置内容。支持 localOnly 仅作用于当前节点。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`。
+请求体Type：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/config`
 
-#### 请求参数
+#### Request Parameters
 
 请求体为 JSON，包含以下字段：
 
-| 参数名         | 类型       | 必填 | 参数描述           |
+| Name         | Type       | Required | Description           |
 |-------------|----------|----|----------------|
-| `pluginType` | `string` | **是** | 插件类型，如 auth。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `config` | `string` | **是** | 插件配置项。 |
-| `localOnly` | `boolean` | 否 | 是否仅写本地，不持久化。 |
+| `pluginType` | `string` | **Yes** | 插件Type，如 auth。 |
+| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `config` | `string` | **Yes** | 插件配置项。 |
+| `localOnly` | `boolean` | No | 是否仅写本地，不持久化。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为字符串表示操作结果。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为字符串表示操作结果。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
   -H 'Content-Type: application/json' -d '{}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1554,57 +1554,57 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
 
 ### 1.23. 获取插件详情
 
-#### 接口描述
+#### Description
 
-通过该接口，可以按类型和名称获取指定插件的详情信息。
+通过该接口，可以按Type和Name获取指定插件的详情信息。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 auth |
-| `pluginName` | `string` | **是** | 插件名称 |
+| `pluginType` | `string` | **Yes** | 插件Type，如 auth |
+| `pluginName` | `string` | **Yes** | 插件Name |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | pluginId | `string` | 插件 ID |
-| pluginType | `string` | 插件类型 |
-| pluginName | `string` | 插件名称 |
+| pluginType | `string` | 插件Type |
+| pluginName | `string` | 插件Name |
 | enabled | `boolean` | 是否启用 |
 | critical | `boolean` | 是否关键插件 |
 | configurable | `boolean` | 是否可配置 |
 | config | `object` | 配置内容 |
 | configDefinitions | `array` | 配置定义列表 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=auth&pluginName=nacos-default-auth-plugin'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1625,45 +1625,45 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=
 
 ### 1.24. 获取插件列表
 
-#### 接口描述
+#### Description
 
-通过该接口，可以获取所有插件列表，可按插件类型筛选。
+通过该接口，可以获取所有插件列表，可按插件Type筛选。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | 否 | 插件类型，不传则返回全部 |
+| `pluginType` | `string` | No | 插件Type，不传则返回全部 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为插件对象数组。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为插件对象数组。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=auth'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1685,53 +1685,53 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 ### 1.25. 启用或禁用插件
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新插件的启用状态（启用或禁用）。支持 localOnly 仅作用于当前节点。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`。
+请求体Type：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/status`
 
-#### 请求参数
+#### Request Parameters
 
 请求体为 JSON，包含以下字段：
 
-| 参数名         | 类型        | 必填 | 参数描述       |
+| Name         | Type        | Required | Description       |
 |-------------|-----------|----|------------|
-| `pluginType` | `string` | **是** | 插件类型。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `enabled` | `boolean` | **是** | 是否启用。 |
-| `localOnly` | `boolean` | 否 | 是否仅写本地。 |
+| `pluginType` | `string` | **Yes** | 插件Type。 |
+| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `enabled` | `boolean` | **Yes** | 是否启用。 |
+| `localOnly` | `boolean` | No | 是否仅写本地。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为字符串表示操作结果。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为字符串表示操作结果。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
   -H 'Content-Type: application/json' -d '{}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1745,35 +1745,35 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
 
 ### 2.1. 查看Naming模块的相关开关
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查看Nacos Naming模块的相关开关。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/switches`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                      | 参数类型      | 描述                                                                                                      |
+| Name                      | Type      | Description                                                                                                      |
 |--------------------------|-----------|---------------------------------------------------------------------------------------------------------|
 | `clientBeatInterval`     | `integer` | Nacos1.X客户端的默认心跳间隔                                                                                      |
 | `defaultCacheMillis`     | `integer` | 客户端订阅的服务列表的默认缓存时间                                                                                       |
@@ -1787,15 +1787,15 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
 
 > 注意： 其余未列出的参数，均为Nacos旧版本的开关或配置内容，已废弃或即将废弃，请谨慎使用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' 
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1854,49 +1854,49 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches'
 
 ### 2.2. 修改Naming模块的相关开关
 
-#### 接口描述
+#### Description
 
 通过该接口，可以修改Nacos Naming模块的相关开关。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/switches`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名     | 类型        | 必填    | 参数描述                                              |
+| Name     | Type        | Required    | Description                                              |
 |---------|-----------|-------|---------------------------------------------------|
-| `entry` | `string` | **是** | 修改的开关或配置名称 |
-| `value` | `string` | **是** | 开关或配置的新值，不同的开关或配置的类型不同，具体请参考[开关和配置参数](#返回数据-10) |
-| `debug` | `boolean` | 否 | 是否开启调试模式，开启后，修改的配置不会同步到集群其他节点中，仅在本节点生效，默认为`false` |
+| `entry` | `string` | **Yes** | 修改的开关或配置Name |
+| `value` | `string` | **Yes** | 开关或配置的新值，不同的开关或配置的Type不同，具体请参考[开关和配置参数](#返回数据-10) |
+| `debug` | `boolean` | No | 是否开启调试模式，开启后，修改的配置不会同步到集群其他节点中，仅在本节点生效，默认为`false` |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 成功为`ok` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' -d "entry=pushEnabled&value=false"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1908,39 +1908,39 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' -d "entry=pus
 
 ### 2.3. 查询系统当前数据指标
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询系统当前数据指标。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/metrics`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名          | 参数类型      | 是否必填 | 默认值    | 参数描述  |
+| Name          | Type      | Required | Default    | Description  |
 |--------------|-----------|------|--------|-------|
-| `onlyStatus` | `boolean` | 否    | `true` | 只显示状态 |
+| `onlyStatus` | `boolean` | No    | `true` | 只显示状态 |
 
 > 当`onlyStatus`设置为`true`时，只返回表示系统状态的字符串
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                           | 参数类型     | 描述说明    |
+| Name                           | Type     | Description    |
 |-------------------------------|----------|---------|
 | `status`                      | `string` | 系统状态    |
 | `serviceCount`                | `integer` | 服务数量    |
@@ -1952,15 +1952,15 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' -d "entry=pus
 | `persistentIpPortClientCount` | `integer` | 持久客户端数量 |
 | `responsibleClientCount`      | `integer` | 响应客户端数  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/metrics?onlyStatus=false'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1982,55 +1982,55 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/metrics?onlyStatus=fals
 
 ### 2.4. 修改日志级别
 
-#### 接口描述
+#### Description
 
 通过该接口，可以动态修改指定日志的级别。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`。
+请求体Type：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/log`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 类型       | 必填 | 参数描述        |
+| Name   | Type       | Required | Description        |
 |-------|----------|---|-------------|
 
 请求体字段：
 
-| 参数名       | 类型       | 必填    | 参数描述      |
+| Name       | Type       | Required    | Description      |
 |-----------|----------|-------|-----------|
-| `logName`  | `string` | **是** | 需要修改的日志名称。 |
-| `logLevel` | `string` | **是** | 日志级别的新值。   |
+| `logName`  | `string` | **Yes** | 需要修改的日志Name。 |
+| `logLevel` | `string` | **Yes** | 日志级别的新值。   |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 成功为`ok` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/log' -H 'Content-Type: application/json' -d '{"logName":"com.example.Logger","logLevel":"DEBUG"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2042,39 +2042,39 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/log' -H 'Content-Type: 
 
 ### 2.5 查询所有客户端列表
 
-#### 接口描述
+#### Description
 
 查询所有客户端的列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/list`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型           | 描述      |
+| Name    | Type           | Description      |
 |--------|----------------|---------|
 | `data` | `array` | Client ID list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/list'
@@ -2094,57 +2094,57 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/list'
 
 ### 2.6 查询客户端详细信息
 
-#### 接口描述
+#### Description
 
 根据客户端ID查询客户端的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填  | 描述    |
+| Name        | Type     | Required  | Description    |
 |------------|----------|-------|-------|
-| `clientId` | `string` | **是** | 客户端ID |
+| `clientId` | `string` | **Yes** | 客户端ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型      | 描述                 |
+| Name               | Type      | Description                 |
 |-------------------|-----------|--------------------|
 | `clientId`        | `string` | 客户端的唯一 ID。         |
 | `ephemeral`       | `boolean` | 客户端是否为临时客户端        |
 | `lastUpdatedTime` | `integer` | 客户端的最后更新时间（时间戳）    |
-| `clientType`      | `string` | 客户端类型              |
-| `connectType`     | `string` | 连接类型（仅适用于 2.x 客户端） |
-| `appName`         | `string` | 客户端所属的应用名称         |
+| `clientType`      | `string` | 客户端Type              |
+| `connectType`     | `string` | 连接Type（仅适用于 2.x 客户端） |
+| `appName`         | `string` | 客户端所属的应用Name         |
 | `version`         | `string` | 客户端的版本号            |
 | `clientIp`        | `string` | 客户端的 IP 地址         |
 | `clientPort`      | `string` | 客户端的端口号            |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client?clientId=1741748952410_127.0.0.1_53863'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2186,37 +2186,37 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client?clientId=17417489524
 
 ### 2.7 查询客户端注册的服务列表
 
-#### 接口描述
+#### Description
 
 查询指定客户端注册的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/publish/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填  | 描述    |
+| Name        | Type     | Required  | Description    |
 |------------|----------|-------|-------|
-| `clientId` | `string` | **是** | 客户端ID |
+| `clientId` | `string` | **Yes** | 客户端ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                         | 参数类型     | 描述说明      |
+| Name                         | Type     | Description      |
 |-----------------------------|----------|-----------|
 | `namespaceId`               | `string` | 命名空间      |
 | `groupName`                 | `string` | 分组名       |
@@ -2226,15 +2226,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client?clientId=17417489524
 | `publisherInfo.port`        | `integer` | 端口号       |
 | `publisherInfo.clusterName` | `string` | 集群名       |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/publish/list?clientId=1664527081276_127.0.0.1_4400'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2259,37 +2259,37 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/publish/list?clientI
 
 ### 2.8 查询客户端订阅的服务列表
 
-#### 接口描述
+#### Description
 
 查询指定客户端订阅的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/subscribe/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填 | 描述    |
+| Name        | Type     | Required | Description    |
 |------------|----------|------|-------|
-| `clientId` | `string` | **是** | 客户端ID |
+| `clientId` | `string` | **Yes** | 客户端ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                      | 参数类型     | 描述说明  |
+| Name                      | Type     | Description  |
 |--------------------------|----------|-------|
 | `namespaceId`            | `string` | 命名空间  |
 | `groupName`              | `string` | 分组名   |
@@ -2299,15 +2299,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/publish/list?clientI
 | `subscriberInfo.agent`   | `string` | 客户端信息 |
 | `subscriberInfo.address` | `string` | 地址    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/subscribe/list?clientId=1664527081276_127.0.0.1_4400'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2332,56 +2332,56 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/subscribe/list?clien
 
 ### 2.9 查询注册指定服务的客户端列表
 
-#### 接口描述
+#### Description
 
 查询注册指定服务的客户端列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/service/publisher/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值               | 描述说明                     |
+| Name           | Type      | Required  | Default               | Description                     |
 |---------------|-----------|-------|-------------------|--------------------------|
-| `namespaceId` | `string` | 否 | `"public"` |
-| `groupName` | `string` | 否 | `"DEFAULT_GROUP"` |
-| `serviceName` | `string` | **是** | 无 |
-| `ip` | `string` | 否 | 无 |
-| `port` | `integer` | 否 | None |
+| `namespaceId` | `string` | No | `"public"` |
+| `groupName` | `string` | No | `"DEFAULT_GROUP"` |
+| `serviceName` | `string` | **Yes** | None |
+| `ip` | `string` | No | None |
+| `port` | `integer` | No | None |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型     | 描述说明    |
+| Name           | Type     | Description    |
 |---------------|----------|---------|
 | `clientId`    | `string` | 客户端`id` |
 | `ip`          | `string` | 实例的`IP` |
 | `port`        | `integer` | 实例的端口   |
 | `clusterName` | `string` | 实例的集群名  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/publisher/list?serviceName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2400,56 +2400,56 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/publisher/li
 
 ### 2.10 查询订阅指定服务的客户端列表
 
-#### 接口描述
+#### Description
 
 查询订阅指定服务的客户端列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/service/subscriber/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值               | 描述说明                     |
+| Name           | Type      | Required  | Default               | Description                     |
 |---------------|-----------|-------|-------------------|--------------------------|
-| `namespaceId` | `string` | 否 | `"public"` |
-| `groupName` | `string` | 否 | `"DEFAULT_GROUP"` |
-| `serviceName` | `string` | **是** | 无 |
-| `ip` | `string` | 否 | 无 |
-| `port` | `integer` | 否 | None |
+| `namespaceId` | `string` | No | `"public"` |
+| `groupName` | `string` | No | `"DEFAULT_GROUP"` |
+| `serviceName` | `string` | **Yes** | None |
+| `ip` | `string` | No | None |
+| `port` | `integer` | No | None |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名        | 参数类型     | 描述说明                             |
+| Name        | Type     | Description                             |
 |------------|----------|----------------------------------|
 | `clientId` | `string` | 客户端`id`                          |
 | `address`  | `string` | 订阅者客户端的`IP`                      |
 | `agent`    | `string` | 订阅者客户端的版本                        |
 | `appName`  | `string` | 订阅者客户端的应用名，`unknown`表示未配置或客户端不支持 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/subscriber/list?serviceName=service1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2468,52 +2468,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/subscriber/l
 
 ### 2.11 查询客户端的负责服务器
 
-#### 接口描述
+#### Description
 
 根据客户端的IP和端口查询其负责的服务器，仅针对持久化服务实例或通过运维API注册的临时实例。使用2.X以上客户端注册的临时实例无法通过此接口定位负责服务器节点。
 
 > 对于使用1.X客户端注册的实例也适用此接口， 但1.X客户端将在未来版本不再支持。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/distro`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名    | 参数类型     | 是否必填  | 描述    |
+| Name    | Type     | Required  | Description    |
 |--------|----------|-------|-------|
-| `ip`   | `string` | **是** | 客户端IP |
-| `port` | `integer` | **是** | Client port. |
+| `ip`   | `string` | **Yes** | 客户端IP |
+| `port` | `integer` | **Yes** | Client port. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                 | 参数类型     | 描述       |
+| Name                 | Type     | Description       |
 |---------------------|----------|----------|
 | `responsibleServer` | `string` | 负责的服务器信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/distro?ip=127.0.0.1&port=8080'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2527,54 +2527,54 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/distro?ip=127.0.0.1&
 
 ### 2.12 更新集群信息
 
-#### 接口描述
+#### Description
 
 更新指定集群的元数据信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/cluster`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型                  | 是否必填  | 描述                |
+| Name                     | Type                  | Required  | Description                |
 |-------------------------|-----------------------|-------|-------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `clusterName` | `string` | **是** | 集群名称 |
-| `checkPort` | `integer` | 否 | 健康检查端口 |
-| `useInstancePort4Check` | `boolean` | 否 | 是否使用实例端口进行健康检查 |
-| `healthChecker` | `string` | 否 | 健康检查器配置（JSON 字符串） |
-| `metadata` | `string` | 否 | 集群的扩展元数据，默认为`""` |
-| `groupName` | `string` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间ID |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `clusterName` | `string` | **Yes** | 集群Name |
+| `checkPort` | `integer` | No | 健康检查端口 |
+| `useInstancePort4Check` | `boolean` | No | 是否使用实例端口进行健康检查 |
+| `healthChecker` | `string` | No | 健康检查器配置（JSON 字符串） |
+| `metadata` | `string` | No | 集群的扩展元数据，默认为`""` |
+| `groupName` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/cluster' -d 'serviceName=test&clusterName=DEFAULT&checkPort=80&useInstancePort4Check=true&healthChecker={"type":"none"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2586,56 +2586,56 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/cluster' -d 'serviceName=te
 
 ### 2.13 更新实例健康状态
 
-#### 接口描述
+#### Description
 
 更新指定实例的健康状态。
 
 > 仅对持久化服务的实例有效， 且该服务的健康检查方式为`NONE`。
-> 临时实例的健康状态由连接（客户端）维护，其他健康检查类型的持久化服务，健康检查任务会自动维护健康状态，即使更新成功了，也很快会被健康检查任务重制。
+> 临时实例的健康状态由连接（客户端）维护，其他健康检查Type的持久化服务，健康检查任务会自动维护健康状态，即使更新成功了，也很快会被健康检查任务重制。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/health/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 描述                      |
+| Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `healthy` | `boolean` | **是** | 健康状态（`true` 为健康） |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `healthy` | `boolean` | **Yes** | 健康状态（`true` 为健康） |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/instance' -d 'namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&clusterName=cluster1&ip=127.0.0.1&port=8080&healthy=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2647,45 +2647,45 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/instance' -d 'namesp
 
 ### 2.14 获取所有健康检查器
 
-#### 接口描述
+#### Description
 
-获取系统中支持的所有健康检查器类型及其配置。
+获取系统中支持的所有健康检查器Type及其配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/health/checkers`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型                                 | 描述          |
+| Name    | Type                                 | Description          |
 |--------|--------------------------------------|-------------|
-| `data` | `Map<String, AbstractHealthChecker>` | 健康检查器类型及其配置 |
+| `data` | `Map<String, AbstractHealthChecker>` | 健康检查器Type及其配置 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/checkers'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2710,58 +2710,58 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/checkers'
 
 ### 2.15 注册实例
 
-#### 接口描述
+#### Description
 
 注册一个新的实例到指定服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型                  | 是否必填  | 描述                      |
+| Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `weight` | `number` | 否 | 实例权重，默认为`1.0` |
-| `healthy` | `boolean` | 否 | 健康状态，默认为`true` |
-| `enabled` | `boolean` | 否 | 是否启用，默认为`true` |
-| `metadata` | `string` | 否 | 实例元数据 |
-| `ephemeral` | `boolean` | 否 | 是否临时实例 |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `weight` | `number` | No | 实例权重，默认为`1.0` |
+| `healthy` | `boolean` | No | 健康状态，默认为`true` |
+| `enabled` | `boolean` | No | 是否启用，默认为`true` |
+| `metadata` | `string` | No | 实例元数据 |
+| `ephemeral` | `boolean` | No | 是否临时实例 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 -d 'namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&clusterName=cluster1&ip=127.0.0.1&port=8080&weight=1.0&healthy=true&enabled=true&metadata={"key1=value1"}&ephemeral=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2773,52 +2773,52 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 
 ### 2.16 注销实例
 
-#### 接口描述
+#### Description
 
 从指定服务中注销一个实例。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 描述                      |
+| Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&clusterName=cluster1&ip=127.0.0.1&port=8080&ephemeral=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2830,7 +2830,7 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=pub
 
 ### 2.17 更新实例
 
-#### 接口描述
+#### Description
 
 更新指定实例的信息。
 
@@ -2843,54 +2843,54 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=pub
 > 同时该接口将会完全覆盖之前更新过的元数据信息，例如，先使用`k1=v1`更新元数据，再使用`k2=v2`
 > 更新元数据，此时读取到的元数据为`k2=v2`，而不是`k1=v1,k2=v2`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型                  | 是否必填  | 描述                      |
+| Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `weight` | `number` | 否 | 实例权重，默认为`1.0` |
-| `healthy` | `boolean` | 否 | 健康状态，默认为`true` |
-| `enabled` | `boolean` | 否 | 是否启用，默认为`true` |
-| `metadata` | `string` | 否 | 实例元数据 |
-| `ephemeral` | `boolean` | 否 | 是否临时实例 |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `weight` | `number` | No | 实例权重，默认为`1.0` |
+| `healthy` | `boolean` | No | 健康状态，默认为`true` |
+| `enabled` | `boolean` | No | 是否启用，默认为`true` |
+| `metadata` | `string` | No | 实例元数据 |
+| `ephemeral` | `boolean` | No | 是否临时实例 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 -d 'serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&ip=1.1.1.1&port=3306&ephemeral=true&weight=100&enabled=false&metadata=%7B%22%E5%95%A6%E5%95%A6%E5%95%A6%26%E5%95%B5%E5%95%B5%E5%95%B5%22%3A%22xxx%22%7D'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2902,53 +2902,53 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 
 ### 2.18 批量更新实例元数据
 
-#### 接口描述
+#### Description
 
 批量更新指定实例的元数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/metadata/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 参数类型                  | 是否必填  | 描述                                                                                           |
+| Name               | Type                  | Required  | Description                                                                                           |
 |-------------------|-----------------------|-------|----------------------------------------------------------------------------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `instances` | `string` | 否 | 实例列表（JSON数组 字符串）默认为`""`表示所有实例更新；若指定时，每个元素代表一个需要更新的实例，必须需要包含`ip`和`port`字段，`clusterName`字段为可选, |
-| `metadata` | `string` | **是** | 元数据 |
-| `consistencyType` | `string` | 否 | 一致性类型`ephemeral`和`persist`，对应服务的`ephemeral`，默认为`ephemeral` |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `instances` | `string` | No | 实例列表（JSON数组 字符串）默认为`""`表示所有实例更新；若指定时，每个元素代表一个需要更新的实例，必须需要包含`ip`和`port`字段，`clusterName`字段为可选, |
+| `metadata` | `string` | **Yes** | 元数据 |
+| `consistencyType` | `string` | No | 一致性Type`ephemeral`和`persist`，对应服务的`ephemeral`，默认为`ephemeral` |
 
-#### 返回数据
+#### Response Data
 
-| **参数名**   | **参数类型**       | **描述**  |
+| **Name**   | **Type**       | **Description**  |
 |-----------|----------------|---------|
 | `updated` | `array` | Updated instance list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch' \
 -d 'namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&instances=[{"ip":"127.0.0.1","port":8080}]&metadata={"key1":"value1"}&consistencyType=ephemeral'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2964,53 +2964,53 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch' \
 
 ### 2.19 批量删除实例元数据
 
-#### 接口描述
+#### Description
 
 批量删除指定实例的元数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/metadata/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 参数类型                  | 是否必填  | 描述                      |
+| Name               | Type                  | Required  | Description                      |
 |-------------------|-----------------------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `instances` | `string` | 否 | 实例列表（JSON 字符串），默认为`""` |
-| `metadata` | `string` | **是** | 元数据 |
-| `consistencyType` | `string` | 否 | 一致性类型，默认为`""` |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `instances` | `string` | No | 实例列表（JSON 字符串），默认为`""` |
+| `metadata` | `string` | **Yes** | 元数据 |
+| `consistencyType` | `string` | No | 一致性Type，默认为`""` |
 
-#### 返回数据
+#### Response Data
 
-| **参数名**        | **参数类型**                           | **描述**  |
+| **Name**        | **Type**                           | **Description**  |
 |----------------|------------------------------------|---------|
 | `data`         | `InstanceMetadataBatchOperationVo` | 操作结果信息  |
 | `data.updated` | `array`                     | Updated instance list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch?namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&instances=%5B%7B%22ip%22%3A%22127.0.0.1%22%2C%22port%22%3A8080%7D%5D&metadata=%7B%22key1%22%3A%22value1%22%7D&consistencyType=ephemeral'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3026,60 +3026,60 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch?
 
 ### 2.20 部分更新实例
 
-#### 接口描述
+#### Description
 
 部分更新指定实例的信息。
 
 > 不同于[更新实例](#217-更新实例)，该接口支持部分更新实例信息，例如：先使用`k1=v1`更新元数据，再使用`k2=v2`
 > 更新元数据，此时读取到的元数据为`k1=v1,k2=v2`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/partial`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型**  | **是否必填** | **描述**             |
+| **Name**       | **Type**  | **Required** | **Description**             |
 |---------------|-----------|----------|--------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `weight` | `number` | 否 | 实例权重，默认为1.0 |
-| `enabled` | `boolean` | 否 | 是否启用，默认启用 |
-| `metadata` | `string` | 否 | 实例元数据（JSON 字符串） |
-| `ephemeral` | `boolean` | 否 | - |
-| `groupName` | `string` | 否 | - |
-| `healthy` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `weight` | `number` | No | 实例权重，默认为1.0 |
+| `enabled` | `boolean` | No | 是否启用，默认启用 |
+| `metadata` | `string` | No | 实例元数据（JSON 字符串） |
+| `ephemeral` | `boolean` | No | - |
+| `groupName` | `string` | No | - |
+| `healthy` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'namespaceId=public&serviceName=example-service&ip=127.0.0.1&clusterName=DEFAULT&port=8080&weight=1.0&enabled=true&metadata={"key":"value"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3091,44 +3091,44 @@ curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'names
 
 ### 2.21 查询服务实例列表
 
-#### 接口描述
+#### Description
 
 查询指定服务的所有实例列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/list`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型**  | **是否必填** | **描述**                  |
+| **Name**       | **Type**  | **Required** | **Description**                  |
 |---------------|-----------|----------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认`public` |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `clusterName` | `string` | 否 | Cluster name. If not provided, instances of all clusters will be returned. |
-| `healthyOnly` | `boolean` | 否 | 是否只返回健康实例，默认为`false` |
+| `namespaceId` | `string` | No | 命名空间ID，默认`public` |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `clusterName` | `string` | No | Cluster name. If not provided, instances of all clusters will be returned. |
+| `healthyOnly` | `boolean` | No | 是否只返回健康实例，默认为`false` |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型      | 描述说明                              |
+| Name           | Type      | Description                              |
 |---------------|-----------|-----------------------------------|
 | `serviceName` | `string` | 服务名,格式为`groupName`@@`serviceName` |
-| `clusterName` | `string` | 实例所在的集群名称                         |
+| `clusterName` | `string` | 实例所在的集群Name                         |
 | `ip`          | `string` | 实例`IP`                            |
 | `port`        | `integer` | 实例端口号                             |
 | `weight`      | `number` | 实例权重                              |
@@ -3141,15 +3141,15 @@ curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'names
 > 关于心跳的参数`instanceHeartBeatInterval`, `instanceHeartBeatTimeOut`和`ipDeleteTimeout`
 > 用于兼容1.X客户端的心跳模式数据，后续版本可能会移除对1.X客户端的支持，届时这3个参数将被废弃。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/list?namespaceId=public&serviceName=service1&healthyOnly=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3179,45 +3179,45 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/list?namespaceId=p
 
 ### 2.22 查询实例详情
 
-#### 接口描述
+#### Description
 
 查询指定实例的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **描述说明**               |
+| **Name**       | **Type** | **Required** | **Description**               |
 |---------------|----------|----------|------------------------|
-| `namespaceId` | `string` | 否        | 命名空间Id，默认为`public`     |
-| `groupName`   | `string` | 否    | Group name. Defaults to `DEFAULT_GROUP`. |
-| `serviceName` | `string` | **是**    | 服务名                    |
-| `clusterName` | `string` | 否        | 集群名称，默认为`DEFAULT`      |
-| `ip`          | `string` | **是**    | `IP`地址                 |
-| `port`        | `integer` | **是**    | 端口号                    |
+| `namespaceId` | `string` | No        | 命名空间Id，默认为`public`     |
+| `groupName`   | `string` | No    | Group name. Defaults to `DEFAULT_GROUP`. |
+| `serviceName` | `string` | **Yes**    | 服务名                    |
+| `clusterName` | `string` | No        | 集群Name，默认为`DEFAULT`      |
+| `ip`          | `string` | **Yes**    | `IP`地址                 |
+| `port`        | `integer` | **Yes**    | 端口号                    |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型      | 描述说明                              |
+| Name           | Type      | Description                              |
 |---------------|-----------|-----------------------------------|
 | `serviceName` | `string` | 服务名,格式为`groupName`@@`serviceName` |
-| `clusterName` | `string` | 实例所在的集群名称                         |
+| `clusterName` | `string` | 实例所在的集群Name                         |
 | `ip`          | `string` | 实例`IP`                            |
 | `port`        | `integer` | 实例端口号                             |
 | `weight`      | `number` | 实例权重                              |
@@ -3230,15 +3230,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/list?namespaceId=p
 > 关于心跳的参数`instanceHeartBeatInterval`, `instanceHeartBeatTimeOut`和`ipDeleteTimeout`
 > 用于兼容1.X客户端的心跳模式数据，后续版本可能会移除对1.X客户端的支持，届时这3个参数将被废弃。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=public&serviceName=service1&ip=1.1.1.1&port=3306'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3268,47 +3268,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=public
 
 ### 2.23 创建服务
 
-#### 接口描述
+#### Description
 
 创建一个新的持久化服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型           | 是否必填  | 描述说明                   |
+| Name                | Type           | Required  | Description                   |
 |--------------------|----------------|-------|------------------------|
-| `namespaceId` | `string` | 否 | 命名空间`Id`，默认为`public` |
-| `groupName` | `string` | 否 | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名 |
-| `metadata` | `string` | 否 | 服务元数据，默认为空 |
-| `ephemeral` | `boolean` | 否 | 是否为临时实例，默认为`false` |
-| `protectThreshold` | `number` | 否 | 保护阈值，默认为`0` |
-| `selector` | `string` | 否 | 访问策略，默认为空 |
+| `namespaceId` | `string` | No | 命名空间`Id`，默认为`public` |
+| `groupName` | `string` | No | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名 |
+| `metadata` | `string` | No | 服务元数据，默认为空 |
+| `ephemeral` | `boolean` | No | 是否为临时实例，默认为`false` |
+| `protectThreshold` | `number` | No | 保护阈值，默认为`0` |
+| `selector` | `string` | No | 访问策略，默认为空 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -d 'serviceName=nacos.test.1' \
@@ -3317,7 +3317,7 @@ curl -d 'serviceName=nacos.test.1' \
   -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/service'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3329,49 +3329,49 @@ curl -d 'serviceName=nacos.test.1' \
 
 ### 2.24 删除服务
 
-#### 接口描述
+#### Description
 
 删除指定服务
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述说明                   |
+| Name           | Type     | Required  | Description                   |
 |---------------|----------|-------|------------------------|
-| `namespaceId` | `string` | 否     | 命名空间`Id`，默认为`public`   |
-| `groupName`   | `string` | 否     | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名                    |
+| `namespaceId` | `string` | No     | 命名空间`Id`，默认为`public`   |
+| `groupName`   | `string` | No     | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名                    |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.test.1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3383,39 +3383,39 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=naco
 
 ### 2.25 查询服务详情
 
-#### 接口描述
+#### Description
 
 查询指定服务的详细信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述说明                   |
+| Name           | Type     | Required  | Description                   |
 |---------------|----------|-------|------------------------|
-| `namespaceId` | `string` | 否     | 命名空间`Id`，默认为`public`   |
-| `groupName`   | `string` | 否     | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名                    |
+| `namespaceId` | `string` | No     | 命名空间`Id`，默认为`public`   |
+| `groupName`   | `string` | No     | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名                    |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                                 | 参数类型         | 描述                                   |
+| Name                                                 | Type         | Description                                   |
 |-----------------------------------------------------|--------------|--------------------------------------|
 | `namespaceId`                                       | `string` | 服务所属的namespaceId。                    |
 | `groupName`                                         | `string` | 服务所属的groupName。                      |
@@ -3431,15 +3431,15 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=naco
 | `clusterMap`.$ClusterName.`useInstancePortForCheck` | `boolean` | 是否使用所注册的实例的`IP:Port`进行健康检查。          |
 | `clusterMap`.$ClusterName.`metadata`                | `map<string, string>` | Cluster metadata. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.test.1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3474,43 +3474,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.t
 
 ### 2.26 查询服务列表
 
-#### 接口描述
+#### Description
 
 查询所有服务的列表，支持分页和条件过滤。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型           | 是否必填  | 描述说明                   |
+| Name           | Type           | Required  | Description                   |
 |---------------|----------------|-------|------------------------|
-| `namespaceId` | `string` | 否 | 命名空间`Id`，默认为`public` |
-| `pageNo` | `integer` | **是** | 当前页，默认为`1` |
-| `pageSize` | `integer` | **是** | 页条目数，默认为`20`，最大为`500` |
-| `groupNameParam` | `string` | 否 | - |
-| `ignoreEmptyService` | `boolean` | 否 | - |
-| `serviceNameParam` | `string` | 否 | - |
-| `withInstances` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间`Id`，默认为`public` |
+| `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
+| `pageSize` | `integer` | **Yes** | 页条目数，默认为`20`，最大为`500` |
+| `groupNameParam` | `string` | No | - |
+| `ignoreEmptyService` | `boolean` | No | - |
+| `serviceNameParam` | `string` | No | - |
+| `withInstances` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                   | 参数类型     | 描述说明         |
+| Name                                   | Type     | Description         |
 |---------------------------------------|----------|--------------|
 | `totalCount`                          | `integer` | 符合条件的服务的总数。  |
 | `pageNumber`                          | `integer` | 当前页码，起始为`1`。 |
@@ -3523,15 +3523,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.t
 | `pageItems`[i].`healthyInstanceCount` | `string` | 服务下的健康实例数量。  |
 | `pageItems`[i].`triggerFlag`          | `string` | 是否触发了服务的保护。  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3565,50 +3565,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/list'
 
 ### 2.27 更新服务
 
-#### 接口描述
+#### Description
 
 更新指定服务的配置信息。
 
 > 该接口将会完全覆盖之前更新过的元数据信息，例如，先使用`k1=v1`更新元数据，再使用`k2=v2`
 > 更新元数据，此时读取到的元数据为`k2=v2`，而不是`k1=v1,k2=v2`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型           | 是否必填  | 描述说明                   |
+| Name                | Type           | Required  | Description                   |
 |--------------------|----------------|-------|------------------------|
-| `namespaceId` | `string` | 否 | 命名空间`Id`，默认为`public` |
-| `groupName` | `string` | 否 | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名 |
-| `metadata` | `string` | 否 | 服务元数据，默认为空 |
-| `protectThreshold` | `number` | 否 | 保护阈值，默认为`0` |
-| `selector` | `string` | 否 | 访问策略，默认为空 |
-| `ephemeral` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间`Id`，默认为`public` |
+| `groupName` | `string` | No | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名 |
+| `metadata` | `string` | No | 服务元数据，默认为空 |
+| `protectThreshold` | `number` | No | 保护阈值，默认为`0` |
+| `selector` | `string` | No | 访问策略，默认为空 |
+| `ephemeral` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -d 'serviceName=nacos.test.1' \
@@ -3616,7 +3616,7 @@ curl -d 'serviceName=nacos.test.1' \
   -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/service'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3628,42 +3628,42 @@ curl -d 'serviceName=nacos.test.1' \
 
 ### 2.28 查询订阅者列表
 
-#### 接口描述
+#### Description
 
 查询指定服务的订阅者列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service/subscribers`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型**  | **是否必填** | **描述**                  |
+| **Name**       | **Type**  | **Required** | **Description**                  |
 |---------------|-----------|----------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认是`DEFAULT_GROUP` |
-| `pageNo` | `integer` | **是** | 页码 |
-| `pageSize` | `integer` | **是** | 每页大小 |
-| `aggregation` | `boolean` | 否 | 是否聚合,默认为`true` |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认是`DEFAULT_GROUP` |
+| `pageNo` | `integer` | **Yes** | 页码 |
+| `pageSize` | `integer` | **Yes** | 每页大小 |
+| `aggregation` | `boolean` | No | 是否聚合,默认为`true` |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型      | 描述                   |
+| Name                          | Type      | Description                   |
 |------------------------------|-----------|----------------------|
 | `totalCount`                 | `integer` | 符合条件的服务的总数。          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。         |
@@ -3678,15 +3678,15 @@ curl -d 'serviceName=nacos.test.1' \
 | `pageItems`[i].`groupName`   | `string` | 订阅的分组名。              |
 | `pageItems`[i].`serviceName` | `string` | 订阅的服务名。              |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/subscribers?namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3712,47 +3712,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/subscribers?namespa
 }
 ```
 
-### 2.29 查询选择器类型
+### 2.29 查询选择器Type
 
-#### 接口描述
+#### Description
 
-查询系统中支持的所有选择器类型。
+查询系统中支持的所有选择器Type。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service/selector/types`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型           | 描述      |
+| Name    | Type           | Description      |
 |--------|----------------|---------|
 | `data` | `array` | Selector type list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/selector/types'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3769,65 +3769,65 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/selector/types'
 
 ### 3.1. 获取配置
 
-#### 接口描述
+#### Description
 
 获取指定配置
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **类型**   | **必填** | **默认值**  | **参数描述** |
+| **Name**       | **Type**   | **Required** | **Default**  | **Description** |
 |---------------|----------|--------|----------|----------|
-| `namespaceId` | `string` | 否      | `public` | 命名空间     |
-| `groupName`   | `string` | **是**  | 无        | 配置分组名    |
-| `dataId`      | `string` | **是**  | 无        | 配置名      |
+| `namespaceId` | `string` | No      | `public` | 命名空间     |
+| `groupName`   | `string` | **Yes**  | None        | 配置分组名    |
+| `dataId`      | `string` | **Yes**  | None        | 配置名      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                         |
+| Name                | Type     | Description                         |
 |--------------------|----------|----------------------------|
-| `id`               | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `id`               | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
 | `dataId`           | `string` | 配置ID。                      |
 | `groupName`        | `string` | 配置分组。                      |
 | `namespaceId`      | `string` | 命名空间ID。                    |
 | `content`          | `string` | 配置内容。                      |
-| `desc`             | `string` | 配置描述。                      |
+| `desc`             | `string` | 配置Description。                      |
 | `md5`              | `string` | 配置内容的MD5值。                 |
 | `configTags`       | `string` | 配置的标签。                     |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。     |
-| `appName`          | `string` | 配置所属的应用名称。                 |
-| `type`             | `string` | 配置类型。                      |
+| `appName`          | `string` | 配置所属的应用Name。                 |
+| `type`             | `string` | 配置Type。                      |
 | `createTime`       | `integer` | 配置创建时间。                    |
 | `modifyTime`       | `integer` | 配置修改时间。                    |
 | `createUser`       | `string` | 配置创建人。                     |
 | `createIp`         | `string` | 配置创建IP。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3855,53 +3855,53 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.example
 
 ### 3.2. 发布配置
 
-#### 接口描述
+#### Description
 
 发布指定配置
 
 > 当配置已存在时，则对配置进行更新
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填    | 默认值      | 参数描述            |
+| Name           | Type       | Required    | Default      | Description            |
 |---------------|----------|-------|----------|-----------------|
-| `namespaceId` | `string` | 否 | `public` |
-| `groupName` | `string` | **是** | 无 |
-| `dataId` | `string` | **是** | 无 |
-| `content` | `string` | **是** | 无 |
-| `appName` | `string` | 否 | 无 |
-| `configTags` | `string` | 否 | 无 |
-| `desc` | `string` | 否 | 无 |
-| `type` | `string` | 否 | 无 |
-| `encryptedDataKey` | `string` | 否 | - |
-| `srcUser` | `string` | 否 | - |
-| `tag` | `string` | 否 | - |
+| `namespaceId` | `string` | No | `public` |
+| `groupName` | `string` | **Yes** | None |
+| `dataId` | `string` | **Yes** | None |
+| `content` | `string` | **Yes** | None |
+| `appName` | `string` | No | None |
+| `configTags` | `string` | No | None |
+| `desc` | `string` | No | None |
+| `type` | `string` | No | None |
+| `encryptedDataKey` | `string` | No | - |
+| `srcUser` | `string` | No | - |
+| `tag` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -d 'dataId=nacos.example' \
@@ -3911,7 +3911,7 @@ curl -d 'dataId=nacos.example' \
  -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3923,49 +3923,49 @@ curl -d 'dataId=nacos.example' \
 
 ### 3.3. 删除配置
 
-#### 接口描述
+#### Description
 
 删除指定配置
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填    | 默认值      | 参数描述  |
+| Name           | Type       | Required    | Default      | Description  |
 |---------------|----------|-------|----------|-------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间  |
-| `groupName`   | `string` | **是** | 无        | 配置分组名 |
-| `dataId`      | `string` | **是** | 无        | 配置名   |
+| `namespaceId` | `string` | No     | `public` | 命名空间  |
+| `groupName`   | `string` | **Yes** | None        | 配置分组名 |
+| `dataId`      | `string` | **Yes** | None        | 配置名   |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3977,47 +3977,47 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.exam
 
 ### 3.4 批量删除配置
 
-#### 接口描述
+#### Description
 
 根据配置ID批量删除配置
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 参数类型         | 是否必填  | 描述     |
+| Name   | Type         | Required  | Description     |
 |-------|--------------|-------|--------|
-| `ids` | `array` | **是** | Config ID list. Separate multiple IDs with commas. |
+| `ids` | `array` | **Yes** | Config ID list. Separate multiple IDs with commas. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/batch?ids=1,2,3'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4029,53 +4029,53 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/batch?ids=1,2,3'
 
 ### 3.5 查询配置的监听者
 
-#### 接口描述
+#### Description
 
 查询指定配置的监听者信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/listener`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值      | 描述        |
+| Name           | Type      | Required  | Default      | Description        |
 |---------------|-----------|-------|----------|-----------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间      |
-| `dataId`      | `string` | **是** | 无        | 配置ID      |
-| `groupName`   | `string` | **是** | 无        | 分组名称      |
-| `aggregation` | `boolean` | 否 | `true`   | Whether to aggregate data from other nodes. |
+| `namespaceId` | `string` | No     | `public` | 命名空间      |
+| `dataId`      | `string` | **Yes** | None        | 配置ID      |
+| `groupName`   | `string` | **Yes** | None        | 分组Name      |
+| `aggregation` | `boolean` | No | `true`   | Whether to aggregate data from other nodes. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                    |
+| Name               | Type                  | Description                                    |
 |-------------------|-----------------------|---------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`config`。                 |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`config`。                 |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅者IP，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/listener?namespaceId=public&dataId=example&groupName=DEFAULT_GROUP'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4092,70 +4092,70 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/listener?namespaceId
 
 ### 3.6 通过配置内容查询配置列表
 
-#### 接口描述
+#### Description
 
 根据配置详情（如内容、标签等）搜索配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名            | 参数类型      | 是否必填  | 默认值      | 描述                                                     |
+| Name            | Type      | Required  | Default      | Description                                                     |
 |----------------|-----------|-------|----------|--------------------------------------------------------|
-| `pageNo` | `integer` | **是** | 1 |
-| `pageSize` | `integer` | **是** | 100 |
-| `namespaceId` | `string` | 否 | `public` |
-| `dataId` | `string` | **是** | `""` |
-| `groupName` | `string` | **是** | `""` |
-| `appName` | `string` | 否 |  |
-| `configTags` | `string` | 否 |  |
-| `type` | `string` | 否 |  |
-| `configDetail` | `string` | **是** |  |
-| `search` | `string` | 否 | Search mode: `blur` or `accurate`. Defaults to `blur`. |
+| `pageNo` | `integer` | **Yes** | 1 |
+| `pageSize` | `integer` | **Yes** | 100 |
+| `namespaceId` | `string` | No | `public` |
+| `dataId` | `string` | **Yes** | `""` |
+| `groupName` | `string` | **Yes** | `""` |
+| `appName` | `string` | No |  |
+| `configTags` | `string` | No |  |
+| `type` | `string` | No |  |
+| `configDetail` | `string` | **Yes** |  |
+| `search` | `string` | No | Search mode: `blur` or `accurate`. Defaults to `blur`. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                         |
+| Name                          | Type     | Description                         |
 |------------------------------|----------|----------------------------|
 | `totalCount`                 | `integer` | 符合规则的配置总数。                 |
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `array`   | Configurations matching the query criteria. |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
 | `pageItems`[i].`md5`         | `string` | 配置内容的MD5值。                 |
-| `pageItems`[i].`appName`     | `string` | 配置所属的应用名称。                 |
-| `pageItems`[i].`type`        | `string` | 配置类型。                      |
+| `pageItems`[i].`appName`     | `string` | 配置所属的应用Name。                 |
+| `pageItems`[i].`type`        | `string` | 配置Type。                      |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/list?pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4195,51 +4195,51 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/list?pageNo=1&pageSi
 
 ### 3.7 停止Beta配置
 
-#### 接口描述
+#### Description
 
 停止指定配置的Beta配置
 
 > 只有在[发布配置](#32-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能停止BETA发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 默认值      | 描述   |
+| Name           | Type     | Required  | Default      | Description   |
 |---------------|----------|-------|----------|------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间 |
-| `dataId`      | `string` | **是** | 无        | 配置ID |
-| `groupName`   | `string` | **是** | 无        | 分组名称 |
+| `namespaceId` | `string` | No     | `public` | 命名空间 |
+| `dataId`      | `string` | **Yes** | None        | 配置ID |
+| `groupName`   | `string` | **Yes** | None        | 分组Name |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=public&dataId=example&groupName=DEFAULT_GROUP'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4251,68 +4251,68 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=
 
 ### 3.8 查询Beta配置
 
-#### 接口描述
+#### Description
 
 查询指定配置的Beta配置
 
 > 只有在[发布配置](#32-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能停止BETA发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 默认值      | 描述   |
+| Name           | Type     | Required  | Default      | Description   |
 |---------------|----------|-------|----------|------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间 |
-| `dataId`      | `string` | **是** | 无        | 配置ID |
-| `groupName`   | `string` | **是** | 无        | 分组名称 |
+| `namespaceId` | `string` | No     | `public` | 命名空间 |
+| `dataId`      | `string` | **Yes** | None        | 配置ID |
+| `groupName`   | `string` | **Yes** | None        | 分组Name |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                                  |
+| Name                | Type     | Description                                  |
 |--------------------|----------|-------------------------------------|
 | `id`               | `string` | beta配置的存储ID。                        |
 | `dataId`           | `string` | 配置的dataId。                          |
 | `groupName`        | `string` | 配置的groupName。                       |
 | `namespaceId`      | `string` | 配置所属的命名空间。                          |
-| `desc`             | `string` | 配置描述。                               |
+| `desc`             | `string` | 配置Description。                               |
 | `md5`              | `string` | 配置内容的MD5值。                          |
 | `configTags`       | `string` | 配置的标签。                              |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。              |
-| `appName`          | `string` | 配置所属的应用名称。                          |
-| `type`             | `string` | 配置类型。                               |
+| `appName`          | `string` | 配置所属的应用Name。                          |
+| `type`             | `string` | 配置Type。                               |
 | `createTime`       | `integer` | 配置创建时间。                             |
 | `modifyTime`       | `integer` | 配置修改时间。                             |
 | `createUser`       | `string` | 配置创建人。                              |
 | `createIp`         | `string` | 配置创建IP。                             |
-| `grayName`         | `string` | 灰度发布规则名称, 固定为`beta`。                |
+| `grayName`         | `string` | 灰度发布规则Name, 固定为`beta`。                |
 | `grayRule`         | `string` | 灰度发布规则，格式为JSON，其中的`expr`为beta的ip列表。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=public&dataId=example&groupName=DEFAULT_GROUP'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4342,46 +4342,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=pub
 
 ### 3.9 导入并发布配置
 
-#### 接口描述
+#### Description
 
 导入配置并发布到指定命名空间
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 Request body type: `multipart/form-data`. Parameters are sent in the request body.
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/import`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型               | 是否必填 | 默认值      | 描述     |
+| Name           | Type               | Required | Default      | Description     |
 |---------------|--------------------|------|----------|--------|
-| `namespaceId` | `string` | 否 | `public` |
-| `src_user` | `string` | 否 | 无 |
-| `policy` | `string` | 否 | `ABORT` |
-| `file` | `MultipartFile` | 否 | ZIP file containing skill package |
+| `namespaceId` | `string` | No | `public` |
+| `src_user` | `string` | No | None |
+| `policy` | `string` | No | `ABORT` |
+| `file` | `MultipartFile` | No | ZIP file containing skill package |
 
-#### 返回数据
+#### Response Data
 
-| 参数名              | 参数类型                  | 描述     |
+| Name              | Type                  | Description     |
 |------------------|-----------------------|--------|
 | `data`           | `map<string, object>` | Import result. |
 | `data.succCount` | `integer` | 成功导入数量 |
 | `data.skipCount` | `integer` | 跳过导入数量 |
 
-#### 示例
+#### Examples
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/import' \
@@ -4390,7 +4390,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/import' \
 -F 'file=@/path/to/config.zip'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4405,45 +4405,45 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/import' \
 
 ### 3.10 导出配置
 
-#### 接口描述
+#### Description
 
 导出指定配置为ZIP文件。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/export`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型         | 是否必填 | 默认值      | 描述     |
+| Name           | Type         | Required | Default      | Description     |
 |---------------|--------------|------|----------|--------|
-| `namespaceId` | `string` | 否 | `public` |
-| `groupName` | `string` | 否 | `""` |
-| `dataId` | `string` | 否 | `""` |
-| `ids` | `array` | 否 | None |
-| `appName` | `string` | 否 | - |
+| `namespaceId` | `string` | No | `public` |
+| `groupName` | `string` | No | `""` |
+| `dataId` | `string` | No | `""` |
+| `ids` | `array` | No | None |
+| `appName` | `string` | No | - |
 
 > 使用时建议分开使用 `ids` 和 `dataId` + `groupName` 的组合，只选择一种方式，另一类传入空字符串，否则可能导致导出文件为空内容。
 
-#### 返回数据
+#### Response Data
 
 返回体为ZIP文件，包含配置内容和元数据
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/export?namespaceId=public&ids=' --output config.zip
@@ -4451,50 +4451,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/export?namespaceId=p
 
 ### 3.11 克隆配置
 
-#### 接口描述
+#### Description
 
 克隆配置到指定命名空间
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/clone`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名       | 参数类型               | 是否必填 | 默认值     | 描述       |
+| Name       | Type               | Required | Default     | Description       |
 |-----------|--------------------|------|---------|----------|
-| `namespaceId` | `string` | **是** | `public` |
-| `policy` | `string` | 否 | `ABORT` |
-| `src_user` | `string` | 否 | - |
+| `namespaceId` | `string` | **Yes** | `public` |
+| `policy` | `string` | No | `ABORT` |
+| `src_user` | `string` | No | - |
 
-#### 请求参数
+#### Request Parameters
 
-请求体类型为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
+请求体Type为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型      | 描述     |
+| Name         | Type      | Description     |
 |-------------|-----------|--------|
 | `succCount` | `integer` | 成功导入数量 |
 | `skipCount` | `integer` | 跳过导入数量 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespaceId=test&policy=ABORT" \
@@ -4502,7 +4502,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 -d "[{\"cfgId\":\"838029534438625280\",\"dataId\":\"111\",\"group\":\"DEFAULT_GROUP\"},{\"cfgId\":\"838033747294031872\",\"dataId\":\"qtc-user.yaml\",\"group\":\"DEFAULT_GROUP\"}]"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4517,41 +4517,41 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 
 ### 3.12. 查询配置历史列表
 
-#### 接口描述
+#### Description
 
 获取指定配置的历史版本列表
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填    | 默认值             | 参数描述  |
+| Name           | Type       | Required    | Default             | Description  |
 |---------------|----------|-------|-----------------|-------|
-| `namespaceId` | `string` | 否     | `public`        | 命名空间  |
-| `groupName`   | `string` | **是** | 无               | 配置分组名 |
-| `dataId`      | `string` | **是** | 无               | 配置名   |
-| `pageNo`      | `integer` | **是** | `1`             | 当前页   |
-| `pageSize`    | `integer` | **是** | `100`（最大为`500`） | 页条目数  |
+| `namespaceId` | `string` | No     | `public`        | 命名空间  |
+| `groupName`   | `string` | **Yes** | None               | 配置分组名 |
+| `dataId`      | `string` | **Yes** | None               | 配置名   |
+| `pageNo`      | `integer` | **Yes** | `1`             | 当前页   |
+| `pageSize`    | `integer` | **Yes** | `100`（最大为`500`） | 页条目数  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                                |
+| Name                          | Type     | Description                                |
 |------------------------------|----------|-----------------------------------|
 | `totalCount`                 | `integer` | 历史记录的总数。                          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。                      |
@@ -4562,22 +4562,22 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 | `pageItems`[i].`groupName`   | `string` | 配置的groupName。                     |
 | `pageItems`[i].`namespaceId` | `string` | 配置所属的命名空间。                        |
 | `pageItems`[i].`appName`     | `string` | 配置所属的appName。                     |
-| `pageItems`[i].`opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。        |
-| `pageItems`[i].`publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。 |
+| `pageItems`[i].`opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。        |
+| `pageItems`[i].`publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。 |
 | `pageItems`[i].`srcIp`       | `string` | 发布的来源IP。                          |
 | `pageItems`[i].`srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。       |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                           |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                           |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public&pageNo=1&pageSize=100'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4625,40 +4625,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.e
 
 ### 3.13. 查询配置某一历史版本详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的某次历史变更记录。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名         | 类型       | 必填    | 默认值      | 参数描述   |
+| Name         | Type       | Required    | Default      | Description   |
 |-------------|----------|-------|----------|--------|
-| namespaceId | `string` | 否     | `public` | 命名空间   |
-| groupName   | `string` | **是** | 无        | 配置分组名  |
-| dataId      | `string` | **是** | 无        | 配置名    |
-| nid         | `integer` | **是** | 无        | 配置历史Id |
+| namespaceId | `string` | No     | `public` | 命名空间   |
+| groupName   | `string` | **Yes** | None        | 配置分组名  |
+| dataId      | `string` | **Yes** | None        | 配置名    |
+| nid         | `integer` | **Yes** | None        | 配置历史Id |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -4666,24 +4666,24 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.e
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupName=DEFAULT_GROUP&nid=7'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4713,40 +4713,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupN
 
 ### 3.14. 查询配置上一版本信息
 
-#### 接口描述
+#### Description
 
 获取指定配置的上一版本
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history/previous`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名         | 类型       | 必填    | 默认值      | 参数描述  |
+| Name         | Type       | Required    | Default      | Description  |
 |-------------|----------|-------|----------|-------|
-| namespaceId | `string` | 否     | `public` | 命名空间  |
-| groupName   | `string` | **是** | 无        | 配置分组名 |
-| dataId      | `string` | **是** | 无        | 配置名   |
-| id          | `integer` | **是** | 无        | 配置Id  |
+| namespaceId | `string` | No     | `public` | 命名空间  |
+| groupName   | `string` | **Yes** | None        | 配置分组名 |
+| dataId      | `string` | **Yes** | None        | 配置名   |
+| id          | `integer` | **Yes** | None        | 配置Id  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -4754,24 +4754,24 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupN
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/previous?id=101&dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4801,52 +4801,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/previous?id=101&dat
 
 ### 3.15. 查询指定命名空间下的配置列表
 
-#### 接口描述
+#### Description
 
 获取指定命名空间下的配置信息列表
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history/configs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名         | 类型       | 必填    | 默认值 | 参数描述 |
+| Name         | Type       | Required    | Default | Description |
 |-------------|----------|-------|-----|------|
-| namespaceId | `string` | **是** | 无   | 命名空间 |
+| namespaceId | `string` | **Yes** | None   | 命名空间 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型     | 描述            |
+| Name         | Type     | Description            |
 |-------------|----------|---------------|
 | `dataId`    | `string` | 配置的dataId。    |
 | `groupName` | `string` | 配置的groupName。 |
 
 > 其他字段均无用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/configs?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4881,43 +4881,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/configs?namespaceId
 
 ### 3.16 查询容量信息
 
-#### 接口描述
+#### Description
 
 查询指定分组或命名空间的容量信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/capacity`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填 | 默认值 | 描述     |
+| Name           | Type     | Required | Default | Description     |
 |---------------|----------|------|-----|--------|
-| `groupName`   | `string` | 否    | 无   | 分组名称   |
-| `namespaceId` | `string` | 否    | 无   | 命名空间ID |
+| `groupName`   | `string` | No    | None   | 分组Name   |
+| `namespaceId` | `string` | No    | None   | 命名空间ID |
 
 **注意** ：`groupName` 和 `namespaceId` 至少需要提供一个。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型      | 描述         |
+| Name                | Type      | Description         |
 |--------------------|-----------|------------|
 | `id`               | `integer` | 容量信息的唯一ID  |
-| `groupName`        | `string` | 分组名称       |
+| `groupName`        | `string` | 分组Name       |
 | `namespaceId`      | `string` | 命名空间ID     |
 | `quota`            | `integer` | 配额         |
 | `usage`            | `integer` | 当前使用量      |
@@ -4927,15 +4927,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/configs?namespaceId
 | ~~`maxAggrCount`~~ | `integer` | 未使用，将废弃    |
 | ~~`maxAggrSize`~~  | `integer` | 未使用，将废弃    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4957,52 +4957,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity?namespaceId=public
 
 ### 3.17 更新容量信息
 
-#### 接口描述
+#### Description
 
 更新指定分组或命名空间的容量信息。如果容量信息未初始化，则会自动初始化
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/capacity`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 描述                   |
+| Name           | Type      | Required  | Description                   |
 |---------------|-----------|-------|----------------------|
-| `groupName` | `string` | **是** | 分组名称，与命名空间ID 两者必须有其一 |
-| `namespaceId` | `string` | 否 | 命名空间ID，与分组名称 两者必须有其一 |
-| `quota` | `integer` | 否 | 配额 |
-| `maxSize` | `integer` | 否 | 最大大小 |
-| `maxAggrCount` | `integer` | 否 | - |
-| `maxAggrSize` | `integer` | 否 | - |
+| `groupName` | `string` | **Yes** | 分组Name，与命名空间ID 两者必须有其一 |
+| `namespaceId` | `string` | No | 命名空间ID，与分组Name 两者必须有其一 |
+| `quota` | `integer` | No | 配额 |
+| `maxSize` | `integer` | No | 最大大小 |
+| `maxAggrCount` | `integer` | No | - |
+| `maxAggrSize` | `integer` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity' -d 'namespaceId=public&quota=200&maxSize=2048'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5014,45 +5014,45 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity' -d 'namespaceId=
 
 ### 3.18 手动触发本地缓存更新
 
-#### 接口描述
+#### Description
 
 手动触发从存储中加载所有配置数据到本地缓存。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/localCache`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述   |
+| Name    | Type     | Description   |
 |--------|----------|------|
 | `data` | `string` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/localCache'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5064,48 +5064,48 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/localCache'
 
 ### 3.19 设置日志级别
 
-#### 接口描述
+#### Description
 
 动态设置指定模块的日志级别
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/log`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填  | 默认值 | 描述                    |
+| Name        | Type     | Required  | Default | Description                    |
 |------------|----------|-------|-----|-----------------------|
-| `logName`  | `string` | **是** | 无   | 模块名称                  |
-| `logLevel` | `string` | **是** | 无   | 日志级别（如`INFO`、`DEBUG`） |
+| `logName`  | `string` | **Yes** | None   | 模块Name                  |
+| `logLevel` | `string` | **Yes** | None   | 日志级别（如`INFO`、`DEBUG`） |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述   |
+| Name    | Type     | Description   |
 |--------|----------|------|
 | `data` | `string` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/log' -d "logName=config-server&logLevel=DEBUG"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5117,49 +5117,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/log' -d "logName=config
 
 ### 3.20 执行Derby数据库操作
 
-#### 接口描述
+#### Description
 
 执行Derby数据库的查询操作（仅支持 `SELECT` 语句）
 
 > **注意** 此接口需要开启`nacos.config.derby.ops.enabled`配置，且数据库为`Derby` 时才可使用，仅提供给运维人员进行Derby数据库排查数据问题时使用。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/derby`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 参数类型     | 是否必填  | 默认值 | 描述       |
+| Name   | Type     | Required  | Default | Description       |
 |-------|----------|-------|-----|----------|
-| `sql` | `string` | **是** | 无   | SQL 查询语句 |
+| `sql` | `string` | **Yes** | None   | SQL 查询语句 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型                        | 描述   |
+| Name    | Type                        | Description   |
 |--------|-----------------------------|------|
 | `data` | `array` | Query result. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby?sql=SELECT%20*%20FROM%20config_info'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5201,45 +5201,45 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby?sql=SELECT%20*%20
 
 ### 3.21 导入Derby数据库数据
 
-#### 接口描述
+#### Description
 
 从外部数据源导入数据到Derby数据库
 
 > **注意** 此接口需要开启`nacos.config.derby.ops.enabled`配置，且数据库为`Derby` 时才可使用，仅提供给运维人员进行Derby数据库排查数据问题时使用。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-请求体类型：`multipart/form-data`，参数放在请求体中。
+请求体Type：`multipart/form-data`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/derby/import`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名    | 参数类型            | 是否必填 | 默认值 | 描述           |
+| Name    | Type            | Required | Default | Description           |
 |--------|-----------------|------|-----|--------------|
-| `file` | `MultipartFile` | 否    | 无   | 导入文件（SQL 文件）。 |
+| `file` | `MultipartFile` | No    | None   | 导入文件（SQL 文件）。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 导入结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby/import' \
@@ -5247,7 +5247,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby/import' \
 -F 'file=@data.sql'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5259,53 +5259,53 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby/import' \
 
 ### 3.22 获取客户端订阅信息
 
-#### 接口描述
+#### Description
 
 获取指定 IP 客户端的订阅配置信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/listener`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值      | 描述         |
+| Name           | Type      | Required  | Default      | Description         |
 |---------------|-----------|-------|----------|------------|
-| `ip`          | `string` | **是** | 无        | 客户端 IP 地址  |
-| `all`         | `boolean` | 否     | `false`  | 是否返回所有配置信息 |
-| `namespaceId` | `string` | 否     | `public` | 命名空间ID     |
-| `aggregation` | `boolean` | 否     | `true`   | 是否从其他节点聚合  |
+| `ip`          | `string` | **Yes** | None        | 客户端 IP 地址  |
+| `all`         | `boolean` | No     | `false`  | 是否返回所有配置信息 |
+| `namespaceId` | `string` | No     | `public` | 命名空间ID     |
+| `aggregation` | `boolean` | No     | `true`   | 是否从其他节点聚合  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                                                            |
+| Name               | Type                  | Description                                                                            |
 |-------------------|-----------------------|-------------------------------------------------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`ip`。                                                             |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`ip`。                                                             |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅的配置信息，格式为`dataId`+`groupName`+`namespaceId`，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/listener?ip=127.0.0.1&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5322,40 +5322,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/listener?ip=127.0.0.1&names
 
 ### 3.23 获取集群客户端指标
 
-#### 接口描述
+#### Description
 
 获取集群中指定 IP 客户端的配置指标信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/metrics/cluster`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **默认值**  | **描述**    |
+| **Name**       | **Type** | **Required** | **Default**  | **Description**    |
 |---------------|----------|----------|----------|-----------|
-| `ip`          | `string` | **是**    | 无        | 客户端 IP 地址 |
-| `dataId`      | `string` | 否        | 无        | 配置ID      |
-| `groupName`   | `string` | 否        | 无        | 分组名称      |
-| `namespaceId` | `string` | 否        | `public` | 命名空间ID    |
+| `ip`          | `string` | **Yes**    | None        | 客户端 IP 地址 |
+| `dataId`      | `string` | No        | None        | 配置ID      |
+| `groupName`   | `string` | No        | None        | 分组Name      |
+| `namespaceId` | `string` | No        | `public` | 命名空间ID    |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                            | 参数类型      | 描述说明     |
+| Name                                            | Type      | Description     |
 |------------------------------------------------|-----------|----------|
 | `data`                                         |           | 服务信息     |
 | `data.{namespaceId}.isFixedServer`             | `boolean` | 是否固定服务器  |
@@ -5366,15 +5366,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/listener?ip=127.0.0.1&names
 | `data.{namespaceId}.metricValues.cacheData`    | `string` | 缓存数据md5值 |
 | `data.{namespaceId}.metricValues.snapshotData` | `string` | 快照数据md5值 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.1&dataId=example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5398,40 +5398,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.
 
 ### 3.24 获取本地客户端指标
 
-#### 接口描述
+#### Description
 
 获取本地机器上指定 IP 客户端指标信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/metrics/ip`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **默认值**  | **描述**    |
+| **Name**       | **Type** | **Required** | **Default**  | **Description**    |
 |---------------|----------|----------|----------|-----------|
-| `ip`          | `string` | **是**    | 无        | 客户端 IP 地址 |
-| `dataId`      | `string` | 否        | 无        | 配置ID      |
-| `groupName`   | `string` | 否        | 无        | 分组名称      |
-| `namespaceId` | `string` | 否        | `public` | 命名空间      |
+| `ip`          | `string` | **Yes**    | None        | 客户端 IP 地址 |
+| `dataId`      | `string` | No        | None        | 配置ID      |
+| `groupName`   | `string` | No        | None        | 分组Name      |
+| `namespaceId` | `string` | No        | `public` | 命名空间      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                            | 参数类型      | 描述说明     |
+| Name                                            | Type      | Description     |
 |------------------------------------------------|-----------|----------|
 | `data`                                         |           | 服务信息     |
 | `data.{namespaceId}.isFixedServer`             | `boolean` | 是否固定服务器  |
@@ -5442,15 +5442,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.
 | `data.{namespaceId}.metricValues.cacheData`    | `string` | 缓存数据md5值 |
 | `data.{namespaceId}.metricValues.snapshotData` | `string` | 快照数据md5值 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/ip?ip=127.0.0.1&dataId=example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5474,47 +5474,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/ip?ip=127.0.0.1&dat
 
 ### 3.25. 更新配置元数据
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新配置的元数据信息：仅能更新`描述`和`标签`。
+通过该接口，可以更新配置的元数据信息：仅能更新`Description`和`标签`。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/metadata`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **默认值**  | **描述** |
+| **Name**       | **Type** | **Required** | **Default**  | **Description** |
 |---------------|----------|----------|----------|--------|
-| `dataId`      | `string` | **是**    | 无        | 配置ID   |
-| `groupName`   | `string` | **是**    | 无        | 分组名称   |
-| `namespaceId` | `string` | 否        | `public` | 命名空间   |
-| `desc`        | `string` | 否        | null     | 配置的新描述 |
-| `configTags`  | `string` | 否        | null     | 配置的新标签 |
+| `dataId`      | `string` | **Yes**    | None        | 配置ID   |
+| `groupName`   | `string` | **Yes**    | None        | 分组Name   |
+| `namespaceId` | `string` | No        | `public` | 命名空间   |
+| `desc`        | `string` | No        | null     | 配置的新Description |
+| `configTags`  | `string` | No        | null     | 配置的新标签 |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT '127.0.0.1:8848/v3/admin/cs/config/metadata' \
@@ -5524,7 +5524,7 @@ curl -X PUT '127.0.0.1:8848/v3/admin/cs/config/metadata' \
 -d 'desc=testDesc' \
 -d 'configTags=customTag'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5536,38 +5536,38 @@ curl -X PUT '127.0.0.1:8848/v3/admin/cs/config/metadata' \
 
 ### 3.26. Get Gray Configuration
 
-#### 接口描述
+#### Description
 
 This interface retrieves the details of a specified gray configuration.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/gray`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public` when omitted. |
-| `groupName` | `string` | **是** | Configuration group name. |
-| `dataId` | `string` | **是** | Configuration ID. |
-| `grayName` | `string` | **是** | Gray configuration name. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public` when omitted. |
+| `groupName` | `string` | **Yes** | Configuration group name. |
+| `dataId` | `string` | **Yes** | Configuration ID. |
+| `grayName` | `string` | **Yes** | Gray configuration name. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.dataId | `string` | Configuration ID. |
 | data.groupName | `string` | Configuration group name. |
@@ -5576,15 +5576,15 @@ This interface retrieves the details of a specified gray configuration.
 | data.grayName | `string` | Gray configuration name. |
 | data.grayRule | `string` | Gray matching rule. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=public&groupName=DEFAULT_GROUP&dataId=example&grayName=gray'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5596,52 +5596,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=pub
 
 ### 3.27. Publish Gray Configuration
 
-#### 接口描述
+#### Description
 
 This interface publishes a gray configuration using tagv2 gray matching rules.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/gray`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public` when omitted. |
-| `groupName` | `string` | **是** | Configuration group name. |
-| `dataId` | `string` | **是** | Configuration ID. |
-| `content` | `string` | **是** | Gray configuration content. |
-| `grayName` | `string` | **是** | Gray configuration name. |
-| `grayType` | `string` | 否 | Gray rule type. |
-| `grayMatchRuleExp` | `string` | **是** | Gray matching rule expression. |
-| `grayVersion` | `string` | **是** | Gray version. |
-| `grayPriority` | `integer` | 否 | Gray rule priority. |
-| `type` | `string` | 否 | Configuration type. |
-| `srcUser` | `string` | 否 | Operator username. |
-| `encryptedDataKey` | `string` | 否 | Data key for encrypted configuration content. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public` when omitted. |
+| `groupName` | `string` | **Yes** | Configuration group name. |
+| `dataId` | `string` | **Yes** | Configuration ID. |
+| `content` | `string` | **Yes** | Gray configuration content. |
+| `grayName` | `string` | **Yes** | Gray configuration name. |
+| `grayType` | `string` | No | Gray rule type. |
+| `grayMatchRuleExp` | `string` | **Yes** | Gray matching rule expression. |
+| `grayVersion` | `string` | **Yes** | Gray version. |
+| `grayPriority` | `integer` | No | Gray rule priority. |
+| `type` | `string` | No | Configuration type. |
+| `srcUser` | `string` | No | Operator username. |
+| `encryptedDataKey` | `string` | No | Data key for encrypted configuration content. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | Whether the gray configuration was published successfully. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray' \
@@ -5656,7 +5656,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray' \
   -d 'grayPriority=1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5668,50 +5668,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray' \
 
 ### 3.28. Delete Gray Configuration
 
-#### 接口描述
+#### Description
 
 This interface deletes a specified gray configuration.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/gray`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public` when omitted. |
-| `groupName` | `string` | **是** | Configuration group name. |
-| `dataId` | `string` | **是** | Configuration ID. |
-| `grayName` | `string` | **是** | Gray configuration name. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public` when omitted. |
+| `groupName` | `string` | **Yes** | Configuration group name. |
+| `dataId` | `string` | **Yes** | Configuration ID. |
+| `grayName` | `string` | **Yes** | Gray configuration name. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | Whether the gray configuration was deleted successfully. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=public&groupName=DEFAULT_GROUP&dataId=example&grayName=gray'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5725,41 +5725,41 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=
 
 ### 4.1. 查询MCP服务的服务列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的MCP服务的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                                     |
+| Name           | Type     | Required  | Description                                                     |
 |---------------|----------|-------|--------------------------------------------------------|
-| `pageNo` | `integer` | **是** | 当前页，默认为`1` |
-| `pageSize` | `integer` | **是** | 页条目数，默认为`20`，最大为`500` |
-| `namespaceId` | `string` | 否 | MCP服务的命名空间ID，默认为`public` |
-| `mcpName` | `string` | 否 | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
-| `search` | `string` | 否 | Search mode: `blur` or `accurate`. Defaults to `blur`. |
+| `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
+| `pageSize` | `integer` | **Yes** | 页条目数，默认为`20`，最大为`500` |
+| `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
+| `mcpName` | `string` | No | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
+| `search` | `string` | No | Search mode: `blur` or `accurate`. Defaults to `blur`. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                           | 参数类型                  | 描述                                                                                              |
+| Name                                           | Type                  | Description                                                                                              |
 |-----------------------------------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `totalCount`                                  | `integer` | 符合条件的服务的总数。                                                                                     |
 | `pageNumber`                                  | `integer` | 当前页码，起始为`1`。                                                                                    |
@@ -5780,20 +5780,20 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP service version.       |
 | `release_date` | `string` | MCP service release time.  |
 | `is_latest`    | `boolean` | Whether this is the latest version of the MCP service. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5836,47 +5836,47 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&nam
 
 ### 4.2. 查询MCP服务的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定MCP服务的服务的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
-| `mcpId`       | `string` | 否     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
-| `mcpName`     | `string` | 否     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是返回最新版本                      |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
+| `mcpId`       | `string` | No     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
+| `mcpName`     | `string` | No     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
+| `version`     | `string` | No     | MCP服务的版本，未传入是返回最新版本                      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID。                                                                               |
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `namespaceId`        | `string` | MCP服务所属的命名空间ID。                                                                                 |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的描述。                                                                                       |
+| `description`        | `string` | MCP服务的Description。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |                                                                                          |
 | `versionDetail`      | `object`              | Queried version information of the MCP service.                                                        |
 | `localServerConfig`  | `map<string, object>` | Startup information for a local MCP service when the MCP service type is **stdio**.                    |
@@ -5889,20 +5889,20 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&nam
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP service version.       |
 | `release_date` | `string` | MCP service release time.  |
 | `is_latest`    | `boolean` | Whether this is the latest version of the MCP service. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5942,48 +5942,48 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 ### 4.3. 更新MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                             |
+| Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
-| `namespaceId` | `string` | 否 | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **是** | MCP服务的描述详情 |
-| `toolSpecification` | `string` | 否 | MCP服务的工具描述详情 |
-| `endpointSpecification` | `string` | 否 | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
-| `overrideExisting` | `boolean` | 否 | MCP服务更新时是否覆盖原 endpointSpecification，仅在非`stdio`协议时生效 |
-| `latest` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
+| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
+| `overrideExisting` | `boolean` | No | MCP服务更新时是否覆盖原 endpointSpecification，仅在非`stdio`协议时生效 |
+| `latest` | `boolean` | No | - |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，必须传入，用于定位待更新的MCP服务。                                                            |
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的描述。                                                                                       |
+| `description`        | `string` | MCP服务的Description。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -5994,7 +5994,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -6002,7 +6002,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `array`                   | Tool list provided by the MCP Server. See the standard MCP protocol definition of MCP Tool. |
 | `toolsMeta`       | `map<string, object>`     | Extra metadata for tools provided by the MCP Server. This can extend information not defined in the standard MCP protocol. The key is the `name` of `McpTool`, and the value is the extended metadata. |
@@ -6010,15 +6010,15 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的名称                                     |
-| `description` | `string` | MCP 工具的描述                                     |
+| `name`        | `string` | MCP 工具的Name                                     |
+| `description` | `string` | MCP 工具的Description                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -6026,33 +6026,33 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
+| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务更新结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
@@ -6060,7 +6060,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"d7a64724-a556-4fe4-82fa-e806d43e00dc","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6072,46 +6072,46 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 ### 4.4. 创建MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的MCP服务，可以是存量API转换的MCP服务，也可以是MCP市场中的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                             |
+| Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
-| `namespaceId` | `string` | 否 | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **是** | MCP服务的描述详情 |
-| `toolSpecification` | `string` | 否 | MCP服务的工具描述详情 |
-| `endpointSpecification` | `string` | 否 | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
+| `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
+| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，无需传入，系统自动生成。                                                                   |
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的描述。                                                                                       |
+| `description`        | `string` | MCP服务的Description。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -6122,7 +6122,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -6130,7 +6130,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `array`                   | Tool list provided by the MCP Server. See the standard MCP protocol definition of MCP Tool. |
 | `toolsMeta`       | `map<string, object>`     | Extra metadata for tools provided by the MCP Server. This can extend information not defined in the standard MCP protocol. The key is the `name` of `McpTool`, and the value is the extended metadata. |
@@ -6138,15 +6138,15 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的名称                                     |
-| `description` | `string` | MCP 工具的描述                                     |
+| `name`        | `string` | MCP 工具的Name                                     |
+| `description` | `string` | MCP 工具的Description                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -6154,33 +6154,33 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
+| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 新建MCP服务的id。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
@@ -6188,7 +6188,7 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6200,51 +6200,51 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 ### 4.5. 删除MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
-| `mcpId`       | `string` | 否     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
-| `mcpName`     | `string` | 否     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是为最新版本                       |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
+| `mcpId`       | `string` | No     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
+| `mcpName`     | `string` | No     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
+| `version`     | `string` | No     | MCP服务的版本，未传入是为最新版本                       |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6258,52 +6258,52 @@ curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=
 
 ### 5.1. 查询指定AgentCard的版本列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定托管在Nacos上的AgentCard的版本列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a/version/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的Name                |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                   | 参数类型      | 描述              |
+| Name                   | Type      | Description              |
 |-----------------------|-----------|-----------------|
 | `data`[i].`version`   | `string` | AgentCard的版本号。  |
 | `data`[i].`createdAt` | `string` | 该版本的创建时间。       |
 | `data`[i].`updatedAt` | `string` | 该版本的最后更新时间。     |
 | `data`[i].`latest`    | `boolean` | 该版本是否标记为最新发布版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6320,41 +6320,41 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=publi
 
 ### 5.2. 查询AgentCard的列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的AgentCard的列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                              |
+| Name           | Type     | Required  | Description                                              |
 |---------------|----------|-------|-------------------------------------------------|
-| `pageNo` | `integer` | **是** | 当前页，默认为`1` |
-| `pageSize` | `integer` | **是** | 页条目数，默认为`100` |
-| `namespaceId` | `string` | 否 | AgentCard的命名空间ID，默认为`public` |
-| `agentName` | `string` | 否 | AgentCard的名称，为空是查询所有AgentCard |
-| `search` | `string` | 否 | blur or accurate |
+| `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
+| `pageSize` | `integer` | **Yes** | 页条目数，默认为`100` |
+| `namespaceId` | `string` | No | AgentCard的命名空间ID，默认为`public` |
+| `agentName` | `string` | No | AgentCard的Name，为空是查询所有AgentCard |
+| `search` | `string` | No | blur or accurate |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                     | 参数类型                       | 描述                                                                                                     |
+| Name                                     | Type                       | Description                                                                                                     |
 |-----------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------|
 | `totalCount`                            | `integer` | 符合条件的服务的总数。                                                                                            |
 | `pageNumber`                            | `integer` | 当前页码，起始为`1`。                                                                                           |
@@ -6373,21 +6373,21 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=publi
 
 其中`AgentVersionDetail`包含内容如下：
 
-| 参数名         | 参数类型      | 描述              |
+| Name         | Type      | Description              |
 |-------------|-----------|-----------------|
 | `version`   | `string` | AgentCard version. |
 | `createdAt` | `string` | Creation time of this version. |
 | `updatedAt` | `string` | Last update time of this version. |
 | `latest`    | `boolean` | Whether this version is marked as the latest published version. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6441,44 +6441,44 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 
 ### 5.3. 查询AgentCard的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定AgentCard的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型     | 是否必填  | 描述                                                                                 |
+| Name                | Type     | Required  | Description                                                                                 |
 |--------------------|----------|-------|------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                        |
-| `agentName`        | `string` | **是** | AgentCard的名称                                                                       |
-| `version`          | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情                                                          |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                        |
+| `agentName`        | `string` | **Yes** | AgentCard的Name                                                                       |
+| `version`          | `string` | No     | AgentCard的版本号，为空时返回最新版本详情                                                          |
+| `registrationType` | `string` | No     | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                 | 参数类型                              | 描述                                                                                                       |
+| Name                                 | Type                              | Description                                                                                                       |
 |-------------------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `protocolVersion`                   | `string` | AgentCard的A2A协议版本。                                                                                       |
-| `name`                              | `string` | AgentCard的名称。                                                                                            |
-| `description`                       | `string` | AgentCard的描述。                                                                                            |
+| `name`                              | `string` | AgentCard的Name。                                                                                            |
+| `description`                       | `string` | AgentCard的Description。                                                                                            |
 | `version`                           | `string` | AgentCard的版本号。                                                                                           |
 | `iconUrl`                           | `string` | AgentCard的iconURL。                                                                                       |
 | `capabilities`                      | `object`                         | AgentCard capabilities, matching [A2A standard capabilities](https://a2a-protocol.org/latest/specification/#552-agentcapabilities-object). |
@@ -6493,17 +6493,17 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | `defaultInputModes`                 | `array`                          | All default input modes of the AgentCard. |
 | `defaultOutputModes`                | `array`                          | All default output modes of the AgentCard. |
 | `supportsAuthenticatedExtendedCard` | `string` | AgentCard是否支持认证的扩展卡。                                                                                     |
-| `registrationType`                  | `string` | AgentCard的默认注册类型，可选`URL`和`SERVICE`。                                                                      |
+| `registrationType`                  | `string` | AgentCard的默认注册Type，可选`URL`和`SERVICE`。                                                                      |
 | `latestVersion`                     | `string` | AgentCard当前版本时否为最新版本。                                                                                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0&registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6575,46 +6575,46 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 
 ### 5.4. 更新AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId` | `string` | 否 | AgentCard所属的命名空间，默认`public` |
-| `agentCard` | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否 | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
-| `setAsLatest` | `boolean` | 否 | 是否设置此版本为最新发布版本，默认为false |
+| `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
+| `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `setAsLatest` | `boolean` | No | 是否设置此版本为最新发布版本，默认为false |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述               |
+| Name    | Type     | Description               |
 |--------|----------|------------------|
 | `data` | `string` | AgentCard服务更新结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
@@ -6623,7 +6623,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'registrationType=SERVICE' \
 -d 'setAsLatest=true'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6635,45 +6635,45 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 
 ### 5.5. 创建AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId` | `string` | 否 | AgentCard所属的命名空间，默认`public` |
-| `agentCard` | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否 | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认值为`URL` |
+| `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
+| `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, Default为`URL` |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard发布结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
@@ -6681,7 +6681,7 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \ 
 -d 'registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6693,50 +6693,50 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 
 ### 5.6. 删除AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
-| `version`     | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情   |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的Name                |
+| `version`     | `string` | No     | AgentCard的版本号，为空时返回最新版本详情   |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6750,53 +6750,53 @@ curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentNam
 
 ### 6.1. Publish Prompt
 
-#### 接口描述
+#### Description
 
 This API publishes a new Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. Defaults to `public`. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version. |
-| `template` | `string` | 否 | Template content. |
-| `commitMsg` | `string` | 否 | Commit message. |
-| `description` | `string` | 否 | Description. |
-| `bizTags` | `string` | 否 | Business tags. |
-| `variables` | `string` | 否 | Prompt template variable definitions as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. Defaults to `public`. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version. |
+| `template` | `string` | No | Template content. |
+| `commitMsg` | `string` | No | Commit message. |
+| `description` | `string` | No | Description. |
+| `bizTags` | `string` | No | Business tags. |
+| `variables` | `string` | No | Prompt template variable definitions as a JSON string. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt' \
   -d 'namespaceId=public' -d 'promptKey=my-prompt' -d 'version=1.0.0' -d 'template=hello'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6808,46 +6808,46 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt' \
 
 ### 6.2. Delete Prompt
 
-#### 接口描述
+#### Description
 
 This API deletes the specified Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6859,49 +6859,49 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt?namespaceId=publi
 
 ### 6.3. Get Prompt Detail
 
-#### 接口描述
+#### Description
 
 This API queries Prompt details by version or label.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version. |
-| `label` | `string` | 否 | Label. |
-| `md5` | `string` | 否 | Content MD5. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version. |
+| `label` | `string` | No | Label. |
+| `md5` | `string` | No | Content MD5. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` contains fields such as `promptKey`, `version`, `template`, `commitMsg`, and `md5`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` contains fields such as `promptKey`, `version`, `template`, `commitMsg`, and `md5`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/detail?namespaceId=public&promptKey=my-prompt&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6917,49 +6917,49 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/detail?namespaceId=p
 
 ### 6.4. Bind Label
 
-#### 接口描述
+#### Description
 
 This API binds a label to the specified Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/label`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `label` | `string` | **是** | Label name. |
-| `version` | `string` | **是** | Version. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `label` | `string` | **Yes** | Label name. |
+| `version` | `string` | **Yes** | Version. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label' \
   -d 'namespaceId=public' -d 'promptKey=my-prompt' -d 'label=stable' -d 'version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6971,47 +6971,47 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label' \
 
 ### 6.5. Unbind Label
 
-#### 接口描述
+#### Description
 
 This API unbinds a label from a Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/label`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `label` | `string` | **是** | Label name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `label` | `string` | **Yes** | Label name. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label?namespaceId=public&promptKey=my-prompt&label=stable'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7023,50 +7023,50 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label?namespaceId
 
 ### 6.6. List Prompts
 
-#### 接口描述
+#### Description
 
 This API queries Prompts by page.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Number of records per page. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | 否 | Prompt key filter. |
-| `search` | `string` | 否 | Search mode: `blur` or `accurate`. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Number of records per page. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | No | Prompt key filter. |
+| `search` | `string` | No | Search mode: `blur` or `accurate`. |
+| `bizTags` | `string` | No | Business tags. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` is a paginated object that contains fields such as `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` is a paginated object that contains fields such as `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/list?pageNo=1&pageSize=10&namespaceId=public&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7088,46 +7088,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/list?pageNo=1&pageSi
 
 ### 6.7. Get Prompt Metadata
 
-#### 接口描述
+#### Description
 
 This API queries metadata of the specified Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/metadata`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` contains fields such as `promptKey`, `description`, `bizTags`, `latestVersion`, `versions`, and `labels`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` contains fields such as `promptKey`, `description`, `bizTags`, `latestVersion`, `versions`, and `labels`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7143,49 +7143,49 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata?namespaceId
 
 ### 6.8. Update Prompt Metadata
 
-#### 接口描述
+#### Description
 
 This API updates Prompt metadata, such as description and business tags.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/metadata`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `description` | `string` | 否 | Description. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `description` | `string` | No | Description. |
+| `bizTags` | `string` | No | Business tags. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata' \
   -d 'namespaceId=public' -d 'promptKey=my-prompt' -d 'description=desc'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7197,48 +7197,48 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata' \
 
 ### 6.9. List Prompt Versions
 
-#### 接口描述
+#### Description
 
 This API queries versions of the specified Prompt by page.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/versions`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Number of records per page. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Number of records per page. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` is a paginated object that contains `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`; each item contains fields such as `version`, `commitMsg`, and `gmtModified`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` is a paginated object that contains `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`; each item contains fields such as `version`, `commitMsg`, and `gmtModified`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/versions?namespaceId=public&promptKey=my-prompt&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7260,506 +7260,506 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/versions?namespaceId
 
 ### 6.10. Update Prompt Business Tags
 
-#### 接口描述
+#### Description
 
 This API updates Prompt business tags.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `bizTags` | `string` | No | Business tags. |
 
 ### 6.11. Update Prompt Description
 
-#### 接口描述
+#### Description
 
 This API updates the Prompt description.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/description`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `description` | `string` | **是** | Description. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `description` | `string` | **Yes** | Description. |
 
 ### 6.12. Create Prompt Draft
 
-#### 接口描述
+#### Description
 
 This API creates a Prompt draft version, or recreates a draft from an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `basedOnVersion` | `string` | 否 | Version to base the draft on. |
-| `targetVersion` | `string` | 否 | Target version. |
-| `template` | `string` | 否 | Template content. |
-| `variables` | `string` | 否 | Prompt template variable definitions as a JSON string. |
-| `commitMsg` | `string` | 否 | Commit message. |
-| `description` | `string` | 否 | Description. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `basedOnVersion` | `string` | No | Version to base the draft on. |
+| `targetVersion` | `string` | No | Target version. |
+| `template` | `string` | No | Template content. |
+| `variables` | `string` | No | Prompt template variable definitions as a JSON string. |
+| `commitMsg` | `string` | No | Commit message. |
+| `description` | `string` | No | Description. |
+| `bizTags` | `string` | No | Business tags. |
 
 ### 6.13. Update Prompt Draft
 
-#### 接口描述
+#### Description
 
 This API updates the current Prompt draft content.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `template` | `string` | **是** | Template content. |
-| `variables` | `string` | 否 | Prompt template variable definitions as a JSON string. |
-| `commitMsg` | `string` | 否 | Commit message. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `template` | `string` | **Yes** | Template content. |
+| `variables` | `string` | No | Prompt template variable definitions as a JSON string. |
+| `commitMsg` | `string` | No | Commit message. |
 
 ### 6.14. Delete Prompt Draft
 
-#### 接口描述
+#### Description
 
 This API deletes the current Prompt draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
 ### 6.15. Force Publish Prompt Version
 
-#### 接口描述
+#### Description
 
 This API force-publishes a Prompt version while bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 6.16. Get Prompt Governance Details
 
-#### 接口描述
+#### Description
 
 This API retrieves Prompt metadata, version governance information, and version summaries.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/governance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
 ### 6.17. Update Prompt Labels
 
-#### 接口描述
+#### Description
 
 This API updates the runtime routing labels of a Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `labels` | `string` | **是** | Label JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `labels` | `string` | **Yes** | Label JSON string. |
 
 ### 6.18. Offline Prompt Version
 
-#### 接口描述
+#### Description
 
 This API takes a specified Prompt version offline.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 6.19. Online Prompt Version
 
-#### 接口描述
+#### Description
 
 This API brings a specified Prompt version online.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 6.20. Publish Prompt Version
 
-#### 接口描述
+#### Description
 
 This API publishes an approved Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 6.21. Redraft Prompt Version
 
-#### 接口描述
+#### Description
 
 This API converts a reviewed Prompt version back to a draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 6.22. Submit Prompt Version for Review
 
-#### 接口描述
+#### Description
 
 This API submits a Prompt version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version number. |
 
 ### 6.23. Get Prompt Version Details
 
-#### 接口描述
+#### Description
 
 This API retrieves details of a specified Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version number. |
 
 ### 6.24. Download Prompt Version
 
-#### 接口描述
+#### Description
 
 This API downloads a specified Prompt version as a Markdown file.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version number. |
 
 ## 7. AI Skills Management
 
 ### 7.1. Get Skill Details
 
-#### 接口描述
+#### Description
 
 This API obtains the details of a specified skill by namespace and skill name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
 
-#### 返回数据
+#### Response Data
 
-The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` contains fields such as name, description, instruction, resource, version, inputModes, and outputModes.
+The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format). `data` contains fields such as name, description, instruction, resource, version, inputModes, and outputModes.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=public&skillName=my-skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7777,50 +7777,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=public&s
 
 ### 7.2. Create Skill Draft Version
 
-#### 接口描述
+#### Description
 
 This API creates a draft version of a skill based on an existing version or a new SkillCard.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | 否 | Skill name. |
-| `basedOnVersion` | `string` | 否 | Create the draft based on this version. |
-| `targetVersion` | `string` | 否 | Target version. |
-| `skillCard` | `string` | 否 | Skill card JSON; required if basedOnVersion is not set |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | No | Skill name. |
+| `basedOnVersion` | `string` | No | Create the draft based on this version. |
+| `targetVersion` | `string` | No | Target version. |
+| `skillCard` | `string` | No | Skill card JSON; required if basedOnVersion is not set |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as a string indicating the draft creation result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as a string indicating the draft creation result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
   -d 'namespaceId=public' -d 'skillName=my-skill' -d 'basedOnVersion=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7832,48 +7832,48 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
 
 ### 7.3. Update Skill Draft Content
 
-#### 接口描述
+#### Description
 
 This API updates the SkillCard content of the current skill draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillCard` | `string` | **是** | Skill card JSON string containing complete Skill information |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillCard` | `string` | **Yes** | Skill card JSON string containing complete Skill information |
+| `skillName` | `string` | **Yes** | Skill name. |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as a string indicating the draft update result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as a string indicating the draft update result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
   -d 'namespaceId=public' -d 'skillName=my-skill' -d 'skillCard={}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7885,46 +7885,46 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
 
 ### 7.4. Delete Skill
 
-#### 接口描述
+#### Description
 
 This API deletes a skill from Nacos by namespace and skill name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as a string indicating the operation result, such as "ok". On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as a string indicating the operation result, such as "ok". On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=public&skillName=my-skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7936,50 +7936,50 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=publi
 
 ### 7.5. List Skills
 
-#### 接口描述
+#### Description
 
 This API filters and paginates the skill list by query conditions.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Page size. |
-| `filterableForm` | `string` | **是** | Filter condition form. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | 否 | Skill name filter. |
-| `search` | `string` | 否 | Search mode: accurate or blur |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Page size. |
+| `filterableForm` | `string` | **Yes** | Filter condition form. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | No | Skill name filter. |
+| `search` | `string` | No | Search mode: accurate or blur |
 
-#### 返回数据
+#### Response Data
 
-The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` is a pagination structure containing totalCount, pageNumber, pagesAvailable, and pageItems. Each item includes fields such as name, description, and updateTime.
+The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format). `data` is a pagination structure containing totalCount, pageNumber, pagesAvailable, and pageItems. Each item includes fields such as name, description, and updateTime.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8002,52 +8002,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSi
 
 ### 7.6. Upload Skill from ZIP File
 
-#### 接口描述
+#### Description
 
 This API uploads a ZIP package in multipart/form-data format and registers the skill. The file must be a valid skill package.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-请求体类型：`multipart/form-data`，参数放在请求体中。
+请求体Type：`multipart/form-data`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public`. |
-| `overwrite` | `boolean` | 否 | Whether to overwrite an existing skill with the same name. |
-| `targetVersion` | `string` | 否 | Target version after upload. |
-| `commitMsg` | `string` | 否 | Commit message. |
-| `file` | `file` | 否 | ZIP file containing skill package. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public`. |
+| `overwrite` | `boolean` | No | Whether to overwrite an existing skill with the same name. |
+| `targetVersion` | `string` | No | Target version after upload. |
+| `commitMsg` | `string` | No | Commit message. |
+| `file` | `file` | No | ZIP file containing skill package. |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as the uploaded skill name. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as the uploaded skill name. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload' \
   -F "file=@skill.zip" -F "namespaceId=public" -F "overwrite=false" -F "targetVersion=1.0.0" -F "commitMsg=initial"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8059,100 +8059,100 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload' \
 
 ### 7.7. Delete Skill Draft Version
 
-#### 接口描述
+#### Description
 
 This API deletes the current draft version of a specified skill.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
 
 ### 7.8. Update Skill Business Tags
 
-#### 接口描述
+#### Description
 
 This API updates the business tag list of a skill without changing the version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `bizTags` | `string` | **是** | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `bizTags` | `string` | **Yes** | Business tags. |
 
 ### 7.9. Update Skill Version Labels
 
-#### 接口描述
+#### Description
 
 This API updates the version routing labels of a skill, such as latest.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `labels` | `string` | **是** | Label JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `labels` | `string` | **Yes** | Label JSON string. |
 
 ### 7.10. Skill Version Online, Offline, and Publish Operations
 
-#### 接口描述
+#### Description
 
 The following APIs are used to control the skill version publishing workflow.
 
-#### 请求参数
+#### Request Parameters
 
 | Method | Request URL | Key parameters |
 |--------|----------|----------|
@@ -8164,93 +8164,93 @@ The following APIs are used to control the skill version publishing workflow.
 
 ### 7.11. Get Skill Version Details
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | No | Version number. |
 
 ### 7.12. Download Skill Version ZIP Package
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | No | Version number. |
 
 ### 7.13. Offline Skill
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire skill, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `scope` | `string` | 否 | Use 'skill' for skill-level offline; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `scope` | `string` | No | Use 'skill' for skill-level offline; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/offline' -d "namespaceId=namespaceId&skillName=skillName&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8262,50 +8262,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/offline' -d "namesp
 
 
 ### 7.14. Online Skill
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire skill, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `scope` | `string` | 否 | Use 'skill' for skill-level online; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `scope` | `string` | No | Use 'skill' for skill-level online; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/online' -d "namespaceId=namespaceId&skillName=skillName&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8316,50 +8316,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/online' -d "namespa
 ```
 
 ### 7.15. Publish Skill Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved skill version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | **是** | Version identifier. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | **Yes** | Version identifier. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/publish' -d "namespaceId=namespaceId&skillName=skillName&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8370,49 +8370,49 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/publish' -d "namesp
 ```
 
 ### 7.16. Update Skill Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of a skill to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/scope' -d "namespaceId=namespaceId&skillName=skillName&scope=scope"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8423,49 +8423,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/scope' -d "namespace
 ```
 
 ### 7.17. Submit Skill Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting a skill draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/submit' -d "namespaceId=namespaceId&skillName=skillName&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8477,100 +8477,100 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/submit' -d "namespa
 
 ### 7.18. Force Publish Skill Version
 
-#### 接口描述
+#### Description
 
 This API force-publishes a Skill version while bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 7.19. Redraft Skill Version
 
-#### 接口描述
+#### Description
 
 This API converts a reviewed Skill version back to a draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 7.20. Batch Upload Skills
 
-#### 接口描述
+#### Description
 
 This API batch uploads Skills from a ZIP file that contains multiple Skill subdirectories.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 Request body type: `multipart/form-data`. Parameters are sent in the request body.
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/upload/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `overwrite` | `boolean` | 否 | Whether to overwrite existing skills with the same names. |
-| `file` | `file` | 否 | ZIP package containing multiple Skill subdirectories. |
+| `namespaceId` | `string` | No | Namespace. |
+| `overwrite` | `boolean` | No | Whether to overwrite existing skills with the same names. |
+| `file` | `file` | No | ZIP package containing multiple Skill subdirectories. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload/batch' \
@@ -8580,34 +8580,34 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload/batch' \
 ## 8. AgentSpec Management
 
 ### 8.1. Get AgentSpec
-#### 接口描述
+#### Description
 This interface allows getting the latest published version of an AgentSpec by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -8626,15 +8626,15 @@ This interface allows getting the latest published version of an AgentSpec by na
 | data.data.downloadCount | `integer` | - |
 | data.data.versions | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=public&agentSpecName=my-agentspec'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8645,48 +8645,48 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=publ
 ```
 
 ### 8.2. Delete AgentSpec
-#### 接口描述
+#### Description
 This interface allows deleting an AgentSpec and all its versions by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=public&agentSpecName=my-agentspec'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8697,49 +8697,49 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=p
 ```
 
 ### 8.3. Update AgentSpec Business Tags
-#### 接口描述
+#### Description
 This interface allows updating the business tag list of an AgentSpec without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `bizTags` | `string` | **是** | Business tags; pass multiple tags using the agreed format. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `bizTags` | `string` | **Yes** | Business tags; pass multiple tags using the agreed format. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/biz-tags' -d "namespaceId=public&agentSpecName=my-agentspec&bizTags=demo"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8750,49 +8750,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/biz-tags' -d "na
 ```
 
 ### 8.4. Create AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows creating an AgentSpec draft version based on an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `basedOnVersion` | `string` | 否 | Base version used to create the draft. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `basedOnVersion` | `string` | No | Base version used to create the draft. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agentspec&basedOnVersion=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8803,49 +8803,49 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "name
 ```
 
 ### 8.5. Update AgentSpec Draft Content
-#### 接口描述
+#### Description
 This interface allows updating the card content of the current AgentSpec draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | 否 | AgentSpec name. |
-| `agentSpecCard` | `string` | **是** | AgentSpec card JSON string containing complete AgentSpec information |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | No | AgentSpec name. |
+| `agentSpecCard` | `string` | **Yes** | AgentSpec card JSON string containing complete AgentSpec information |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agentspec&agentSpecCard={}"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8856,48 +8856,48 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "names
 ```
 
 ### 8.6. Delete AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows deleting the current draft version of a specified AgentSpec.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft?namespaceId=public&agentSpecName=my-agentspec'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8908,49 +8908,49 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft?namespa
 ```
 
 ### 8.7. Update AgentSpec Version Labels
-#### 接口描述
+#### Description
 This interface allows updating AgentSpec version routing labels (e.g. latest label) without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `labels` | `string` | **是** | Version labels, usually as a JSON string. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `labels` | `string` | **Yes** | Version labels, usually as a JSON string. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/labels' -d "namespaceId=public&agentSpecName=my-agentspec&labels={\"latest\":\"1.0.0\"}"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8961,52 +8961,52 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/labels' -d "name
 ```
 
 ### 8.8. List AgentSpecs
-#### 接口描述
+#### Description
 This interface allows paginated listing of AgentSpecs by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | Page number, starting from 1. |
-| `pageSize` | `integer` | **是** | Number of items per page. |
-| `filterableForm` | `string` | **是** | Filter condition form. |
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | 否 | AgentSpec name. |
-| `search` | `string` | 否 | Search mode: `accurate` or `blur`. |
-#### 返回数据
+| `pageNo` | `integer` | **Yes** | Page number, starting from 1. |
+| `pageSize` | `integer` | **Yes** | Number of items per page. |
+| `filterableForm` | `string` | **Yes** | Filter condition form. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | No | AgentSpec name. |
+| `search` | `string` | No | Search mode: `accurate` or `blur`. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/list?pageNo=1&pageSize=20&namespaceId=public&agentSpecName=my-agentspec&search=accurate'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9017,50 +9017,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/list?pageNo=1&pa
 ```
 
 ### 8.9. Offline AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire AgentSpec, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level offline; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level offline; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/offline' -d "namespaceId=public&agentSpecName=my-agentspec&scope=agentspec&version=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9071,50 +9071,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/offline' -d "na
 ```
 
 ### 8.10. Online AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire AgentSpec, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level online; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level online; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/online' -d "namespaceId=public&agentSpecName=my-agentspec&scope=agentspec&version=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9125,50 +9125,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/online' -d "nam
 ```
 
 ### 8.11. Publish AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved AgentSpec version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | **是** | Version identifier. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | **Yes** | Version identifier. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/publish' -d "namespaceId=public&agentSpecName=my-agentspec&version=1.0.0&updateLatestLabel=true"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9179,49 +9179,49 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/publish' -d "na
 ```
 
 ### 8.12. Update AgentSpec Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of an AgentSpec to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/scope' -d "namespaceId=public&agentSpecName=my-agentspec&scope=PUBLIC"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9232,49 +9232,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/scope' -d "names
 ```
 
 ### 8.13. Submit AgentSpec Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting an AgentSpec draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/submit' -d "namespaceId=public&agentSpecName=my-agentspec&version=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9285,52 +9285,52 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/submit' -d "nam
 ```
 
 ### 8.14. Upload AgentSpec
-#### 接口描述
+#### Description
 This interface allows uploading a ZIP-packaged AgentSpec; the package is parsed and the AgentSpec is created or updated.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 Request body type: `multipart/form-data`. Parameters are sent in the request body.
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `overwrite` | `boolean` | 否 | Whether to overwrite an existing resource with the same name. |
-| `file` | `file` | 否 | ZIP file containing AgentSpec package. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `overwrite` | `boolean` | No | Whether to overwrite an existing resource with the same name. |
+| `file` | `file` | No | ZIP file containing AgentSpec package. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/upload' -F "file=@agentspec.zip" -F "namespaceId=public" -F "overwrite=false"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9341,35 +9341,35 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/upload' -F "fil
 ```
 
 ### 8.15. Get AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows getting a specific version of an AgentSpec by namespace, name, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -9380,15 +9380,15 @@ This interface allows getting a specific version of an AgentSpec by namespace, n
 | data.data.content | `string` | - |
 | data.data.resource | `object` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/version?namespaceId=public&agentSpecName=my-agentspec&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9400,147 +9400,147 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/version?namespac
 
 ### 8.16. Force Publish AgentSpec Version
 
-#### 接口描述
+#### Description
 
 This API force-publishes an AgentSpec version while bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 8.17. Redraft AgentSpec Version
 
-#### 接口描述
+#### Description
 
 This API converts a reviewed AgentSpec version back to a draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 8.18. Get AgentSpec Version Metadata
 
-#### 接口描述
+#### Description
 
 This API retrieves metadata for a specified AgentSpec version without reading resource file content.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/version/meta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | No | Version number. |
 
 ## 9. Pipeline Execution Records
 
 ### 9.1. List Pipeline Execution Records
 
-#### 接口描述
+#### Description
 
 This API lists Pipeline execution records by resource type, resource name, namespace, and version with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | Resource type. |
-| `resourceName` | `string` | 否 | Resource name. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `version` | `string` | 否 | Resource version. |
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Page size. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `resourceName` | `string` | No | Resource name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `version` | `string` | No | Resource version. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Page size. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
 | data.data | `string` | Paginated Pipeline execution records. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines?resourceType=agentspec&resourceName=my-agentspec&namespaceId=public&version=1.0.0&pageNo=1&pageSize=20'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9552,35 +9552,35 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines?resourceType=agen
 
 ### 9.2. Get Pipeline Execution Record Details
 
-#### 接口描述
+#### Description
 
 This API retrieves Pipeline execution record details by Pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines/{pipelineId}`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | Pipeline ID. |
+| `pipelineId` | `string` | **Yes** | Pipeline ID. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
@@ -9594,15 +9594,15 @@ This API retrieves Pipeline execution record details by Pipeline ID.
 | data.data.createTime | `integer` | Creation time. |
 | data.data.updateTime | `integer` | Update time. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/pipeline-001'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9614,54 +9614,54 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/pipeline-001'
 
 ### 9.3. List Pipeline Execution Records
 
-#### 接口描述
+#### Description
 
 This API lists Pipeline execution records by resource type, resource name, namespace, and version with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | Resource type. |
-| `resourceName` | `string` | 否 | Resource name. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `version` | `string` | 否 | Resource version. |
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Page size. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `resourceName` | `string` | No | Resource name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `version` | `string` | No | Resource version. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Page size. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
 | data.data | `string` | Paginated Pipeline execution records. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/list?resourceType=agentspec&resourceName=my-agentspec&namespaceId=public&version=1.0.0&pageNo=1&pageSize=20'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9673,35 +9673,35 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/list?resourceType
 
 ### 9.4. Get Pipeline Execution Record Details
 
-#### 接口描述
+#### Description
 
 This API retrieves Pipeline execution record details by Pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | Pipeline ID. |
+| `pipelineId` | `string` | **Yes** | Pipeline ID. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
@@ -9715,15 +9715,15 @@ This API retrieves Pipeline execution record details by Pipeline ID.
 | data.data.createTime | `integer` | Creation time. |
 | data.data.updateTime | `integer` | Update time. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/detail?pipelineId=pipeline-001'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9737,130 +9737,130 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/detail?pipelineId
 
 ### 10.1. List AI Resource Import Sources
 
-#### 接口描述
+#### Description
 
 This API lists the currently configured AI resource import sources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/sources`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | 否 | Resource type. |
+| `resourceType` | `string` | No | Resource type. |
 
 ### 10.2. Search External AI Resources
 
-#### 接口描述
+#### Description
 
 This API searches importable external AI resources from a specified import source.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/search`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `resourceType` | `string` | **是** | Resource type. |
-| `sourceId` | `string` | **是** | Import source ID. |
-| `query` | `string` | 否 | Search keyword. |
-| `cursor` | `string` | 否 | Pagination cursor. |
-| `limit` | `integer` | 否 | Result limit. |
-| `options` | `string` | 否 | Extension options as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `sourceId` | `string` | **Yes** | Import source ID. |
+| `query` | `string` | No | Search keyword. |
+| `cursor` | `string` | No | Pagination cursor. |
+| `limit` | `integer` | No | Result limit. |
+| `options` | `string` | No | Extension options as a JSON string. |
 
 ### 10.3. Validate AI Resource Import Items
 
-#### 接口描述
+#### Description
 
 This API validates whether selected external AI resources can be imported.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/validate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `resourceType` | `string` | **是** | Resource type. |
-| `sourceId` | `string` | **是** | Import source ID. |
-| `selectedItems` | `string` | **是** | Resource items to validate as a JSON string. |
-| `overwriteExisting` | `boolean` | 否 | Whether to overwrite existing resources. |
-| `options` | `string` | 否 | Extension options as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `sourceId` | `string` | **Yes** | Import source ID. |
+| `selectedItems` | `string` | **Yes** | Resource items to validate as a JSON string. |
+| `overwriteExisting` | `boolean` | No | Whether to overwrite existing resources. |
+| `options` | `string` | No | Extension options as a JSON string. |
 
 ### 10.4. Execute AI Resource Import
 
-#### 接口描述
+#### Description
 
 This API imports the selected external AI resources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/execute`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `resourceType` | `string` | **是** | Resource type. |
-| `sourceId` | `string` | **是** | Import source ID. |
-| `selectedItems` | `string` | **是** | Resource items to import as a JSON string. |
-| `overwriteExisting` | `boolean` | 否 | Whether to overwrite existing resources. |
-| `skipInvalid` | `boolean` | 否 | Whether to skip invalid resource items. |
-| `validationToken` | `string` | 否 | Validation token. |
-| `options` | `string` | 否 | Extension options as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `sourceId` | `string` | **Yes** | Import source ID. |
+| `selectedItems` | `string` | **Yes** | Resource items to import as a JSON string. |
+| `overwriteExisting` | `boolean` | No | Whether to overwrite existing resources. |
+| `skipInvalid` | `boolean` | No | Whether to skip invalid resource items. |
+| `validationToken` | `string` | No | Validation token. |
+| `options` | `string` | No | Extension options as a JSON string. |

--- a/src/content/docs/latest/en/manual/admin/console-api.md
+++ b/src/content/docs/latest/en/manual/admin/console-api.md
@@ -54,33 +54,33 @@ Nacos 3.X Console APIs also provide Swagger-style documentation. You can view it
 
 ### 1.1. 获取集群状态信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取到Nacos 集群的基础状态和开关信息，例如：版本号，运行模式，鉴权是否开启等；该接口不会返回Nacos 集群的节点信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/server/state`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名                           | 参数类型      | 描述                                                                        |
+| Name                           | Type      | Description                                                                        |
 |-------------------------------|-----------|---------------------------------------------------------------------------|
 | version                       | `string` | Nacos集群的版本号，例如`3.0.0`                                                     |
 | startup_mode                  | `string` | Nacos集群的模式，例如`standalone`、`cluster`                                       |
@@ -93,7 +93,7 @@ Nacos 3.X Console APIs also provide Swagger-style documentation. You can view it
 | auth_system_type              | `string` | Nacos鉴权的插件类型，例如`nacos`等，若为``时，说明使用默认鉴权系统类型                                |
 | login_page_enabled            | `boolean` | Nacos控制台是否启用登录页                                                           |
 | plugin_datasource_log_enabled | `boolean` | Nacos是否启用打印数据源访问Debug日志                                                   |
-| config_retention_days         | `integer` | Nacos集群的配置历史数据保留天数，单位为天                                                   | 
+| config_retention_days         | `integer` | Nacos集群的配置历史数据保留天数，单位为天                                                   |
 | isManageCapacity              | `boolean` | Nacos是否启用配置容量限制检查，默认为`true`，开启时仅会统计当前配置的使用量，在超过限额时不会拒绝请求。                 |
 | isCapacityLimitCheck          | `boolean` | Nacos是否启用配置容量限制检查，默认为`false`，开启后当配置容量超出限额时，会拒绝配置的变更请求。                    |
 | defaultMaxSize                | `integer` | Nacos集群的配置文件大小限制，单位为Byte，默认为`102400`，即100KB。                              |
@@ -104,15 +104,15 @@ Nacos 3.X Console APIs also provide Swagger-style documentation. You can view it
 | ~~defaultMaxAggrSize~~        | `integer` | 未实际使用，已废弃                                                                 |
 | ~~defaultMaxAggrCount~~       | `integer` | 未实际使用，已废弃                                                                 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/server/state'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -145,49 +145,49 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/server/state'
 
 ### 1.2. 获取控制台公告信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取到Nacos 控制台希望在浏览器中显示的公告信息。Nacos默认控制台UI会在未开启鉴权时调用此接口，返回集群未开启鉴权的提示。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/server/announcement`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 类型       | 必填 | 参数描述                                        |
+| Name        | Type       | Required | Description                                        |
 |------------|----------|----|---------------------------------------------|
-| `language` | `string` | 否  | 访问的语言i18n值，默认为`zh-CN`，目前仅支持`zh-CN`和`en-US`。 |
+| `language` | `string` | No  | 访问的语言i18n值，默认为`zh-CN`，目前仅支持`zh-CN`和`en-US`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 控制台公告内容 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/server/announcement?language=zh-CN'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -199,47 +199,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/server/announcement?language=zh-CN
 
 ### 1.3. 获取控制台引导内容
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos控制台的引导信息。Nacos默认控制台UI会在关闭Nacos控制台UI时调用，以获取引导信息，相关详情请参考[控制台手册-关闭默认控制台](./console/#33-关闭默认控制台)。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/server/guide`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
-| `data` | `string` | 控制台引导内容 | 
+| `data` | `string` | 控制台引导内容 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/server/guide'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -251,47 +251,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/server/guide'
 
 ### 1.4. 获取Nacos控制台的存活状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos控制台的存活状态，Nacos控制台是否可正常接受和响应请求。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/health/liveness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 固定为`ok` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/health/liveness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -303,47 +303,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/health/liveness'
 
 ### 1.5. 获取Nacos控制台的可读状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos控制台的是否处于可读取状态，即Nacos控制台是否可以读取到数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/health/readiness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述                               |
+| Name    | Type     | Description                               |
 |--------|----------|----------------------------------|
 | `data` | `string` | 若为可读状态时，固定为`ok`，否则为不可读的模块即对应原因信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/health/readiness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -355,46 +355,46 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/health/readiness'
 
 ### 1.6. 获取Nacos节点运行信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos节点运行信息，包括节点ip，节点运行状态，节点元数据等。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/cluster/nodes`
 
-#### 请求参数
+#### Request Parameters
 
 无。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |-----|------|----|
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/cluster/nodes'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -466,37 +466,37 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/cluster/nodes'
 
 ### 1.7. 获取Nacos命名空间列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取当前Nacos集群的命名空间列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 任意有效鉴权身份信息。
 
 > 由于命名空间是Nacos的基础隔离概念，因此大多数数据查询的接口都需要选择某个命名空间才能进行查询。因此，获取命名空间列表的能力应该是任意有效身份信息用户均可访问。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace/list`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                 | 参数类型      | 描述                                           |
+| Name                 | Type      | Description                                           |
 |---------------------|-----------|----------------------------------------------|
 | `namespace`         | `string` | 命名空间id                                       |
 | `namespaceShowName` | `string` | 命名空间名称                                       |
@@ -505,15 +505,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/cluster/nodes'
 | `quota`             | `integer` | 命名空间的配置个数配额，需开启配置配额功能才会实际生效，默认不开启，仅做预留字段。    |
 | `type`              | `integer` | 命名空间的类型，预留字段，目前为`0`时为默认命名空间、`2`时为自定义创建的命名空间。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -534,37 +534,37 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/list'
 
 ### 1.8. 获取命名空间详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定命名空间的详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述    |
+| Name           | Type       | Required | Description    |
 |---------------|----------|----|---------|
-| `namespaceId` | `string` | 是  | 命名空间id。 |
+| `namespaceId` | `string` | Yes  | 命名空间id。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                 | 参数类型      | 描述                                           |
+| Name                 | Type      | Description                                           |
 |---------------------|-----------|----------------------------------------------|
 | `namespace`         | `string` | 命名空间id                                       |
 | `namespaceShowName` | `string` | 命名空间名称                                       |
@@ -573,15 +573,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/list'
 | `quota`             | `integer` | 命名空间的配置个数配额，需开启配置配额功能才会实际生效，默认不开启，仅做预留字段。    |
 | `type`              | `integer` | 命名空间的类型，预留字段，目前为`0`时为默认命名空间、`2`时为自定义创建的命名空间。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -600,51 +600,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=public'
 
 ### 1.9. 创建新命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建新的命名空间。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                 | 类型       | 必填 | 参数描述                     |
+| Name                 | Type       | Required | Description                     |
 |---------------------|----------|----|--------------------------|
-| `customNamespaceId` | `string` | 否  | 命名空间id，未填入时将会使用UUID生成ID。 |
-| `namespaceName`     | `string` | 是  | 命名空间名称。                  |
-| `namespaceDesc`     | `string` | 否  | 命名空间描述。                  |
+| `customNamespaceId` | `string` | No  | 命名空间id，未填入时将会使用UUID生成ID。 |
+| `namespaceName`     | `string` | Yes  | 命名空间名称。                  |
+| `namespaceDesc`     | `string` | No  | 命名空间描述。                  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述          |
+| Name    | Type      | Description          |
 |--------|-----------|-------------|
-| `data` | `boolean` | 创建命名空间是否成功。 | 
+| `data` | `boolean` | 创建命名空间是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceName=test&namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -656,51 +656,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceName
 
 ### 1.10. 更新命名空间
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的名称和描述。
+通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的Name和Description。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名             | 类型       | 必填 | 参数描述    |
+| Name             | Type       | Required | Description    |
 |-----------------|----------|----|---------|
-| `namespaceId`   | `string` | 是  | 命名空间ID  |
-| `namespaceName` | `string` | 是  | 命名空间名称。 |
-| `namespaceDesc` | `string` | 否  | 命名空间描述。 |
+| `namespaceId`   | `string` | Yes  | 命名空间ID  |
+| `namespaceName` | `string` | Yes  | 命名空间名称。 |
+| `namespaceDesc` | `string` | No  | 命名空间描述。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述          |
+| Name    | Type      | Description          |
 |--------|-----------|-------------|
-| `data` | `boolean` | 更新命名空间是否成功。 | 
+| `data` | `boolean` | 更新命名空间是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceId=test&namespaceName=test&namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -712,49 +712,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceId=te
 
 ### 1.11. 删除命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除命名空间。默认命名空间`public`无法被删除。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述    |
+| Name           | Type       | Required | Description    |
 |---------------|----------|----|---------|
-| `namespaceId` | `string` | 是  | 命名空间ID。 |
+| `namespaceId` | `string` | Yes  | 命名空间ID。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述          |
+| Name    | Type      | Description          |
 |--------|-----------|-------------|
-| `data` | `boolean` | 删除命名空间是否成功。 | 
+| `data` | `boolean` | 删除命名空间是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -766,49 +766,49 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=test
 
 ### 1.12. 检查命名空间是否存在
 
-#### 接口描述
+#### Description
 
 通过该接口，可以检查命名空间ID是否存在。默认控制台ID将在创建命名空间前调用，确认自定义的命名空间ID是否已经存在，以防冲突。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 任意有效鉴权身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace/exist`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                 | 类型       | 必填 | 参数描述                          |
+| Name                 | Type       | Required | Description                          |
 |---------------------|----------|----|-------------------------------|
-| `customNamespaceId` | `string` | 是  | 命名空间ID，传入空字符串时认为是需要自动生成的UUID。 |
+| `customNamespaceId` | `string` | Yes  | 命名空间ID，传入空字符串时认为是需要自动生成的UUID。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述                             |
+| Name    | Type      | Description                             |
 |--------|-----------|--------------------------------|
 | `data` | `boolean` | 命名空间是否存在，存在是为`true`，否则为`false` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespaceId=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -820,36 +820,36 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespa
 
 ### 1.13. 获取插件详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以按类型和名称获取指定插件的详情信息。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 `auth`（鉴权）、`control`（控制）、`datasource`（数据源）等。 |
-| `pluginName` | `string` | **是** | 插件名称，如 `nacos-default-auth-plugin`。 |
+| `pluginType` | `string` | **Yes** | 插件类型，如 `auth`（鉴权）、`control`（控制）、`datasource`（数据源）等。 |
+| `pluginName` | `string` | **Yes** | 插件名称，如 `nacos-default-auth-plugin`。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.pluginId | `string` | 插件唯一标识。 |
 | data.pluginType | `string` | 插件类型。 |
@@ -860,15 +860,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespa
 | data.config | `object` | 插件当前配置项。 |
 | data.configDefinitions | `array` | 插件配置项定义列表，用于渲染配置表单。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=nacos-default-auth-plugin'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -885,46 +885,46 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=
 
 ### 1.14. 查询插件在集群节点上的可用性
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定插件在各集群节点上的可用情况。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/availability`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 `auth`、`control`、`datasource` 等。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
+| `pluginType` | `string` | **Yes** | 插件类型，如 `auth`、`control`、`datasource` 等。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
 
-#### 返回数据
+#### Response Data
 
 返回 data 为 Map&lt;节点地址, 是否可用&gt;，键为 Nacos 节点地址（如 `127.0.0.1:8848`），值为该节点上该插件是否可用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=auth&pluginName=nacos-default-auth-plugin'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -938,43 +938,43 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=aut
 
 ### 1.15. 更新插件配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `config` | `string` | 否 | 插件配置内容，JSON 对象，具体字段由插件定义。 |
+| `pluginType` | `string` | **Yes** | 插件类型。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
+| `config` | `string` | No | 插件配置内容，JSON 对象，具体字段由插件定义。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 操作结果描述信息。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
@@ -983,7 +983,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
   -d 'config={}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -995,45 +995,45 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
 
 ### 1.16. 获取插件列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取插件列表，可按插件类型筛选。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | 否 | 插件类型；不传则返回所有类型的插件列表。 |
+| `pluginType` | `string` | No | 插件类型；不传则返回所有类型的插件列表。 |
 
-#### 返回数据
+#### Response Data
 
-返回 data 为插件信息数组，每项包含插件名称、类型、是否启用等。
+返回 data 为插件信息数组，每项包含插件名称、Type、是否启用等。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1051,44 +1051,44 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 
 ### 1.17. 启用或禁用插件
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新插件的启用状态（启用或禁用）。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/status`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `enabled` | `boolean` | **是** | 是否启用，`true` 启用、`false` 禁用。 |
-| `localOnly` | `boolean` | 否 | 是否仅更新本地节点插件状态。 |
+| `pluginType` | `string` | **Yes** | 插件类型。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
+| `enabled` | `boolean` | **Yes** | 是否启用，`true` 启用、`false` 禁用。 |
+| `localOnly` | `boolean` | No | 是否仅更新本地节点插件状态。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 操作结果描述信息。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
@@ -1097,7 +1097,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
   -d 'enabled=True'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1111,41 +1111,41 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
 
 ### 2.1. 获取配置详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定配置的详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                |
+| Name           | Type       | Required | Description                |
 |---------------|----------|----|---------------------|
-| `dataId`      | `string` | 是  | 配置ID。               |
-| `groupName`   | `string` | 是  | 配置分组。               |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public` |
+| `dataId`      | `string` | Yes  | 配置ID。               |
+| `groupName`   | `string` | Yes  | 配置分组。               |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public` |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                         |
+| Name                | Type     | Description                         |
 |--------------------|----------|----------------------------|
-| `id`               | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `id`               | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `dataId`           | `string` | 配置ID。                      |
 | `groupName`        | `string` | 配置分组。                      |
 | `namespaceId`      | `string` | 命名空间ID。                    |
@@ -1161,15 +1161,15 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
 | `createUser`       | `string` | 配置创建人。                     |
 | `createIp`         | `string` | 配置创建IP。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1197,59 +1197,59 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName=te
 
 ### 2.2. 发布配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建新的配置或更新已有配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                     |
+| Name           | Type       | Required | Description                     |
 |---------------|----------|----|--------------------------|
-| `dataId`      | `string` | 是  | 配置ID。                    |
-| `groupName`   | `string` | 是  | 配置分组。                    |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`      |
-| `content`     | `string` | 是  | 配置内容。                    |
-| `desc`        | `string` | 否  | 配置描述。                    |
-| `type`        | `string` | 否  | 配置类型，默认值为`text`。         |
-| `configTags`  | `string` | 否  | 配置标签，多个标签之间用英文逗号分隔。      |
-| `appName`     | `string` | 否  | 配置所属应用名称，主要用于标记配置所使用的应用。 |
+| `dataId`      | `string` | Yes  | 配置ID。                    |
+| `groupName`   | `string` | Yes  | 配置分组。                    |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`      |
+| `content`     | `string` | Yes  | 配置内容。                    |
+| `desc`        | `string` | No  | 配置描述。                    |
+| `type`        | `string` | No  | 配置类型，默认为`text`。         |
+| `configTags`  | `string` | No  | 配置标签，多个标签之间用英文逗号分隔。      |
+| `appName`     | `string` | No  | 配置所属应用名称，主要用于标记配置所使用的应用。 |
 
 - 当配置已存在(`dataId`,`groupName`相同)时，再次调用此接口将会对此配置进行更新
 - 同时更新配置时，若请求`Header`中存在`betaIps`，则会将配置标记为BETA配置，在终止BETA或完全发布配置之前，控制台UI需要进行特殊处理。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述        |
+| Name    | Type      | Description        |
 |--------|-----------|-----------|
-| `data` | `boolean` | 创建配置是否成功。 | 
+| `data` | `boolean` | 创建配置是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/cs/config' -d 'dataId=test&groupName=test&namespaceId=public&content=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1261,51 +1261,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/cs/config' -d 'dataId=test&groupN
 
 ### 2.3. 删除配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除指定配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                 |
+| Name           | Type       | Required | Description                 |
 |---------------|----------|----|----------------------|
-| `dataId`      | `string` | 是  | 配置ID。                |
-| `groupName`   | `string` | 是  | 配置分组。                |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。 |
+| `dataId`      | `string` | Yes  | 配置ID。                |
+| `groupName`   | `string` | Yes  | 配置分组。                |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述        |
+| Name    | Type      | Description        |
 |--------|-----------|-----------|
-| `data` | `boolean` | 删除配置是否成功。 | 
+| `data` | `boolean` | 删除配置是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1317,49 +1317,49 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName
 
 ### 2.4. 批量删除配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以批量删除指定配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/batchDelete`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 类型       | 必填 | 参数描述                                  |
+| Name   | Type       | Required | Description                                  |
 |-------|----------|----|---------------------------------------|
-| `ids` | `array` | 是  | Configuration storage ID list, not a `dataId` list. Separate multiple IDs with commas. |
+| `ids` | `array` | Yes  | Configuration storage ID list, not a `dataId` list. Separate multiple IDs with commas. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述        |
+| Name    | Type      | Description        |
 |--------|-----------|-----------|
-| `data` | `boolean` | 删除配置是否成功。 | 
+| `data` | `boolean` | 删除配置是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config/batchDelete?ids=838025461287096320,838025489170829312'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1371,51 +1371,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config/batchDelete?ids=83802
 
 ### 2.5. 查询配置列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定命名空间下的配置列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                                                            |
+| Name           | Type        | Required | Description                                                                            |
 |---------------|-----------|----|---------------------------------------------------------------------------------|
-| `pageNo`      | `integer` | 是  | 当前页码，起始值为1。                                                                     |
-| `pageSize`    | `integer` | 是  | 每页显示的配置数量。                                                                      |
-| `dataId`      | `string` | **是** | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
-| `groupName`   | `string` | **是** | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
-| `search`      | `string` | 否  | blur or accurate                            |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。                                                            |
-| `appName`     | `string` | 否  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
-| `configTags`  | `string` | 否  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
-| `type`        | `string` | 否  | 配置的类型，默认值为空，传入时过滤此类型的配置，值为空时查询所有类型的配置。                                          |
+| `pageNo`      | `integer` | Yes  | 当前页码，起始值为1。                                                                     |
+| `pageSize`    | `integer` | Yes  | 每页显示的配置数量。                                                                      |
+| `dataId`      | `string` | **Yes** | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
+| `groupName`   | `string` | **Yes** | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
+| `search`      | `string` | No  | blur or accurate                            |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。                                                            |
+| `appName`     | `string` | No  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
+| `configTags`  | `string` | No  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
+| `type`        | `string` | No  | 配置的Type，默认为空，传入时过滤此Type的配置，值为空时查询所有类型的配置。                                          |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                         |
+| Name                          | Type     | Description                         |
 |------------------------------|----------|----------------------------|
 | `totalCount`                 | `integer` | 符合规则的配置总数。                 |
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `List`   | 符合规则的配置列表。                 |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
@@ -1425,15 +1425,15 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config/batchDelete?ids=83802
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/list?dataId=&groupName=&appName=&configTags=&pageNo=1&pageSize=10&namespaceId=&type=&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1477,52 +1477,52 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/list?dataId=&groupName=&
 此接口性能较低，过多调用容易造成稳定性问题，请尽量使用其他接口。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以通过配置内容查询对应配置的列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/searchDetail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                                                            |
+| Name           | Type        | Required | Description                                                                            |
 |---------------|-----------|----|---------------------------------------------------------------------------------|
-| `pageNo`      | `integer` | 是  | 当前页码，起始值为1。                                                                     |
-| `pageSize`    | `integer` | 是  | 每页显示的配置数量。                                                                      |
-| `search`      | `string` | 否  | blur or accurate                            |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。                                                            |
-| `dataId`      | `string` | 否  | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
-| `groupName`   | `string` | 否  | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
-| `appName`     | `string` | 否  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
-| `configTags`  | `string` | 否  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
-| `type`         | `string` | 否  | 配置的类型，默认值为空，传入时过滤此类型的配置，值为空时查询所有类型的配置。                                          |
-| `configDetail` | `string` | 是  | 配置内容检索条件，用于按配置内容过滤，支持模糊匹配（如 `*11*`）。                                         |
+| `pageNo`      | `integer` | Yes  | 当前页码，起始值为1。                                                                     |
+| `pageSize`    | `integer` | Yes  | 每页显示的配置数量。                                                                      |
+| `search`      | `string` | No  | blur or accurate                            |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。                                                            |
+| `dataId`      | `string` | No  | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
+| `groupName`   | `string` | No  | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
+| `appName`     | `string` | No  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
+| `configTags`  | `string` | No  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
+| `type`         | `string` | No  | 配置的Type，默认为空，传入时过滤此Type的配置，值为空时查询所有类型的配置。                                          |
+| `configDetail` | `string` | Yes  | 配置内容检索条件，用于按配置内容过滤，支持模糊匹配（如 `*11*`）。                                         |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                         |
+| Name                          | Type     | Description                         |
 |------------------------------|----------|----------------------------|
 | `totalCount`                 | `integer` | 符合规则的配置总数。                 |
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `List`   | 符合规则的配置列表。                 |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
@@ -1532,15 +1532,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/list?dataId=&groupName=&
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/searchDetail?dataId=&groupName=&appName=&configTags=&pageNo=1&pageSize=10&namespaceId=&type=&search=blur&configDetail=*11*'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1569,53 +1569,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/searchDetail?dataId=&gro
 
 ### 2.7. 查询配置的监听者列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定配置的监听者列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/listener`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                 |
+| Name           | Type       | Required | Description                 |
 |---------------|----------|----|----------------------|
-| `dataId`      | `string` | 是  | 配置ID。                |
-| `groupName`   | `string` | 是  | 配置分组。                |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。 |
-| `aggregation` | `boolean` | 否  | 是否聚合查询。             |
+| `dataId`      | `string` | Yes  | 配置ID。                |
+| `groupName`   | `string` | Yes  | 配置分组。                |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。 |
+| `aggregation` | `boolean` | No  | 是否聚合查询。             |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                    |
+| Name               | Type                  | Description                                    |
 |-------------------|-----------------------|---------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`config`。                 |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`config`。                 |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅者IP，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener?dataId=test&groupName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1632,53 +1632,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener?dataId=test&gro
 
 ### 2.8. 查询某个订阅者IP订阅了哪些配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询某个订阅者IP订阅了哪些配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/listener/ip`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                 |
+| Name           | Type       | Required | Description                 |
 |---------------|----------|----|----------------------|
-| `ip`          | `string` | 是  | 订阅者IP。               |
-| `all`         | `boolean` | 否  | 是否查询全部订阅数据。         |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。 |
-| `aggregation` | `boolean` | 否  | 是否聚合查询。             |
+| `ip`          | `string` | Yes  | 订阅者IP。               |
+| `all`         | `boolean` | No  | 是否查询全部订阅数据。         |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。 |
+| `aggregation` | `boolean` | No  | 是否聚合查询。             |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                                                            |
+| Name               | Type                  | Description                                                                            |
 |-------------------|-----------------------|-------------------------------------------------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`ip`。                                                             |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`ip`。                                                             |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅的配置信息，格式为`dataId`+`groupName`+`namespaceId`，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener/ip?ip=127.0.0.1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1695,52 +1695,52 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener/ip?ip=127.0.0.1
 
 ### 2.9. 导出配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将所选或所查询的配置，导出的配置为zip文件，进行备份或导入到其他Nacos集群。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/export2`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                         |
+| Name           | Type       | Required | Description                         |
 |---------------|----------|----|------------------------------|
-| `dataId`      | `string` | 否  | 需要导出的配置ID的pattern，例如`test*`。 |
-| `groupName`   | `string` | 否  | 需要导出的配置分组的pattern，例如`test*`。 |
-| `ids`         | `array` | 否  | Configuration storage ID list. Separate multiple IDs with commas.    |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。         |
-| `appName`     | `string` | 否  | 需要导出的配置所属的应用名称。              |
+| `dataId`      | `string` | No  | 需要导出的配置ID的pattern，例如`test*`。 |
+| `groupName`   | `string` | No  | 需要导出的配置分组的pattern，例如`test*`。 |
+| `ids`         | `array` | No  | Configuration storage ID list. Separate multiple IDs with commas.    |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。         |
+| `appName`     | `string` | No  | 需要导出的配置所属的应用名称。              |
 
 > 使用时建议分开使用 `ids` 和 `dataId` + `groupName` 的组合，只选择一种方式，另一类传入空字符串，否则可能导致导出文件为空内容。
 
-#### 返回数据
+#### Response Data
 
 导出成功是为byte数组的file
-attachment模式，导出失败时返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+attachment模式，导出失败时返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/cs/config/export2?dataId=&groupId=&ids=" --output ~/test.zip
 ```
 
-* 返回示例
+* Response example
 
 ```shell
 unzip ~/test.zip
@@ -1757,55 +1757,55 @@ unzip ~/test.zip
 接口进行配置文件的导出。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将从Nacos导出的zip文件导入到Nacos的指定命名空间中
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/import`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型                 | 必填 | 参数描述                                                                                                               |
+| Name           | Type                 | Required | Description                                                                                                               |
 |---------------|--------------------|----|--------------------------------------------------------------------------------------------------------------------|
-| `file`        | `MultipartFile`    | 否  | 导入的zip文件。                                                                                                          |
-| `namespaceId` | `string` | 否  | 导入的配置所属的命名空间ID，默认值为`public`。                                                                                       |
-| `policy`      | `string` | 否  | 导入策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的导入策略。可选值有`ABORT(终止导入)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认值为`ABORT`。 |
-| `src_user`    | `string` | 否  | 导入操作来源用户标识。                                                                                                       |
+| `file`        | `MultipartFile`    | No  | 导入的zip文件。                                                                                                          |
+| `namespaceId` | `string` | No  | 导入的配置所属的命名空间ID，默认为`public`。                                                                                       |
+| `policy`      | `string` | No  | 导入策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的导入策略。可选值有`ABORT(终止导入)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认为`ABORT`。 |
+| `src_user`    | `string` | No  | 导入操作来源用户标识。                                                                                                       |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型  | 描述         |
+| Name         | Type  | Description         |
 |-------------|-------|------------|
 | `succCount` | `integer` | 导入成功的配置数量。 |
 | `skipCount` | `integer` | 导入跳过的配置数量。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -vX POST "http://127.0.0.1:8080/v3/console/cs/config/import" -F "file=@/path/to/test.zip" -F "namespaceId=test"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1820,54 +1820,54 @@ curl -vX POST "http://127.0.0.1:8080/v3/console/cs/config/import" -F "file=@/pat
 
 ### 2.11. 克隆配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将所选或所查询的配置克隆到其他命名空间。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`，为配置列表数组。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/clone`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名              | 类型       | 必填    | 参数描述                                                                                                               |
+| Name              | Type       | Required    | Description                                                                                                               |
 |------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------|
-| `srcUser`        | `string` | 否     | 克隆操作来源用户标识。                                                                                                        |
-| `targetNamespaceId` | `string` | **是** | 目标命名空间ID。                                                                                                           |
-| `policy`         | `string` | 否     | 克隆策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的克隆策略。可选值有`ABORT(终止克隆)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认值为`ABORT`。 |
+| `srcUser`        | `string` | No     | 克隆操作来源用户标识。                                                                                                        |
+| `targetNamespaceId` | `string` | **Yes** | 目标命名空间ID。                                                                                                           |
+| `policy`         | `string` | No     | 克隆策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的克隆策略。可选值有`ABORT(终止克隆)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认为`ABORT`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型  | 描述         |
+| Name         | Type  | Description         |
 |-------------|-------|------------|
 | `succCount` | `integer` | 成功克隆的配置数量。 |
 | `skipCount` | `integer` | 克隆跳过的配置数量。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -H "Content-Type: application/json" -X POST "http://127.0.0.1:8080/v3/console/cs/config/clone?targetNamespaceId=public&policy=ABORT" -d "[{\"cfgId\":838029534438625280,\"dataId\":\"111\",\"group\":\"DEFAULT_GROUP\"},{\"cfgId\":838033747294031872,\"dataId\":\"qtc-user.yaml\",\"group\":\"DEFAULT_GROUP\"}]"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1886,50 +1886,50 @@ curl -H "Content-Type: application/json" -X POST "http://127.0.0.1:8080/v3/conso
 只有在[发布配置](#22-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能停止BETA发布状态。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将配置从BETA发布状态停止，即回滚配置的Beta发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `dataId`      | `string` | 是  | 配置的`dataId`。              |
-| `groupName`   | `string` | 是  | 配置的`groupName`。           |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `dataId`      | `string` | Yes  | 配置的`dataId`。              |
+| `groupName`   | `string` | Yes  | 配置的`groupName`。           |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |-----|------|----|
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=test&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1945,39 +1945,39 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=test&grou
 只有在[发布配置](#22-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能获取到配置详情。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的BETA发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `dataId`      | `string` | 是  | 配置的`dataId`。              |
-| `groupName`   | `string` | 是  | 配置的`groupName`。           |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `dataId`      | `string` | Yes  | 配置的`dataId`。              |
+| `groupName`   | `string` | Yes  | 配置的`groupName`。           |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                                  |
+| Name                | Type     | Description                                  |
 |--------------------|----------|-------------------------------------|
 | `id`               | `string` | beta配置的存储ID。                        |
 | `dataId`           | `string` | 配置的dataId。                          |
@@ -1996,15 +1996,15 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=test&grou
 | `grayName`         | `string` | 灰度发布规则名称, 固定为`beta`。                |
 | `grayRule`         | `string` | 灰度发布规则，格式为JSON，其中的`expr`为beta的ip列表。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=111&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2034,41 +2034,41 @@ curl "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=111&groupName=DEFAU
 
 ### 2.14. 查询配置发布历史
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的发布历史。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `pageNo`      | `integer` | 是  | 当前页码，起始为`1`               |
-| `pageSize`    | `integer` | 是  | 每页显示的记录数。                 |
-| `dataId`      | `string` | 是  | 配置的`dataId`。              |
-| `groupName`   | `string` | 是  | 配置的`groupName`。           |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `pageNo`      | `integer` | Yes  | 当前页码，起始为`1`               |
+| `pageSize`    | `integer` | Yes  | 每页显示的记录数。                 |
+| `dataId`      | `string` | Yes  | 配置的`dataId`。              |
+| `groupName`   | `string` | Yes  | 配置的`groupName`。           |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                                |
+| Name                          | Type     | Description                                |
 |------------------------------|----------|-----------------------------------|
 | `totalCount`                 | `integer` | 历史记录的总数。                          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。                      |
@@ -2086,15 +2086,15 @@ curl "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=111&groupName=DEFAU
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                           |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                           |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history/list?pageNo=1&pageSize=10&dataId=111&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2157,40 +2157,40 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/list?pageNo=1&pageSize=10&data
 
 ### 2.15. 查询配置的某次历史变更记录
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的某次历史变更记录。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `nid`         | `integer` | 是  | 历史记录的ID。                  |
-| `dataId`      | `string` | 是  | 配置的dataId。                
-| `groupName`   | `string` | 是  | 配置的groupName。             |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `nid`         | `integer` | Yes  | 历史记录的ID。                  |
+| `dataId`      | `string` | Yes  | 配置的dataId。
+| `groupName`   | `string` | Yes  | 配置的groupName。             |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -2207,15 +2207,15 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/list?pageNo=1&pageSize=10&data
 | `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `JsonString` | 扩展信息，目前包括`src_user`、`type`、`c_desc`，若`publishType`为`gray`, 其中还包括`grayRule`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history?dataId=111&groupName=DEFAULT_GROUP&nid=7"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2245,40 +2245,40 @@ curl "http://127.0.0.1:8080/v3/console/cs/history?dataId=111&groupName=DEFAULT_G
 
 ### 2.16. 查询配置最新状态的前一次变更历史
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置最新状态的前一次变更历史。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history/previous`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `id`          | `integer` | 是  | 配置的存储ID。                  |
-| `dataId`      | `string` | 是  | 配置的dataId。                |
-| `groupName`   | `string` | 是  | 配置的groupName。             |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `id`          | `integer` | Yes  | 配置的存储ID。                  |
+| `dataId`      | `string` | Yes  | 配置的dataId。                |
+| `groupName`   | `string` | Yes  | 配置的groupName。             |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -2295,15 +2295,15 @@ curl "http://127.0.0.1:8080/v3/console/cs/history?dataId=111&groupName=DEFAULT_G
 | `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `JsonString` | 扩展信息，目前包括`src_user`、`type`、`c_desc`，若`publishType`为`gray`, 其中还包括`grayRule`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history/previous?id=838029534438625280&dataId=111&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2333,52 +2333,52 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/previous?id=838029534438625280
 
 ### 2.17. 查询命名空间下的配置列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询命名空间下的配置列表，仅查询dataId和groupName，用于配置历史UI的下拉选择。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history/configs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `namespaceId` | `string` | **是** | 配置所属的命名空间ID，默认值为`public`。 |
+| `namespaceId` | `string` | **Yes** | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型     | 描述            |
+| Name         | Type     | Description            |
 |-------------|----------|---------------|
 | `dataId`    | `string` | 配置的dataId。    |
 | `groupName` | `string` | 配置的groupName。 |
 
 > 其他字段均无用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history/configs?namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2415,55 +2415,55 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/configs?namespaceId=public"
 
 ### 3.1. 创建服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建一个空服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型                    | 必填 | 参数描述                                                   |
+| Name                | Type                    | Required | Description                                                   |
 |--------------------|-----------------------|----|--------------------------------------------------------|
-| `serviceName`      | `string` | 是  | 服务名。                                                   |
-| `groupName`        | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。                    |
-| `namespaceId`      | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。                              |
-| `protectThreshold` | `number` | 否  | 服务的防护阈值，默认值为`0.0`。                                     |
-| `selector`         | `string` | 否  | 服务的路由选择器，默认值为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
-| `metadata`         | `string` | 否  | 服务的元数据，默认值为`{}`。                                       |
-| `ephemeral`        | `boolean` | 否  | 服务是否临时，默认值为`false`即持久化服务。                              |
+| `serviceName`      | `string` | Yes  | 服务名。                                                   |
+| `groupName`        | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。                    |
+| `namespaceId`      | `string` | No  | 服务所属的命名空间ID，默认为`public`。                              |
+| `protectThreshold` | `number` | No  | 服务的防护阈值，默认为`0.0`。                                     |
+| `selector`         | `string` | No  | 服务的路由选择器，默认为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
+| `metadata`         | `string` | No  | 服务的元数据，默认为`{}`。                                       |
+| `ephemeral`        | `boolean` | No  | 服务是否临时，默认为`false`即持久化服务。                              |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 创建成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&groupName=DEFAULT_GROUP&namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2479,51 +2479,51 @@ curl -X POST "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&
 此接口为删除服务，而不是删除服务实例（服务提供者），且当服务下还有服务实例存在时，服务会无法删除。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除一个服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                                |
+| Name           | Type       | Required | Description                                |
 |---------------|----------|----|-------------------------------------|
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 删除成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test&groupName=DEFAULT_GROUP&namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2535,56 +2535,56 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test&gro
 
 ### 3.3. 更新服务元数据
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新一个服务的元数据。仅能更新服务的元数据，如`metadata`、`selector`
 等。服务的serviceName、groupName、namespaceId等不能更新。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型                    | 必填 | 参数描述                                                   |
+| Name                | Type                    | Required | Description                                                   |
 |--------------------|-----------------------|----|--------------------------------------------------------|
-| `serviceName`      | `string` | 是  | 服务名。                                                   |
-| `groupName`        | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。                    |
-| `namespaceId`      | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。                              |
-| `protectThreshold` | `number` | 否  | 服务的防护阈值，默认值为`0.0`。                                     |
-| `ephemeral`        | `boolean` | 否  | 是否临时实例，如 `true`/`false`。                                  |
-| `selector`         | `string` | 否  | 服务的路由选择器，默认值为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
-| `metadata`         | `string` | 否  | 服务的元数据，默认值为`{}`。                                       |
+| `serviceName`      | `string` | Yes  | 服务名。                                                   |
+| `groupName`        | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。                    |
+| `namespaceId`      | `string` | No  | 服务所属的命名空间ID，默认为`public`。                              |
+| `protectThreshold` | `number` | No  | 服务的防护阈值，默认为`0.0`。                                     |
+| `ephemeral`        | `boolean` | No  | 是否临时实例，如 `true`/`false`。                                  |
+| `selector`         | `string` | No  | 服务的路由选择器，默认为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
+| `metadata`         | `string` | No  | 服务的元数据，默认为`{}`。                                       |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 更新成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&groupName=DEFAULT_GROUP&namespaceId=public&protectThreshold=0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2594,50 +2594,50 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&g
 }
 ```
 
-### 3.4. 获取支持的服务路由选择器类型列表
+### 3.4. 获取支持的服务路由选择器Type列表
 
-#### 接口描述
+#### Description
 
-通过该接口，可以获取支持的服务路由选择器类型列表，用于控制台UI在创建和更新服务时，选择对应的路由选择器类型的下拉选择框。
+通过该接口，可以获取支持的服务路由选择器Type列表，用于控制台UI在创建和更新服务时，选择对应的路由选择器Type的下拉选择框。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 任意有效鉴权身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/selector/types`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名     | 参数类型     | 描述                  |
+| Name     | Type     | Description                  |
 |---------|----------|---------------------|
 | `label` | `string` | 通过label表达式进行路由选择过滤。 |
 | `none`  | `string` | 无选择器。               |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/selector/types"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2652,43 +2652,43 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/selector/types"
 
 ### 3.5. 查询服务列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定命名空间下的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                  | 类型        | 必填 | 参数描述                              |
+| Name                  | Type        | Required | Description                              |
 |----------------------|-----------|----|-----------------------------------|
-| `pageNo`             | `integer` | 是  | Page number, starting from `1`. |
-| `pageSize`           | `integer` | 是  | Page size. |
-| `serviceNameParam`   | `string` | 否  | 服务名的pattern，为空时查询所有服务。            |
-| `groupNameParam`     | `string` | 否  | 服务所属的groupName的pattern，为空时查询所有服务。 |
-| `namespaceId`        | `string` | 否  | 服务所属的命名空间ID。                      |
-| `ignoreEmptyService` | `boolean` | 否  | Whether to return only services with instances. Defaults to `false`, meaning empty services are included. |
-| `withInstances`      | `boolean` | 否  | Whether to return service instance details. Defaults to `false`. |
+| `pageNo`             | `integer` | Yes  | Page number, starting from `1`. |
+| `pageSize`           | `integer` | Yes  | Page size. |
+| `serviceNameParam`   | `string` | No  | 服务名的pattern，为空时查询所有服务。            |
+| `groupNameParam`     | `string` | No  | 服务所属的groupName的pattern，为空时查询所有服务。 |
+| `namespaceId`        | `string` | No  | 服务所属的命名空间ID。                      |
+| `ignoreEmptyService` | `boolean` | No  | Whether to return only services with instances. Defaults to `false`, meaning empty services are included. |
+| `withInstances`      | `boolean` | No  | Whether to return service instance details. Defaults to `false`. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                   | 参数类型     | 描述           |
+| Name                                   | Type     | Description           |
 |---------------------------------------|----------|--------------|
 | `totalCount`                          | `integer` | 符合条件的服务的总数。  |
 | `pageNumber`                          | `integer` | 当前页码，起始为`1`。 |
@@ -2701,15 +2701,15 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/selector/types"
 | `pageItems`[i].`healthyInstanceCount` | `string` | 服务下的健康实例数量。  |
 | `pageItems`[i].`triggerFlag`          | `string` | 是否触发了服务的保护。  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/list?pageNo=1&pageSize=10&namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2743,42 +2743,42 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/list?pageNo=1&pageSize=
 
 ### 3.6. 查询服务的订阅者列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定服务下的订阅者列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/subscribers`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                |
+| Name           | Type        | Required | Description                                |
 |---------------|-----------|----|-------------------------------------|
-| `pageNo`      | `integer` | 是  | Page number, starting from `1`. |
-| `pageSize`    | `integer` | 是  | Page size. |
-| `serviceName`  | `string` | 是  | 服务名。                                |
-| `groupName`    | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId`  | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `aggregation`  | `boolean` | 否  | Whether to aggregate the query. |
+| `pageNo`      | `integer` | Yes  | Page number, starting from `1`. |
+| `pageSize`    | `integer` | Yes  | Page size. |
+| `serviceName`  | `string` | Yes  | 服务名。                                |
+| `groupName`    | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId`  | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `aggregation`  | `boolean` | No  | Whether to aggregate the query. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型      | 描述                   |
+| Name                          | Type      | Description                   |
 |------------------------------|-----------|----------------------|
 | `totalCount`                 | `integer` | 符合条件的服务的总数。          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。         |
@@ -2786,22 +2786,22 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/list?pageNo=1&pageSize=
 | `pageItems`                  | `List`    | 服务列表。                |
 | `pageItems`[i].`ip`          | `string` | 订阅者IP。               |
 | `pageItems`[i].`port`        | `integer` | 订阅者端口。               |
-| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 | 
+| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 |
 | `pageItems`[i].`agent`       | `string` | 订阅者客户端版本。            |
 | `pageItems`[i].`appName`     | `string` | 订阅者所属应用。             |
 | `pageItems`[i].`namespaceId` | `string` | 订阅者所属命名空间。           |
 | `pageItems`[i].`groupName`   | `string` | 订阅的分组名。              |
 | `pageItems`[i].`serviceName` | `string` | 订阅的服务名。              |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/subscribers?pageNo=1&pageSize=10&serviceName=test&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2829,39 +2829,39 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/subscribers?pageNo=1&pa
 
 ### 3.7. 查询服务详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定服务详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                                |
+| Name           | Type       | Required | Description                                |
 |---------------|----------|----|-------------------------------------|
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                                 | 参数类型         | 描述                                   |
+| Name                                                 | Type         | Description                                   |
 |-----------------------------------------------------|--------------|--------------------------------------|
 | `namespaceId`                                       | `string` | 服务所属的namespaceId。                    |
 | `groupName`                                         | `string` | 服务所属的groupName。                      |
@@ -2870,22 +2870,22 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/subscribers?pageNo=1&pa
 | `protectThreshold`                                  | `number` | 服务防护阈值。                              |
 | `selector`                                          | `jsonObject` | 服务选择器。                               |
 | `metadata`                                          | `jsonObject` | 服务元数据。                               |
-| `clusterMap`                                        | `jsonObject` | 服务集群列表, key为cluster的名称，value为集群详细信息。 |
+| `clusterMap`                                        | `jsonObject` | 服务集群列表, key为cluster的Name，value为集群详细信息。 |
 | `clusterMap`.$ClusterName.`clusterName`             | `string` | 集群名。                                 |
 | `clusterMap`.$ClusterName.`healthChecker`           | `jsonObject` | 健康检查器。                               |
 | `clusterMap`.$ClusterName.`healthyCheckPort`        | `integer` | 健康检查端口。                              |
 | `clusterMap`.$ClusterName.`useInstancePortForCheck` | `boolean` | 是否使用所注册的实例的`IP:Port`进行健康检查。          |
 | `clusterMap`.$ClusterName.`metadata`                | `jsonObject` | 集群元数据。                               |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2920,38 +2920,38 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test"
 
 ### 3.8. 更新服务集群元数据
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新指定服务集群的元数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/cluster`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 类型                    | 必填 | 参数描述                                |
+| Name                     | Type                    | Required | Description                                |
 |-------------------------|-----------------------|----|-------------------------------------|
-| `clusterName`           | `string` | 是  | 集群名。                                |
-| `serviceName`           | `string` | 是  | 服务名。                                |
-| `checkPort`             | `integer` | 是  | Health check port. |
-| `useInstancePort4Check` | `boolean` | 是  | Whether to use the registered instance `IP:Port` for health checks. |
-| `healthChecker`         | `string` | 是  | 健康检查器。                              |
-| `groupName`             | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId`           | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `metadata`              | `string` | 否  | 服务元数据。                              |
+| `clusterName`           | `string` | Yes  | 集群名。                                |
+| `serviceName`           | `string` | Yes  | 服务名。                                |
+| `checkPort`             | `integer` | Yes  | Health check port. |
+| `useInstancePort4Check` | `boolean` | Yes  | Whether to use the registered instance `IP:Port` for health checks. |
+| `healthChecker`         | `string` | Yes  | 健康检查器。                              |
+| `groupName`             | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId`           | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `metadata`              | `string` | No  | 服务元数据。                              |
 
 > `healthChecker`参数为健康检查器的JSON字符串，目前支持三种健康检查器：
 > 1. `None`: 无健康检查，`{"type":"NONE"}`
@@ -2959,23 +2959,23 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test"
 > 3. `HTTP`: HTTP端口检查，`{"type":"HTTP","path":"/liveness","headers":"health"}`, 其中`path`为HTTP的uri，`headers`
      为HTTP请求头。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 更新成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service/cluster" -d "serviceName=test&clusterName=DEFAULT&checkPort=80&useInstancePort4Check=true&healthChecker={\"type\":\"none\"}"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2987,42 +2987,42 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service/cluster" -d "serviceNam
 
 ### 3.9. 查询服务的实例列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定服务的实例列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/instance/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                |
+| Name           | Type        | Required | Description                                |
 |---------------|-----------|----|-------------------------------------|
-| `pageNo`      | `integer` | 是  | 页码，起始为1。                            |
-| `pageSize`    | `integer` | 是  | 每页记录数。                              |
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId`  | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `clusterName`  | `string` | 否  | 集群名，不传则查询所有集群的实例。                      |
+| `pageNo`      | `integer` | Yes  | 页码，起始为1。                            |
+| `pageSize`    | `integer` | Yes  | 每页记录数。                              |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId`  | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `clusterName`  | `string` | No  | 集群名，不传则查询所有集群的实例。                      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型                  | 描述                                    |
+| Name                          | Type                  | Description                                    |
 |------------------------------|-----------------------|---------------------------------------|
 | `totalCount`                 | `integer` | 符合条件的实例的总数。                           |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。                          |
@@ -3044,15 +3044,15 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service/cluster" -d "serviceNam
 用于兼容1.X客户端的心跳模式数据，后续版本可能会移除对1.X客户端的支持，届时这3个参数将被废弃。
 :::
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/instance/list?&serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&pageSize=10&pageNo=1"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3086,59 +3086,59 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/instance/list?&serviceName=test
 
 ### 3.10. 更新实例元数据
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新指定服务的实例元数据，包括权重和上下线状态；无法更新实例的服务名、分组名、命名空间、IP及端口。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型                    | 必填 | 参数描述                                |
+| Name           | Type                    | Required | Description                                |
 |---------------|-----------------------|----|-------------------------------------|
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `ip`          | `string` | 是  | 实例IP。                               |
-| `port`        | `integer` | 是  | 实例端口。                               |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `clusterName` | `string` | 否  | 实例所属集群, 默认值为`DEFAULT`。              |
-| `ephemeral`   | `boolean` | 否  | 实例是否临时，默认值为`true`。                  |
-| `weight`      | `number` | 否  | 实例权重。                               |
-| `healthy`     | `boolean` | 否  | 实例健康状态。                             |
-| `enabled`     | `boolean` | 否  | 实例是否已上线。                            |
-| `metadata`    | `string` | 否  | 实例元数据。                              |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `ip`          | `string` | Yes  | 实例IP。                               |
+| `port`        | `integer` | Yes  | 实例端口。                               |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `clusterName` | `string` | No  | 实例所属集群, 默认为`DEFAULT`。              |
+| `ephemeral`   | `boolean` | No  | 实例是否临时，默认为`true`。                  |
+| `weight`      | `number` | No  | 实例权重。                               |
+| `healthy`     | `boolean` | No  | 实例健康状态。                             |
+| `enabled`     | `boolean` | No  | 实例是否已上线。                            |
+| `metadata`    | `string` | No  | 实例元数据。                              |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 更新成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8080/v3/console/ns/instance" -d 'serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&ip=1.1.1.1&port=3306&ephemeral=true&weight=100&enabled=false&metadata=%7B%22%E5%95%A6%E5%95%A6%E5%95%A6%26%E5%95%B5%E5%95%B5%E5%95%B5%22%3A%22xxx%22%7D'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3150,59 +3150,59 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/instance" -d 'serviceName=test&
 
 ### 3.11. 删除持久化实例
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除指定服务下的**持久化实例**。该接口仅支持删除`ephemeral=false`的实例，不支持删除临时实例。
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 类型      | 必填 | 参数描述                                       |
+| Name        | Type      | Required | Description                                       |
 | ------------- | --------- | ---- | ---------------------------------------------- |
-| `serviceName` | `string`  | 是   | 服务名。                                       |
-| `ip`          | `string`  | 是   | 实例IP。                                       |
-| `port`        | `integer` | 是   | 实例端口。                                     |
-| `groupName`   | `string`  | 否   | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string`  | 否   | 服务所属的命名空间ID，默认值为`public`。       |
-| `clusterName` | `string`  | 否   | 实例所属集群, 默认值为`DEFAULT`。              |
-| `ephemeral`   | `boolean` | 否   | 实例是否临时，仅支持传入`false`，默认值为`false`。 |
-| `healthy`     | `boolean` | 否   | Whether the instance is healthy. |
-| `weight`      | `number`  | 否   | Instance weight. |
-| `enabled`     | `boolean` | 否   | Whether the instance is enabled. |
-| `metadata`    | `string`  | 否   | Instance metadata as a JSON object string. |
+| `serviceName` | `string`  | Yes   | 服务名。                                       |
+| `ip`          | `string`  | Yes   | 实例IP。                                       |
+| `port`        | `integer` | Yes   | 实例端口。                                     |
+| `groupName`   | `string`  | No   | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string`  | No   | 服务所属的命名空间ID，默认为`public`。       |
+| `clusterName` | `string`  | No   | 实例所属集群, 默认为`DEFAULT`。              |
+| `ephemeral`   | `boolean` | No   | 实例是否临时，仅支持传入`false`，默认为`false`。 |
+| `healthy`     | `boolean` | No   | Whether the instance is healthy. |
+| `weight`      | `number`  | No   | Instance weight. |
+| `enabled`     | `boolean` | No   | Whether the instance is enabled. |
+| `metadata`    | `string`  | No   | Instance metadata as a JSON object string. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述                     |
+| Name | Type | Description                     |
 | ------ | -------- | ------------------------ |
 | `data` | `string` | 删除成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/instance?serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&ip=1.1.1.1&port=3306&ephemeral=false"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3216,40 +3216,40 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/instance?serviceName=test&cl
 
 ### 4.1. 查询MCP服务的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定MCP服务的服务的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
 | `mcpId`       | `string` | One of two required | MCP service ID (usually UUID). One of `mcpId` and `mcpName` must be provided (OpenAPI cannot express this constraint; at least one is required in practice). Prefer `mcpId`. |
 | `mcpName`     | `string` | One of two required | MCP service name template. One of `mcpId` and `mcpName` must be provided; prefer `mcpId`.    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是返回最新版本                      |
+| `version`     | `string` | No     | MCP服务的版本，未传入是返回最新版本                      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID。                                                                               |
 | `name`               | `string` | MCP服务名。                                                                                         |
@@ -3269,20 +3269,20 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/instance?serviceName=test&cl
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
 | `is_latest`    | `boolean` | MCP服务的版本是否为最新版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3322,42 +3322,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 ### 4.2. 更新MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                                                      |
+| Name                     | Type         | Required  | Description                                                      |
 |-------------------------|--------------|-------|---------------------------------------------------------|
-| `namespaceId`           | `string` | 否     | MCP服务的命名空间ID，默认为`public`                                |
-| `latest`                | `boolean` | 否     | 是否按最新版本更新，如 `true`。                                      |
-| `serverSpecification`   | `string` | **是** | MCP服务的描述详情                                              |
-| `toolSpecification`     | `string` | 否     | MCP服务的工具描述详情                                            |
-| `endpointSpecification` | `string` | 否     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效                          |
-| `overrideExisting`      | `boolean` | 否     | MCP服务更新时是否覆盖原endpointSpecification，默认不覆盖，仅在非`stdio`协议时生效 |
+| `namespaceId`           | `string` | No     | MCP服务的命名空间ID，默认为`public`                                |
+| `latest`                | `boolean` | No     | 是否按最新版本更新，如 `true`。                                      |
+| `serverSpecification`   | `string` | **Yes** | MCP服务的描述详情                                              |
+| `toolSpecification`     | `string` | No     | MCP服务的工具描述详情                                            |
+| `endpointSpecification` | `string` | No     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效                          |
+| `overrideExisting`      | `boolean` | No     | MCP服务更新时是否覆盖原endpointSpecification，默认不覆盖，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，必须传入，用于定位待更新的MCP服务。                                                            |
 | `name`               | `string` | MCP服务名。                                                                                         |
@@ -3374,7 +3374,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -3382,7 +3382,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `List<McpTool>`            | 该MCP Server所提供的工具列表，参考标准MCP协议中对于MCP Tool的定义                                             |
 | `toolsMeta`       | `Map<String, McpToolMeta>` | 该MCP Server所提供的工具的额外元数据信息，可用于扩展标准MCP协议中未定义但又使用中需要的信息。key为`McpTool`的`name`, value为拓展元数据。 |
@@ -3390,15 +3390,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
 | `name`        | `string` | MCP 工具的名称                                     |
 | `description` | `string` | MCP 工具的描述                                     |
-| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`类型`,`是否必须`,`描述` 等。 |
+| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`Type`,`是否必须`,`Description` 等。 |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -3406,7 +3406,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
 | `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
@@ -3417,22 +3417,22 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务更新结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
@@ -3440,7 +3440,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"d7a64724-a556-4fe4-82fa-e806d43e00dc","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3452,40 +3452,40 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 ### 4.3. 创建MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的MCP服务，可以是存量API转换的MCP服务，也可以是MCP市场中的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                             |
+| Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
-| `namespaceId`           | `string` | 否     | MCP服务的命名空间ID，默认为`public`       |
-| `serverSpecification`   | `string` | **是** | MCP服务的描述详情                     |
-| `toolSpecification`     | `string` | 否     | MCP服务的工具描述详情                   |
-| `endpointSpecification` | `string` | 否     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
+| `namespaceId`           | `string` | No     | MCP服务的命名空间ID，默认为`public`       |
+| `serverSpecification`   | `string` | **Yes** | MCP服务的描述详情                     |
+| `toolSpecification`     | `string` | No     | MCP服务的工具描述详情                   |
+| `endpointSpecification` | `string` | No     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，无需传入，系统自动生成。                                                                   |
 | `name`               | `string` | MCP服务名。                                                                                         |
@@ -3502,7 +3502,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -3510,7 +3510,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `List<McpTool>`            | 该MCP Server所提供的工具列表，参考标准MCP协议中对于MCP Tool的定义                                             |
 | `toolsMeta`       | `Map<String, McpToolMeta>` | 该MCP Server所提供的工具的额外元数据信息，可用于扩展标准MCP协议中未定义但又使用中需要的信息。key为`McpTool`的`name`, value为拓展元数据。 |
@@ -3518,15 +3518,15 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
 | `name`        | `string` | MCP 工具的名称                                     |
 | `description` | `string` | MCP 工具的描述                                     |
-| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`类型`,`是否必须`,`描述` 等。 |
+| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`Type`,`是否必须`,`Description` 等。 |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -3534,7 +3534,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
 | `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
@@ -3545,22 +3545,22 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 新建MCP服务的id。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp' \
@@ -3568,7 +3568,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3580,52 +3580,52 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 ### 4.4. 删除MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
 | `mcpId`       | `string` | One of two required | MCP service ID (usually UUID). One of `mcpId` and `mcpName` must be provided (OpenAPI cannot express this constraint; at least one is required in practice). Prefer `mcpId`. |
 | `mcpName`     | `string` | One of two required | MCP service name template. One of `mcpId` and `mcpName` must be provided; prefer `mcpId`.    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是为最新版本                       |
+| `version`     | `string` | No     | MCP服务的版本，未传入是为最新版本                       |
 
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3637,41 +3637,41 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpNa
 
 ### 4.5. 查询MCP服务的服务列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的MCP服务的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                                     |
+| Name           | Type     | Required  | Description                                                     |
 |---------------|----------|-------|--------------------------------------------------------|
-| `pageNo`      | `integer` | **是** | 当前页，默认为`1`                                             |
-| `pageSize`    | `integer` | **是** | 页条目数，默认为`20`，最大为`500`                                  |
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                               |
-| `mcpName`     | `string`   | 否     | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
-| `search`      | `string` | 否     | blur or accurate                  |
+| `pageNo`      | `integer` | **Yes** | 当前页，默认为`1`                                             |
+| `pageSize`    | `integer` | **Yes** | 页条目数，默认为`20`，最大为`500`                                  |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                               |
+| `mcpName`     | `string`   | No     | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
+| `search`      | `string` | No     | blur or accurate                  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                           | 参数类型                  | 描述                                                                                              |
+| Name                                           | Type                  | Description                                                                                              |
 |-----------------------------------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `totalCount`                                  | `integer` | 符合条件的服务的总数。                                                                                     |
 | `pageNumber`                                  | `integer` | 当前页码，起始为`1`。                                                                                    |
@@ -3692,20 +3692,20 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpNa
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
 | `is_latest`    | `boolean` | MCP服务的版本是否为最新版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3748,51 +3748,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/list?pageNo=1&pageSize=100&
 
 ### 4.6. 导入MCP工具
 
-#### 接口描述
+#### Description
 
 通过该接口，可以通过指定MCP`URL`的方式直接获取MCP工具并导入，避免逐个填写。
 
-#### 起始版本
+#### Since
 
 `3.0.3`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/importToolsFromMcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名             | 参数类型     | 是否必填  | 描述                                      |
+| Name             | Type     | Required  | Description                                      |
 |-----------------|----------|-------|-----------------------------------------|
-| `transportType` | `string` | **是** | MCP服务的传输协议类型，`mcp-sse`或`mcp-streamable` |
-| `baseUrl`       | `string` | **是** | MCP服务的baseURL                           |
-| `endpoint`      | `string` | **是** | MCP服务的可访问端点                             |
-| `authToken`     | `string` | 否     | MCP服务访问的身份Token                         |
+| `transportType` | `string` | **Yes** | MCP服务的传输协议类型，`mcp-sse`或`mcp-streamable` |
+| `baseUrl`       | `string` | **Yes** | MCP服务的baseURL                           |
+| `endpoint`      | `string` | **Yes** | MCP服务的可访问端点                             |
+| `authToken`     | `string` | No     | MCP服务访问的身份Token                         |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型                   | 描述                                                                                                       |
+| Name    | Type                   | Description                                                                                                       |
 |--------|------------------------|----------------------------------------------------------------------------------------------------------|
 | `data` | `List<McpSchema.Tool>` | MCP工具元数据信息,符合[MCP工具元数据标准定义](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool)。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transportType=mcp-sse&baseUrl=%2Fsse&endpoint=http%3A%2F%2Flocalhost'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3818,42 +3818,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transpor
 
 ### 4.7. 验证待导入的MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以验证当前待导入的MCP服务内容是否符合规则，返回的内容中包含有效个数和无效个数，无效的服务在对应字段中有错误信息。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/import/validate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                      |
+| Name           | Type     | Required  | Description                                      |
 |---------------|----------|-------|-----------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID                            |
-| `importType`  | `string` | **是** | enum of `file`, `json`, `url`           |
-| `data`        | `string` | **是** | 导入数据的内容                                 |
-| `cursor`      | `string` | 否     | Optional start cursor for URL-based import pagination. |
-| `limit`       | `integer` | 否     | 分页的页大小                                  |
-| `search`      | `string`   | 否     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID                            |
+| `importType`  | `string` | **Yes** | enum of `file`, `json`, `url`           |
+| `data`        | `string` | **Yes** | 导入数据的内容                                 |
+| `cursor`      | `string` | No     | Optional start cursor for URL-based import pagination. |
+| `limit`       | `integer` | No     | 分页的页大小                                  |
+| `search`      | `string`   | No     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名              | 参数类型                            | 描述        |
+| Name              | Type                            | Description        |
 |------------------|---------------------------------|-----------|
 | `valid`          | `boolean` | 导入服务是否合法。 |
 | `totalCount`     | `integer` | 导入服务总数。   |
@@ -3863,9 +3863,9 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transpor
 | `servers`        | `List<McpServerValidationItem>` | 导入服务列表。   |
 | `errors`         | `List<String>`                  | 导入服务错误列表。 |
 
-其中`McpServerValidationItem`描述如下:
+其中 `McpServerValidationItem` 描述如下:
 
-| 参数名          | 参数类型      | 描述       |
+| Name          | Type      | Description       |
 |--------------|-----------|----------|
 | `serverName` | `string` | 服务名称。    |
 | `serverId`   | `string` | 服务ID。    |
@@ -3873,9 +3873,9 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transpor
 | `selected`   | `boolean` | 服务是否被选中。 |
 | `exists`     | `boolean` | 服务是否已存在。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
@@ -3884,7 +3884,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 -d 'data=' \
 -d 'limit=10'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3916,46 +3916,46 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 
 ### 4.8. 导入的MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以通过`文件`,`JSON`和指定MCP`URL`的方式直接导入MCP服务，避免逐个填写。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/import/execute`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型      | 是否必填  | 描述                                      |
+| Name                | Type      | Required  | Description                                      |
 |--------------------|-----------|-------|-----------------------------------------|
-| `namespaceId`      | `string` | 否     | MCP服务的命名空间ID                            |
-| `importType`       | `string` | **是** | enum of `file`, `json`, `url`           |
-| `data`             | `string` | **是** | 导入数据的内容                                 |
-| `cursor`           | `string` | 否     | Optional start cursor for URL-based import pagination. |
-| `limit`            | `integer` | 否     | 分页的页大小                                  |
-| `search`           | `string`    | 否     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
-| `overrideExisting` | `boolean` | 否     | 导入时若服务已存在时是否覆盖。默认为`false`。              |                                    |
-| `skipInvalid`      | `boolean` | 否     | 导入时是否忽略错误无效的服务。默认为`false`。              |
-| `selectedServers`  | `array` | 否     | Selected services to import. Empty means importing all services. |
+| `namespaceId`      | `string` | No     | MCP服务的命名空间ID                            |
+| `importType`       | `string` | **Yes** | enum of `file`, `json`, `url`           |
+| `data`             | `string` | **Yes** | 导入数据的内容                                 |
+| `cursor`           | `string` | No     | Optional start cursor for URL-based import pagination. |
+| `limit`            | `integer` | No     | 分页的页大小                                  |
+| `search`           | `string`    | No     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
+| `overrideExisting` | `boolean` | No     | 导入时若服务已存在时是否覆盖。默认为`false`。              |                                    |
+| `skipInvalid`      | `boolean` | No     | 导入时是否忽略错误无效的服务。默认为`false`。              |
+| `selectedServers`  | `array` | No     | Selected services to import. Empty means importing all services. |
 
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名            | 参数类型                          | 描述        |
+| Name            | Type                          | Description        |
 |----------------|-------------------------------|-----------|
 | `success`      | `boolean` | 导入服务是否成功。 |
 | `totalCount`   | `integer` | 导入服务总数。   |
@@ -3964,9 +3964,9 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 | `skippedCount` | `integer` | 导入服务跳过个数。 |
 | `results`      | `List<McpServerImportResult>` | 导入服务列表。   |
 
-其中`McpServerImportResult`描述如下:
+其中 `McpServerImportResult` 描述如下:
 
-| 参数名            | 参数类型      | 描述                     |
+| Name            | Type      | Description                     |
 |----------------|-----------|------------------------|
 | `serverName`   | `string` | 服务名称。                  |
 | `serverId`     | `string` | 服务ID。                  |
@@ -3974,9 +3974,9 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 | `errorMessage` | `boolean` | 服务导入失败的错误信息，仅在导入失败时存在。 |
 
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
@@ -3988,7 +3988,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
 -d 'selectedServers=[]' \
 -d 'limit=10'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4017,41 +4017,41 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
 
 ### 5.1. 查询AgentCard的列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的AgentCard的列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                              |
+| Name           | Type     | Required  | Description                                              |
 |---------------|----------|-------|-------------------------------------------------|
-| `pageNo`      | `integer` | **是** | 当前页，默认为`1`                                      |
-| `pageSize`    | `integer` | **是** | 页条目数，默认为`100`                                   |
-| `namespaceId` | `string` | 否     | AgentCard的命名空间ID，默认为`public`                    |
-| `agentName`   | `string` | 否     | AgentCard的名称，为空是查询所有AgentCard                   |
-| `search`      | `string` | **是** | blur or accurate |
+| `pageNo`      | `integer` | **Yes** | 当前页，默认为`1`                                      |
+| `pageSize`    | `integer` | **Yes** | 页条目数，默认为`100`                                   |
+| `namespaceId` | `string` | No     | AgentCard的命名空间ID，默认为`public`                    |
+| `agentName`   | `string` | No     | AgentCard的名称，为空是查询所有AgentCard                   |
+| `search`      | `string` | **Yes** | blur or accurate |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                     | 参数类型                       | 描述                                                                                                     |
+| Name                                     | Type                       | Description                                                                                                     |
 |-----------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------|
 | `totalCount`                            | `integer` | 符合条件的服务的总数。                                                                                            |
 | `pageNumber`                            | `integer` | 当前页码，起始为`1`。                                                                                           |
@@ -4070,21 +4070,21 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
 
 其中`AgentVersionDetail`包含内容如下：
 
-| 参数名         | 参数类型      | 描述              |
+| Name         | Type      | Description              |
 |-------------|-----------|-----------------|
 | `version`   | `string` | AgentCard的版本号。  |
 | `createdAt` | `string` | 该版本的创建时间。       |
 | `updatedAt` | `string` | 该版本的最后更新时间。     |
 | `latest`    | `boolean` | 该版本是否标记为最新发布版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4138,52 +4138,52 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/list?pageNo=1&pageSize=100&
 
 ### 5.2. 查询指定AgentCard的版本列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定托管在Nacos上的AgentCard的版本列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a/version/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                   | 参数类型      | 描述              |
+| Name                   | Type      | Description              |
 |-----------------------|-----------|-----------------|
 | `data`[i].`version`   | `string` | AgentCard的版本号。  |
 | `data`[i].`createdAt` | `string` | 该版本的创建时间。       |
 | `data`[i].`updatedAt` | `string` | 该版本的最后更新时间。     |
 | `data`[i].`latest`    | `boolean` | 该版本是否标记为最新发布版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/version/list?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4200,40 +4200,40 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/version/list?namespaceId=pu
 
 ### 5.3. 查询AgentCard的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定AgentCard的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型     | 是否必填  | 描述                                                                                 |
+| Name                | Type     | Required  | Description                                                                                 |
 |--------------------|----------|-------|------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                        |
-| `agentName`        | `string` | **是** | AgentCard的名称                                                                       |
-| `version`          | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情                                                          |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                        |
+| `agentName`        | `string` | **Yes** | AgentCard的名称                                                                       |
+| `version`          | `string` | No     | AgentCard的版本号，为空时返回最新版本详情                                                          |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                 | 参数类型                              | 描述                                                                                                       |
+| Name                                 | Type                              | Description                                                                                                       |
 |-------------------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `protocolVersion`                   | `string` | AgentCard的A2A协议版本。                                                                                       |
 | `name`                              | `string` | AgentCard的名称。                                                                                            |
@@ -4256,14 +4256,14 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/version/list?namespaceId=pu
 | `latestVersion`                     | `string` | AgentCard当前版本时否为最新版本。                                                                                    |
 
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0&registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4335,47 +4335,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agentNam
 
 ### 5.4. 更新AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                                                     |
-| `agentCard`        | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成                              |
-| `setAsLatest`      | `boolean` | 否     | 是否设置此版本为最新发布版本，默认为false                                                                                         |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                                                     |
+| `agentCard`        | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成                              |
+| `setAsLatest`      | `boolean` | No     | 是否设置此版本为最新发布版本，默认为false                                                                                         |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述               |
+| Name    | Type     | Description               |
 |--------|----------|------------------|
 | `data` | `string` | AgentCard服务更新结果。 |
 
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/a2a' \
@@ -4384,7 +4384,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 -d 'registrationType=SERVICE' \
 -d 'setAsLatest=true'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4396,45 +4396,45 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 
 ### 5.5. 创建AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                                                     |
-| `agentCard`        | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认值为`URL`                   |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                                                     |
+| `agentCard`        | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认为`URL`                   |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard发布结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/a2a' \
@@ -4442,7 +4442,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 -d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '1600 Amphitheatre Parkway, Mountain View, CA' to 'San Francisco International Airport' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \
 -d 'registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4454,50 +4454,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 
 ### 5.6. 删除AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
-| `version`     | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情   |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
+| `version`     | `string` | No     | AgentCard的版本号，为空时返回最新版本详情   |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4512,49 +4512,49 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agent
 Prompt 管理 API 提供 Prompt 的草稿、发布、上下线、治理查询、版本查询与下载能力。
 
 ### 6.1. Delete Prompt
-#### 接口描述
+#### Description
 This interface allows deleting a specific Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `boolean` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4566,50 +4566,50 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt?namespaceId=public&pr
 
 
 ### 6.2. Update Prompt Biz Tags
-#### 接口描述
+#### Description
 This interface updates Prompt biz tags.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `bizTags` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `bizTags` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/biz-tags' -d "namespaceId=namespaceId&promptKey=promptKey&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4621,50 +4621,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/biz-tags' -d "namespaceI
 
 
 ### 6.3. Update Prompt Description
-#### 接口描述
+#### Description
 This interface updates the Prompt description.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/description`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `description` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `description` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/description' -d "namespaceId=namespaceId&promptKey=promptKey&description=description"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4676,56 +4676,56 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/description' -d "namespa
 
 
 ### 6.4. Create Prompt Draft
-#### 接口描述
+#### Description
 This interface creates a Prompt draft version or forks a draft from an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `basedOnVersion` | `string` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `template` | `string` | 否 | - |
-| `variables` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
-| `description` | `string` | 否 | - |
-| `bizTags` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `basedOnVersion` | `string` | No | - |
+| `targetVersion` | `string` | No | - |
+| `template` | `string` | No | - |
+| `variables` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
+| `description` | `string` | No | - |
+| `bizTags` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=namespaceId&promptKey=promptKey&basedOnVersion=basedOnVersion&targetVersion=targetVersion&template=template&variables=variables&commitMsg=commitMsg&description=description&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4737,52 +4737,52 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=
 
 
 ### 6.5. Update Prompt Draft
-#### 接口描述
+#### Description
 This interface updates the current Prompt draft content.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `template` | `string` | **是** | - |
-| `variables` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `template` | `string` | **Yes** | - |
+| `variables` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=namespaceId&promptKey=promptKey&template=template&variables=variables&commitMsg=commitMsg"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4794,49 +4794,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=n
 
 
 ### 6.6. Delete Prompt Draft
-#### 接口描述
+#### Description
 This interface deletes the current Prompt draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt/draft?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4848,51 +4848,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt/draft?namespaceId=pub
 
 
 ### 6.7. Force Publish Prompt Version
-#### 接口描述
+#### Description
 This interface force-publishes a Prompt version by bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/force-publish' -d "namespaceId=namespaceId&promptKey=promptKey&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4904,35 +4904,35 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/force-publish' -d "name
 
 
 ### 6.8. Get Prompt Governance Detail
-#### 接口描述
+#### Description
 This interface retrieves Prompt metadata, version governance information, and version summaries.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/governance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -4951,15 +4951,15 @@ This interface retrieves Prompt metadata, version governance information, and ve
 | data.data.versions | `array` | - |
 | data.data.versionDetails | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/governance?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4971,50 +4971,50 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/governance?namespaceId=p
 
 
 ### 6.9. Update Prompt Labels
-#### 接口描述
+#### Description
 This interface updates runtime routing labels of a Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `labels` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `labels` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/labels' -d "namespaceId=namespaceId&promptKey=promptKey&labels=labels"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5026,53 +5026,53 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/labels' -d "namespaceId=
 
 
 ### 6.10. List Prompts
-#### 接口描述
+#### Description
 This interface allows listing Prompts with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | 否 | - |
-| `search` | `string` | 否 | blur or accurate |
-| `bizTags` | `string` | 否 | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | No | - |
+| `search` | `string` | No | blur or accurate |
+| `bizTags` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/list?pageNo=1&pageSize=10&namespaceId=public&promptKey=my-prompt&search=blur&bizTags=tag-a'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5084,50 +5084,50 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/list?pageNo=1&pageSize=1
 
 
 ### 6.11. Offline Prompt Version
-#### 接口描述
+#### Description
 This interface takes a specified Prompt version offline.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/offline' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5139,50 +5139,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/offline' -d "namespaceI
 
 
 ### 6.12. Online Prompt Version
-#### 接口描述
+#### Description
 This interface brings a specified Prompt version online.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/online' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5194,51 +5194,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/online' -d "namespaceId
 
 
 ### 6.13. Publish Prompt Version
-#### 接口描述
+#### Description
 This interface publishes an approved Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/publish' -d "namespaceId=namespaceId&promptKey=promptKey&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5250,50 +5250,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/publish' -d "namespaceI
 
 
 ### 6.14. Redraft Prompt Version
-#### 接口描述
+#### Description
 This interface transitions a reviewed Prompt version back to draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/redraft' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5305,50 +5305,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/redraft' -d "namespaceI
 
 
 ### 6.15. Submit Prompt Version
-#### 接口描述
+#### Description
 This interface submits a Prompt version for pipeline review.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/submit' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5360,36 +5360,36 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/submit' -d "namespaceId
 
 
 ### 6.16. Get Prompt Version Detail
-#### 接口描述
+#### Description
 This interface retrieves details of a specified Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -5405,15 +5405,15 @@ This interface retrieves details of a specified Prompt version.
 | data.data.md5 | `string` | - |
 | data.data.variables | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version?namespaceId=public&promptKey=my-prompt&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5425,42 +5425,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version?namespaceId=publ
 
 
 ### 6.17. Download Prompt Version
-#### 接口描述
+#### Description
 This interface downloads a specified Prompt version as a Markdown file.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version/download?namespaceId=public&promptKey=my-prompt&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5472,51 +5472,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version/download?namespa
 
 
 ### 6.18. List Prompt Versions
-#### 接口描述
+#### Description
 This interface allows listing versions of a specific Prompt with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/versions`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/versions?namespaceId=public&promptKey=my-prompt&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5531,36 +5531,36 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/versions?namespaceId=pub
 Skills 管理 API 提供 Skill 的查询、草稿、发布、上下线、版本管理与 ZIP 上传能力。
 
 ### 7.1. Get Skill Details
-#### 接口描述
+#### Description
 This interface allows retrieving detailed information of a specific Skill hosted on Nacos.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -5580,15 +5580,15 @@ This interface allows retrieving detailed information of a specific Skill hosted
 | data.data.downloadCount | `integer` | - |
 | data.data.versions | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5600,50 +5600,50 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&skill
 
 
 ### 7.2. Delete Skill
-#### 接口描述
+#### Description
 This interface allows deleting a Skill hosted on Nacos.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5655,50 +5655,50 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&sk
 
 
 ### 7.3. Update Skill Business Tags
-#### 接口描述
+#### Description
 This interface allows updating the business tag list of a skill without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `bizTags` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `bizTags` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/biz-tags' -d "namespaceId=public&skillName=my-skill&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5710,52 +5710,52 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/biz-tags' -d "namespaceI
 
 
 ### 7.4. Create Skill Draft Version
-#### 接口描述
+#### Description
 This interface allows creating a draft version based on an existing version or a brand-new SkillCard.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | 否 | - |
-| `basedOnVersion` | `string` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `skillCard` | `string` | 否 | Skill card JSON; required if basedOnVersion is not set |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | No | - |
+| `basedOnVersion` | `string` | No | - |
+| `targetVersion` | `string` | No | - |
+| `skillCard` | `string` | No | Skill card JSON; required if basedOnVersion is not set |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=public&skillName=my-skill&basedOnVersion=basedOnVersion&targetVersion=targetVersion&skillCard=skillCard"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5767,50 +5767,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=
 
 
 ### 7.5. Update Skill Draft Content
-#### 接口描述
+#### Description
 This interface allows updating the SkillCard content of the current draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `skillCard` | `string` | **是** | Skill card JSON string containing complete Skill information |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `skillCard` | `string` | **Yes** | Skill card JSON string containing complete Skill information |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=public&skillName=my-skill&skillCard=skillCard"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5822,49 +5822,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=p
 
 
 ### 7.6. Delete Skill Draft Version
-#### 接口描述
+#### Description
 This interface allows deleting the current draft version of a specified skill.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills/draft?namespaceId=public&skillName=my-skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5876,51 +5876,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills/draft?namespaceId=pub
 
 
 ### 7.7. Force Publish Skill Version
-#### 接口描述
+#### Description
 This interface force-publishes a Skill version by bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/force-publish' -d "namespaceId=public&skillName=my-skill&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5932,50 +5932,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/force-publish' -d "name
 
 
 ### 7.8. Update Skill Version Labels
-#### 接口描述
+#### Description
 This interface allows updating skill version routing labels (e.g. latest label) without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `labels` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `labels` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/labels' -d "namespaceId=public&skillName=my-skill&labels=labels"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5987,53 +5987,53 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/labels' -d "namespaceId=
 
 
 ### 7.9. List Skills
-#### 接口描述
+#### Description
 This interface allows querying the list of Skills hosted on Nacos.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `filterableForm` | `string` | **是** | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | 否 | - |
-| `search` | `string` | 否 | blur or accurate |
+| `filterableForm` | `string` | **Yes** | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | No | - |
+| `search` | `string` | No | blur or accurate |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?filterableForm=true&pageNo=1&pageSize=10&namespaceId=public&skillName=my-skill&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6045,51 +6045,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?filterableForm=true
 
 
 ### 7.10. Offline Skill
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire skill, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'skill' for skill-level offline; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'skill' for skill-level offline; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/offline' -d "namespaceId=public&skillName=my-skill&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6101,51 +6101,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/offline' -d "namespaceI
 
 
 ### 7.11. Online Skill
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire skill, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'skill' for skill-level online; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'skill' for skill-level online; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/online' -d "namespaceId=public&skillName=my-skill&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6157,51 +6157,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/online' -d "namespaceId
 
 
 ### 7.12. Publish Skill Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved skill version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/publish' -d "namespaceId=public&skillName=my-skill&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6213,50 +6213,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/publish' -d "namespaceI
 
 
 ### 7.13. Redraft Skill Version
-#### 接口描述
+#### Description
 This interface transitions a reviewed Skill version back to draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/redraft' -d "namespaceId=public&skillName=my-skill&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6268,50 +6268,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/redraft' -d "namespaceI
 
 
 ### 7.14. Update Skill Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of a skill to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/scope' -d "namespaceId=public&skillName=my-skill&scope=scope"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6323,50 +6323,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/scope' -d "namespaceId=p
 
 
 ### 7.15. Submit Skill Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting a skill draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/submit' -d "namespaceId=public&skillName=my-skill&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6378,61 +6378,61 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/submit' -d "namespaceId
 
 
 ### 7.16. Upload Skill (ZIP)
-#### 接口描述
+#### Description
 This interface allows uploading a Skill from a ZIP file.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`（如文件上传），请求示例中需使用 `-F` 或 `-H 'Content-Type: multipart/form-data'`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
+| `targetVersion` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `file` | `file` | 否 | ZIP file containing skill |
-| `overwrite` | `boolean` | 否 | - |
-| `namespaceId` | `string` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
+| `file` | `file` | No | ZIP file containing skill |
+| `overwrite` | `boolean` | No | - |
+| `namespaceId` | `string` | No | - |
+| `targetVersion` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload?namespaceId=public&overwrite=false&targetVersion=1.0.0&commitMsg=init' -F "file=@/path/to/skill.zip" -F "overwrite=false" -F "namespaceId=public" -F "targetVersion=1.0.0" -F "commitMsg=init"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6444,58 +6444,58 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload?namespaceId=publ
 
 
 ### 7.17. Batch Upload Skills
-#### 接口描述
+#### Description
 This interface uploads multiple Skills from a ZIP file that contains one-level Skill subdirectories.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`（如文件上传），请求示例中需使用 `-F` 或 `-H 'Content-Type: multipart/form-data'`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/upload/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
-| `file` | `file` | 否 | ZIP file containing skill directories |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
+| `file` | `file` | No | ZIP file containing skill directories |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data.succeeded | `array` | - |
 | data.data.failed | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload/batch?namespaceId=public&overwrite=false' -F "namespaceId=public" -F "overwrite=false" -F "file=@/path/to/skills.zip"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6507,36 +6507,36 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload/batch?namespaceI
 
 
 ### 7.18. Get Skill Version Detail
-#### 接口描述
+#### Description
 This interface allows querying the detail of a specific Skill version by namespace, skill name, and version number.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -6546,15 +6546,15 @@ This interface allows querying the detail of a specific Skill version by namespa
 | data.data.skillMd | `string` | - |
 | data.data.resource | `object` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6566,42 +6566,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version?namespaceId=publ
 
 
 ### 7.19. Download Skill Version ZIP
-#### 接口描述
+#### Description
 This interface allows downloading the ZIP package of a specific Skill version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version/download?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6616,36 +6616,36 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version/download?namespa
 AgentSpec 管理 API 提供 AgentSpec 的查询、草稿、发布、上下线、版本管理与 ZIP 上传能力。
 
 ### 8.1. Get AgentSpec
-#### 接口描述
+#### Description
 This interface allows getting the latest published version of an AgentSpec by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -6664,15 +6664,15 @@ This interface allows getting the latest published version of an AgentSpec by na
 | data.data.downloadCount | `integer` | - |
 | data.data.versions | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=public&agentSpecName=my-agent&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6684,49 +6684,49 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=public&a
 
 
 ### 8.2. Delete AgentSpec
-#### 接口描述
+#### Description
 This interface allows deleting an AgentSpec and all its versions by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=public&agentSpecName=my-agent'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6738,50 +6738,50 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=publi
 
 
 ### 8.3. Update AgentSpec Business Tags
-#### 接口描述
+#### Description
 This interface allows updating the business tag list of an AgentSpec without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `bizTags` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `bizTags` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/biz-tags' -d "namespaceId=public&agentSpecName=my-agent&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6793,50 +6793,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/biz-tags' -d "namesp
 
 
 ### 8.4. Create AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows creating an AgentSpec draft version based on an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `basedOnVersion` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `basedOnVersion` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agent&basedOnVersion=basedOnVersion"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6848,50 +6848,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespac
 
 
 ### 8.5. Update AgentSpec Draft Content
-#### 接口描述
+#### Description
 This interface allows updating the card content of the current AgentSpec draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | 否 | - |
-| `agentSpecCard` | `string` | **是** | AgentSpec card JSON string containing complete AgentSpec information |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | No | - |
+| `agentSpecCard` | `string` | **Yes** | AgentSpec card JSON string containing complete AgentSpec information |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agent&agentSpecCard=agentSpecCard"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6903,49 +6903,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespace
 
 
 ### 8.6. Delete AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows deleting the current draft version of a specified AgentSpec.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft?namespaceId=public&agentSpecName=my-agent'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6957,51 +6957,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft?namespaceId
 
 
 ### 8.7. Force Publish AgentSpec Version
-#### 接口描述
+#### Description
 This interface force-publishes an AgentSpec version by bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/force-publish' -d "namespaceId=public&agentSpecName=my-agent&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7013,50 +7013,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/force-publish' -d "
 
 
 ### 8.8. Update AgentSpec Version Labels
-#### 接口描述
+#### Description
 This interface allows updating AgentSpec version routing labels (e.g. latest label) without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `labels` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `labels` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/labels' -d "namespaceId=public&agentSpecName=my-agent&labels=labels"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7068,53 +7068,53 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/labels' -d "namespac
 
 
 ### 8.9. List AgentSpecs
-#### 接口描述
+#### Description
 This interface allows paginated listing of AgentSpecs by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `filterableForm` | `string` | **是** | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | 否 | - |
-| `search` | `string` | 否 | Search mode: accurate or blur |
+| `filterableForm` | `string` | **Yes** | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | No | - |
+| `search` | `string` | No | Search mode: accurate or blur |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/list?filterableForm=true&pageNo=1&pageSize=10&namespaceId=public&agentSpecName=my-agent&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7126,51 +7126,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/list?filterableForm=
 
 
 ### 8.10. Offline AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire AgentSpec, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level offline; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level offline; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/offline' -d "namespaceId=public&agentSpecName=my-agent&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7182,51 +7182,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/offline' -d "namesp
 
 
 ### 8.11. Online AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire AgentSpec, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level online; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level online; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/online' -d "namespaceId=public&agentSpecName=my-agent&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7238,51 +7238,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/online' -d "namespa
 
 
 ### 8.12. Publish AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved AgentSpec version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/publish' -d "namespaceId=public&agentSpecName=my-agent&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7294,50 +7294,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/publish' -d "namesp
 
 
 ### 8.13. Redraft AgentSpec Version
-#### 接口描述
+#### Description
 This interface transitions a reviewed AgentSpec version back to draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/redraft' -d "namespaceId=public&agentSpecName=my-agent&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7349,50 +7349,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/redraft' -d "namesp
 
 
 ### 8.14. Update AgentSpec Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of an AgentSpec to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/scope' -d "namespaceId=public&agentSpecName=my-agent&scope=scope"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7404,50 +7404,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/scope' -d "namespace
 
 
 ### 8.15. Submit AgentSpec Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting an AgentSpec draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/submit' -d "namespaceId=public&agentSpecName=my-agent&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7459,57 +7459,57 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/submit' -d "namespa
 
 
 ### 8.16. Upload AgentSpec
-#### 接口描述
+#### Description
 This interface allows uploading a ZIP-packaged AgentSpec; the package is parsed and the AgentSpec is created or updated.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`（如文件上传），请求示例中需使用 `-F` 或 `-H 'Content-Type: multipart/form-data'`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
-| `file` | `file` | 否 | ZIP file containing agentspec package |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
+| `file` | `file` | No | ZIP file containing agentspec package |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/upload?namespaceId=public&overwrite=false' -F "namespaceId=public" -F "overwrite=false" -F "file=@/path/to/skills.zip"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7521,36 +7521,36 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/upload?namespaceId=
 
 
 ### 8.17. Get AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows getting a specific version of an AgentSpec by namespace, name, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7561,15 +7561,15 @@ This interface allows getting a specific version of an AgentSpec by namespace, n
 | data.data.content | `string` | - |
 | data.data.resource | `object` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/version?namespaceId=public&agentSpecName=my-agent&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7584,53 +7584,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/version?namespaceId=
 Pipeline 管理 API 提供 Pipeline 执行记录列表、详情与实例查询能力。
 
 ### 9.1. List Pipeline Executions
-#### 接口描述
+#### Description
 This interface allows paginated listing of Pipeline execution records by resource type, name, namespace, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | - |
-| `resourceName` | `string` | 否 | - |
-| `namespaceId` | `string` | 否 | - |
-| `version` | `string` | 否 | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
+| `resourceType` | `string` | **Yes** | - |
+| `resourceName` | `string` | No | - |
+| `namespaceId` | `string` | No | - |
+| `version` | `string` | No | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines?resourceType=skill&resourceName=my-skill&namespaceId=public&version=1.0.0&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7642,34 +7642,34 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines?resourceType=skill&re
 
 
 ### 9.2. Get Pipeline Execution
-#### 接口描述
+#### Description
 This interface allows retrieving a Pipeline execution record by pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | - |
+| `pipelineId` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7683,15 +7683,15 @@ This interface allows retrieving a Pipeline execution record by pipeline ID.
 | data.data.createTime | `integer` | - |
 | data.data.updateTime | `integer` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/detail?pipelineId=pipeline-001'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7703,53 +7703,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/detail?pipelineId=pip
 
 
 ### 9.3. List Pipeline Executions
-#### 接口描述
+#### Description
 This interface allows paginated listing of Pipeline execution records by resource type, name, namespace, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | - |
-| `resourceName` | `string` | 否 | - |
-| `namespaceId` | `string` | 否 | - |
-| `version` | `string` | 否 | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
+| `resourceType` | `string` | **Yes** | - |
+| `resourceName` | `string` | No | - |
+| `namespaceId` | `string` | No | - |
+| `version` | `string` | No | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/list?resourceType=skill&resourceName=my-skill&namespaceId=public&version=1.0.0&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7761,34 +7761,34 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/list?resourceType=ski
 
 
 ### 9.4. Get Pipeline Execution
-#### 接口描述
+#### Description
 This interface allows retrieving a Pipeline execution record by pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines/{pipelineId}`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | - |
+| `pipelineId` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7802,15 +7802,15 @@ This interface allows retrieving a Pipeline execution record by pipeline ID.
 | data.data.createTime | `integer` | - |
 | data.data.updateTime | `integer` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/{pipelineId}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7825,41 +7825,41 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/{pipelineId}'
 AI 资源导入 API 提供外部 AI 资源导入源查询、搜索、校验与执行能力。
 
 ### 10.1. Execute AI Resource Import
-#### 接口描述
+#### Description
 This interface imports selected external AI resources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/execute`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `resourceType` | `string` | **是** | - |
-| `sourceId` | `string` | **是** | - |
-| `selectedItems` | `string` | **是** | - |
-| `overwriteExisting` | `boolean` | 否 | - |
-| `skipInvalid` | `boolean` | 否 | - |
-| `validationToken` | `string` | 否 | - |
-| `options` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `resourceType` | `string` | **Yes** | - |
+| `sourceId` | `string` | **Yes** | - |
+| `selectedItems` | `string` | **Yes** | - |
+| `overwriteExisting` | `boolean` | No | - |
+| `skipInvalid` | `boolean` | No | - |
+| `validationToken` | `string` | No | - |
+| `options` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7870,15 +7870,15 @@ This interface imports selected external AI resources.
 | data.data.skippedCount | `integer` | - |
 | data.data.results | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/execute' -d "namespaceId=namespaceId&resourceType=resourceType&sourceId=sourceId&selectedItems=selectedItems&overwriteExisting=overwriteExisting&skipInvalid=skipInvalid&validationToken=validationToken&options=options"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7890,40 +7890,40 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/execute' -d "namespaceI
 
 
 ### 10.2. Search External AI Resources
-#### 接口描述
+#### Description
 This interface searches importable external AI resources from a specified source.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/search`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `resourceType` | `string` | **是** | - |
-| `sourceId` | `string` | **是** | - |
-| `query` | `string` | 否 | - |
-| `cursor` | `string` | 否 | - |
-| `limit` | `integer` | 否 | - |
-| `options` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `resourceType` | `string` | **Yes** | - |
+| `sourceId` | `string` | **Yes** | - |
+| `query` | `string` | No | - |
+| `cursor` | `string` | No | - |
+| `limit` | `integer` | No | - |
+| `options` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7933,15 +7933,15 @@ This interface searches importable external AI resources from a specified source
 | data.data.hasMore | `boolean` | - |
 | data.data.items | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/search' -d "namespaceId=namespaceId&resourceType=resourceType&sourceId=sourceId&query=query&cursor=cursor&limit=limit&options=options"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7953,48 +7953,48 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/search' -d "namespaceId
 
 
 ### 10.3. List AI Resource Import Sources
-#### 接口描述
+#### Description
 This interface lists configured AI resource import sources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/sources`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | 否 | - |
+| `resourceType` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/import/sources?resourceType=skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8006,39 +8006,39 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/import/sources?resourceType=ski
 
 
 ### 10.4. Validate AI Resource Import Items
-#### 接口描述
+#### Description
 This interface validates selected external AI resources before import.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/validate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `resourceType` | `string` | **是** | - |
-| `sourceId` | `string` | **是** | - |
-| `selectedItems` | `string` | **是** | - |
-| `overwriteExisting` | `boolean` | 否 | - |
-| `options` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `resourceType` | `string` | **Yes** | - |
+| `sourceId` | `string` | **Yes** | - |
+| `selectedItems` | `string` | **Yes** | - |
+| `overwriteExisting` | `boolean` | No | - |
+| `options` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -8047,15 +8047,15 @@ This interface validates selected external AI resources before import.
 | data.data.validationToken | `string` | - |
 | data.data.items | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/validate' -d "namespaceId=namespaceId&resourceType=resourceType&sourceId=sourceId&selectedItems=selectedItems&overwriteExisting=overwriteExisting&options=options"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8071,33 +8071,33 @@ Copilot 相关 API 提供配置获取/保存、Prompt 调试与优化、Skill �
 
 ### 11.1. 获取Copilot配置
 
-#### 接口描述
+#### Description
 
 获取当前Copilot配置，仅返回apiKey、model、studioUrl、studioProject。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/config`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.enabled | `boolean` | Copilot 功能是否启用。 |
 | data.defaultNamespace | `string` | 默认使用的命名空间 ID。 |
@@ -8106,15 +8106,15 @@ Copilot 相关 API 提供配置获取/保存、Prompt 调试与优化、Skill �
 | data.studioUrl | `string` | 关联的 Studio 服务地址。 |
 | data.studioProject | `string` | 关联的 Studio 项目标识。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/copilot/config'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8131,45 +8131,45 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/copilot/config'
 
 ### 11.2. 保存Copilot配置
 
-#### 接口描述
+#### Description
 
-创建或更新Copilot配置，仅接受apiKey、model、studioUrl、studioProject，其他字段使用默认值。
+创建或更新Copilot配置，仅接受apiKey、model、studioUrl、studioProject，其他字段使用Default。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/config`
 
-#### 请求参数
+#### Request Parameters
 
 无（请求体可传 apiKey、model、studioUrl、studioProject 等字段，具体以实际接口为准）。
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | 是否保存成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/config'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8181,48 +8181,48 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/config'
 
 ### 11.3. 流式调试Prompt
 
-#### 接口描述
+#### Description
 
 通过该接口，可使用用户输入流式调试Prompt并返回模型响应，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/prompt/debug`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名       | 类型     | 必填 | 参数描述     |
+| Name       | Type     | Required | Description     |
 |-----------|--------|----|----------|
-| `userInput` | `string` | 否 | 用户输入内容。 |
-| `prompt`    | `string` | 否 | 待调试的 Prompt。 |
+| `userInput` | `string` | No | 用户输入内容。 |
+| `prompt`    | `string` | No | 待调试的 Prompt。 |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/debug' -H 'Content-Type: application/json' -d '{"userInput":"","prompt":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}
@@ -8230,48 +8230,48 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/debug' -H 'Content
 
 ### 11.4. 流式优化Prompt
 
-#### 接口描述
+#### Description
 
 通过该接口，可流式优化Prompt，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/prompt/optimize`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名              | 类型     | 必填 | 参数描述        |
+| Name              | Type     | Required | Description        |
 |------------------|--------|----|-------------|
-| `optimizationGoal` | `string` | 否 | 优化目标。       |
-| `prompt`           | `string` | 否 | 待优化的 Prompt。 |
+| `optimizationGoal` | `string` | No | 优化目标。       |
+| `prompt`           | `string` | No | 待优化的 Prompt。 |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/optimize' -H 'Content-Type: application/json' -d '{"optimizationGoal":"","prompt":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}
@@ -8279,49 +8279,49 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/optimize' -H 'Cont
 
 ### 11.5. 流式生成Skill
 
-#### 接口描述
+#### Description
 
 通过该接口，可基于背景信息流式生成Skill，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/skill/generate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型     | 必填 | 参数描述           |
+| Name                | Type     | Required | Description           |
 |--------------------|--------|----|----------------|
-| `backgroundInfo`     | `string` | 否 | 背景信息。           |
-| `selectedMcpTools`   | `array` | 否 | 选中的 MCP 工具。      |
-| `conversationHistory` | `object` | 否 | 对话历史。           |
+| `backgroundInfo`     | `string` | No | 背景信息。           |
+| `selectedMcpTools`   | `array` | No | 选中的 MCP 工具。      |
+| `conversationHistory` | `object` | No | 对话历史。           |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/skill/generate' -H 'Content-Type: application/json' -d '{"backgroundInfo":"","selectedMcpTools":"","conversationHistory":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}
@@ -8329,51 +8329,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/skill/generate' -H 'Conte
 
 ### 11.6. 流式优化Skill
 
-#### 接口描述
+#### Description
 
 通过该接口，可基于目标与对话历史流式优化Skill，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/skill/optimize`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型     | 必填 | 参数描述           |
+| Name                | Type     | Required | Description           |
 |--------------------|--------|----|----------------|
-| `conversationHistory` | `object` | 否 | 对话历史。           |
-| `targetFileName`      | `string` | 否 | 目标文件名。          |
-| `optimizationGoal`    | `string` | 否 | 优化目标。           |
-| `skill`               | `string` | 否 | 待优化的 Skill 内容。   |
-| `selectedMcpTools`   | `array` | 否 | 选中的 MCP 工具。      |
+| `conversationHistory` | `object` | No | 对话历史。           |
+| `targetFileName`      | `string` | No | 目标文件名。          |
+| `optimizationGoal`    | `string` | No | 优化目标。           |
+| `skill`               | `string` | No | 待优化的 Skill 内容。   |
+| `selectedMcpTools`   | `array` | No | 选中的 MCP 工具。      |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/skill/optimize' -H 'Content-Type: application/json' -d '{"conversationHistory":"","targetFileName":"","optimizationGoal":"","skill":"","selectedMcpTools":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}

--- a/src/content/docs/next/en/manual/admin/admin-api.md
+++ b/src/content/docs/next/en/manual/admin/admin-api.md
@@ -690,7 +690,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=
 
 `POST`
 
-请求体Type：`application/json`，参数放在请求体中。
+请求体类型：`application/json`，参数放在请求体中。
 
 #### Authorization
 
@@ -757,7 +757,7 @@ curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/
 
 `PUT`
 
-请求体Type：`application/json`，参数放在请求体中。
+请求体类型：`application/json`，参数放在请求体中。
 
 #### Authorization
 
@@ -1046,7 +1046,7 @@ Administrator permissions required.
 |--------|----------|------|
 | namespace | `string` | 命名空间 ID |
 | namespaceShowName | `string` | 命名空间展示名 |
-| namespaceDesc | `string` | 命名空间Description |
+| namespaceDesc | `string` | 命名空间描述 |
 | quota | `integer` | 配置数量配额 |
 | configCount | `integer` | 当前配置数量 |
 | type | `integer` | Type |
@@ -1104,7 +1104,7 @@ Administrator permissions required.
 |--------|------|------|----------|
 | `namespaceId` | `string` | **Yes** | 命名空间 ID |
 | `namespaceName` | `string` | **Yes** | 命名空间展示名 |
-| `namespaceDesc` | `string` | No | 命名空间Description |
+| `namespaceDesc` | `string` | No | 命名空间描述 |
 
 #### Response Data
 
@@ -1157,7 +1157,7 @@ Administrator permissions required.
 |--------|------|------|----------|
 | `namespaceId` | `string` | No | 命名空间 ID，不传则由服务端生成 |
 | `namespaceName` | `string` | **Yes** | 命名空间展示名 |
-| `namespaceDesc` | `string` | No | 命名空间Description |
+| `namespaceDesc` | `string` | No | 命名空间描述 |
 
 #### Response Data
 
@@ -1498,7 +1498,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 #### Description
 
-通过该接口，可以更新插件的配置。需要提供插件Type、Name及配置内容。支持 localOnly 仅作用于当前节点。
+通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。支持 localOnly 仅作用于当前节点。
 
 #### Since
 
@@ -1508,7 +1508,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 `PUT`
 
-请求体Type：`application/json`。
+请求体类型：`application/json`。
 
 #### Authorization
 
@@ -1524,8 +1524,8 @@ Administrator permissions required.
 
 | Name         | Type       | Required | Description           |
 |-------------|----------|----|----------------|
-| `pluginType` | `string` | **Yes** | 插件Type，如 auth。 |
-| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `pluginType` | `string` | **Yes** | 插件类型，如 auth。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
 | `config` | `string` | **Yes** | 插件配置项。 |
 | `localOnly` | `boolean` | No | 是否仅写本地，不持久化。 |
 
@@ -1556,7 +1556,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
 
 #### Description
 
-通过该接口，可以按Type和Name获取指定插件的详情信息。
+通过该接口，可以按类型和名称获取指定插件的详情信息。
 
 #### Since
 
@@ -1578,8 +1578,8 @@ Administrator permissions required.
 
 | Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **Yes** | 插件Type，如 auth |
-| `pluginName` | `string` | **Yes** | 插件Name |
+| `pluginType` | `string` | **Yes** | 插件类型，如 auth |
+| `pluginName` | `string` | **Yes** | 插件名称 |
 
 #### Response Data
 
@@ -1588,8 +1588,8 @@ Administrator permissions required.
 | Name | Type | Description |
 |--------|----------|------|
 | pluginId | `string` | 插件 ID |
-| pluginType | `string` | 插件Type |
-| pluginName | `string` | 插件Name |
+| pluginType | `string` | 插件类型 |
+| pluginName | `string` | 插件名称 |
 | enabled | `boolean` | 是否启用 |
 | critical | `boolean` | 是否关键插件 |
 | configurable | `boolean` | 是否可配置 |
@@ -1627,7 +1627,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=
 
 #### Description
 
-通过该接口，可以获取所有插件列表，可按插件Type筛选。
+通过该接口，可以获取所有插件列表，可按插件类型筛选。
 
 #### Since
 
@@ -1649,7 +1649,7 @@ Administrator permissions required.
 
 | Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | No | 插件Type，不传则返回全部 |
+| `pluginType` | `string` | No | 插件类型，不传则返回全部 |
 
 #### Response Data
 
@@ -1697,7 +1697,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 `PUT`
 
-请求体Type：`application/json`。
+请求体类型：`application/json`。
 
 #### Authorization
 
@@ -1713,8 +1713,8 @@ Administrator permissions required.
 
 | Name         | Type        | Required | Description       |
 |-------------|-----------|----|------------|
-| `pluginType` | `string` | **Yes** | 插件Type。 |
-| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `pluginType` | `string` | **Yes** | 插件类型。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
 | `enabled` | `boolean` | **Yes** | 是否启用。 |
 | `localOnly` | `boolean` | No | 是否仅写本地。 |
 
@@ -1792,7 +1792,7 @@ Administrator permissions required.
 * Request example
 
 ```shell
-curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' 
+curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches'
 ```
 
 * Response example
@@ -1994,7 +1994,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/metrics?onlyStatus=fals
 
 `PUT`
 
-请求体Type：`application/json`。
+请求体类型：`application/json`。
 
 #### Authorization
 
@@ -2131,7 +2131,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/list'
 | `lastUpdatedTime` | `integer` | 客户端的最后更新时间（时间戳）    |
 | `clientType`      | `string` | 客户端Type              |
 | `connectType`     | `string` | 连接Type（仅适用于 2.x 客户端） |
-| `appName`         | `string` | 客户端所属的应用Name         |
+| `appName`         | `string` | 客户端所属的应用名称         |
 | `version`         | `string` | 客户端的版本号            |
 | `clientIp`        | `string` | 客户端的 IP 地址         |
 | `clientPort`      | `string` | 客户端的端口号            |
@@ -2552,7 +2552,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/distro?ip=127.0.0.1&
 | Name                     | Type                  | Required  | Description                |
 |-------------------------|-----------------------|-------|-------------------|
 | `namespaceId` | `string` | No | 命名空间ID |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `clusterName` | `string` | **Yes** | 集群Name |
 | `checkPort` | `integer` | No | 健康检查端口 |
 | `useInstancePort4Check` | `boolean` | No | 是否使用实例端口进行健康检查 |
@@ -2614,7 +2614,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/cluster' -d 'serviceName=te
 | Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2735,7 +2735,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/checkers'
 | Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2798,7 +2798,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 | Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2864,7 +2864,7 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=pub
 | Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
 | `ip` | `string` | **Yes** | 实例IP |
@@ -2927,7 +2927,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 | Name               | Type                  | Required  | Description                                                                                           |
 |-------------------|-----------------------|-------|----------------------------------------------------------------------------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `instances` | `string` | No | 实例列表（JSON数组 字符串）默认为`""`表示所有实例更新；若指定时，每个元素代表一个需要更新的实例，必须需要包含`ip`和`port`字段，`clusterName`字段为可选, |
 | `metadata` | `string` | **Yes** | 元数据 |
@@ -2989,7 +2989,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch' \
 | Name               | Type                  | Required  | Description                      |
 |-------------------|-----------------------|-------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
 | `instances` | `string` | No | 实例列表（JSON 字符串），默认为`""` |
 | `metadata` | `string` | **Yes** | 元数据 |
@@ -3054,7 +3054,7 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch?
 | **Name**       | **Type**  | **Required** | **Description**             |
 |---------------|-----------|----------|--------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `ip` | `string` | **Yes** | 实例IP |
 | `port` | `integer` | **Yes** | 实例端口 |
 | `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
@@ -3117,7 +3117,7 @@ curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'names
 |---------------|-----------|----------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认`public` |
 | `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `clusterName` | `string` | No | Cluster name. If not provided, instances of all clusters will be returned. |
 | `healthyOnly` | `boolean` | No | 是否只返回健康实例，默认为`false` |
 
@@ -3653,7 +3653,7 @@ curl -d 'serviceName=nacos.test.1' \
 | **Name**       | **Type**  | **Required** | **Description**                  |
 |---------------|-----------|----------|-------------------------|
 | `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **Yes** | 服务Name |
+| `serviceName` | `string` | **Yes** | 服务名称 |
 | `groupName` | `string` | No | 分组Name，默认是`DEFAULT_GROUP` |
 | `pageNo` | `integer` | **Yes** | 页码 |
 | `pageSize` | `integer` | **Yes** | 每页大小 |
@@ -3671,7 +3671,7 @@ curl -d 'serviceName=nacos.test.1' \
 | `pageItems`                  | `array`    | Service list.                |
 | `pageItems`[i].`ip`          | `string` | 订阅者IP。               |
 | `pageItems`[i].`port`        | `integer` | 订阅者端口。               |
-| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 | 
+| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 |
 | `pageItems`[i].`agent`       | `string` | 订阅者客户端版本。            |
 | `pageItems`[i].`appName`     | `string` | 订阅者所属应用。             |
 | `pageItems`[i].`namespaceId` | `string` | 订阅者所属命名空间。           |
@@ -3803,17 +3803,17 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/selector/types'
 
 | Name                | Type     | Description                         |
 |--------------------|----------|----------------------------|
-| `id`               | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
+| `id`               | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `dataId`           | `string` | 配置ID。                      |
 | `groupName`        | `string` | 配置分组。                      |
 | `namespaceId`      | `string` | 命名空间ID。                    |
 | `content`          | `string` | 配置内容。                      |
-| `desc`             | `string` | 配置Description。                      |
+| `desc`             | `string` | 配置描述。                      |
 | `md5`              | `string` | 配置内容的MD5值。                 |
 | `configTags`       | `string` | 配置的标签。                     |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。     |
-| `appName`          | `string` | 配置所属的应用Name。                 |
-| `type`             | `string` | 配置Type。                      |
+| `appName`          | `string` | 配置所属的应用名称。                 |
+| `type`             | `string` | 配置类型。                      |
 | `createTime`       | `integer` | 配置创建时间。                    |
 | `modifyTime`       | `integer` | 配置修改时间。                    |
 | `createUser`       | `string` | 配置创建人。                     |
@@ -4137,13 +4137,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/listener?namespaceId
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `array`   | Configurations matching the query criteria. |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
 | `pageItems`[i].`md5`         | `string` | 配置内容的MD5值。                 |
-| `pageItems`[i].`appName`     | `string` | 配置所属的应用Name。                 |
-| `pageItems`[i].`type`        | `string` | 配置Type。                      |
+| `pageItems`[i].`appName`     | `string` | 配置所属的应用名称。                 |
+| `pageItems`[i].`type`        | `string` | 配置类型。                      |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
@@ -4291,17 +4291,17 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=
 | `dataId`           | `string` | 配置的dataId。                          |
 | `groupName`        | `string` | 配置的groupName。                       |
 | `namespaceId`      | `string` | 配置所属的命名空间。                          |
-| `desc`             | `string` | 配置Description。                               |
+| `desc`             | `string` | 配置描述。                               |
 | `md5`              | `string` | 配置内容的MD5值。                          |
 | `configTags`       | `string` | 配置的标签。                              |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。              |
-| `appName`          | `string` | 配置所属的应用Name。                          |
-| `type`             | `string` | 配置Type。                               |
+| `appName`          | `string` | 配置所属的应用名称。                          |
+| `type`             | `string` | 配置类型。                               |
 | `createTime`       | `integer` | 配置创建时间。                             |
 | `modifyTime`       | `integer` | 配置修改时间。                             |
 | `createUser`       | `string` | 配置创建人。                              |
 | `createIp`         | `string` | 配置创建IP。                             |
-| `grayName`         | `string` | 灰度发布规则Name, 固定为`beta`。                |
+| `grayName`         | `string` | 灰度发布规则名称, 固定为`beta`。                |
 | `grayRule`         | `string` | 灰度发布规则，格式为JSON，其中的`expr`为beta的ip列表。 |
 
 #### Examples
@@ -4481,7 +4481,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/export?namespaceId=p
 
 #### Request Parameters
 
-请求体Type为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
+请求体类型为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
 
 #### Response Data
 
@@ -4562,8 +4562,8 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 | `pageItems`[i].`groupName`   | `string` | 配置的groupName。                     |
 | `pageItems`[i].`namespaceId` | `string` | 配置所属的命名空间。                        |
 | `pageItems`[i].`appName`     | `string` | 配置所属的appName。                     |
-| `pageItems`[i].`opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。        |
-| `pageItems`[i].`publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。 |
+| `pageItems`[i].`opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。        |
+| `pageItems`[i].`publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。 |
 | `pageItems`[i].`srcIp`       | `string` | 发布的来源IP。                          |
 | `pageItems`[i].`srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。       |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                           |
@@ -4666,13 +4666,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.e
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
 #### Examples
@@ -4754,13 +4754,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupN
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
 #### Examples
@@ -5215,7 +5215,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby?sql=SELECT%20*%20
 
 `POST`
 
-请求体Type：`multipart/form-data`，参数放在请求体中。
+请求体类型：`multipart/form-data`，参数放在请求体中。
 
 #### Authorization
 
@@ -5876,7 +5876,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&nam
 | `namespaceId`        | `string` | MCP服务所属的命名空间ID。                                                                                 |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的Description。                                                                                       |
+| `description`        | `string` | MCP服务的描述。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |                                                                                          |
 | `versionDetail`      | `object`              | Queried version information of the MCP service.                                                        |
 | `localServerConfig`  | `map<string, object>` | Startup information for a local MCP service when the MCP service type is **stdio**.                    |
@@ -5967,8 +5967,8 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 | Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
 | `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
-| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `serverSpecification` | `string` | **Yes** | MCP服务的描述详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具描述详情 |
 | `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 | `overrideExisting` | `boolean` | No | MCP服务更新时是否覆盖原 endpointSpecification，仅在非`stdio`协议时生效 |
 | `latest` | `boolean` | No | - |
@@ -5983,7 +5983,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的Description。                                                                                       |
+| `description`        | `string` | MCP服务的描述。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -6012,8 +6012,8 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 | Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的Name                                     |
-| `description` | `string` | MCP 工具的Description                                     |
+| `name`        | `string` | MCP 工具的名称                                     |
+| `description` | `string` | MCP 工具的描述                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
@@ -6029,17 +6029,17 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 | Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
+| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
 | Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
 #### Response Data
@@ -6097,8 +6097,8 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 | Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
 | `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
-| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `serverSpecification` | `string` | **Yes** | MCP服务的描述详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具描述详情 |
 | `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
@@ -6111,7 +6111,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的Description。                                                                                       |
+| `description`        | `string` | MCP服务的描述。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -6140,8 +6140,8 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 | Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的Name                                     |
-| `description` | `string` | MCP 工具的Description                                     |
+| `name`        | `string` | MCP 工具的名称                                     |
+| `description` | `string` | MCP 工具的描述                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
@@ -6157,17 +6157,17 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 | Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
+| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
 | Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
 #### Response Data
@@ -6283,7 +6283,7 @@ curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=
 | Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
 | `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **Yes** | AgentCard的Name                |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
 
 #### Response Data
 
@@ -6347,7 +6347,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=publi
 | `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
 | `pageSize` | `integer` | **Yes** | 页条目数，默认为`100` |
 | `namespaceId` | `string` | No | AgentCard的命名空间ID，默认为`public` |
-| `agentName` | `string` | No | AgentCard的Name，为空是查询所有AgentCard |
+| `agentName` | `string` | No | AgentCard的名称，为空是查询所有AgentCard |
 | `search` | `string` | No | blur or accurate |
 
 #### Response Data
@@ -6466,9 +6466,9 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | Name                | Type     | Required  | Description                                                                                 |
 |--------------------|----------|-------|------------------------------------------------------------------------------------|
 | `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                        |
-| `agentName`        | `string` | **Yes** | AgentCard的Name                                                                       |
+| `agentName`        | `string` | **Yes** | AgentCard的名称                                                                       |
 | `version`          | `string` | No     | AgentCard的版本号，为空时返回最新版本详情                                                          |
-| `registrationType` | `string` | No     | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 
 #### Response Data
 
@@ -6477,8 +6477,8 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | Name                                 | Type                              | Description                                                                                                       |
 |-------------------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `protocolVersion`                   | `string` | AgentCard的A2A协议版本。                                                                                       |
-| `name`                              | `string` | AgentCard的Name。                                                                                            |
-| `description`                       | `string` | AgentCard的Description。                                                                                            |
+| `name`                              | `string` | AgentCard的名称。                                                                                            |
+| `description`                       | `string` | AgentCard的描述。                                                                                            |
 | `version`                           | `string` | AgentCard的版本号。                                                                                           |
 | `iconUrl`                           | `string` | AgentCard的iconURL。                                                                                       |
 | `capabilities`                      | `object`                         | AgentCard capabilities, matching [A2A standard capabilities](https://a2a-protocol.org/latest/specification/#552-agentcapabilities-object). |
@@ -6493,7 +6493,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | `defaultInputModes`                 | `array`                          | All default input modes of the AgentCard. |
 | `defaultOutputModes`                | `array`                          | All default output modes of the AgentCard. |
 | `supportsAuthenticatedExtendedCard` | `string` | AgentCard是否支持认证的扩展卡。                                                                                     |
-| `registrationType`                  | `string` | AgentCard的默认注册Type，可选`URL`和`SERVICE`。                                                                      |
+| `registrationType`                  | `string` | AgentCard的默认注册类型，可选`URL`和`SERVICE`。                                                                      |
 | `latestVersion`                     | `string` | AgentCard当前版本时否为最新版本。                                                                                    |
 
 #### Examples
@@ -6601,7 +6601,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
 | `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
 | `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `registrationType` | `string` | No | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 | `setAsLatest` | `boolean` | No | 是否设置此版本为最新发布版本，默认为false |
 
 #### Response Data
@@ -6619,7 +6619,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 ```shell
 curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'namespaceId=public' \
--d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \ 
+-d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \
 -d 'registrationType=SERVICE' \
 -d 'setAsLatest=true'
 ```
@@ -6661,7 +6661,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
 | `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
 | `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, Default为`URL` |
+| `registrationType` | `string` | No | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认为`URL` |
 
 #### Response Data
 
@@ -6678,7 +6678,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 ```shell
 curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'namespaceId=public' \
--d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \ 
+-d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \
 -d 'registrationType=SERVICE'
 ```
 * Response example
@@ -6718,7 +6718,7 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 | Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
 | `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **Yes** | AgentCard的Name                |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
 | `version`     | `string` | No     | AgentCard的版本号，为空时返回最新版本详情   |
 
 #### Response Data
@@ -8014,7 +8014,7 @@ This API uploads a ZIP package in multipart/form-data format and registers the s
 
 `POST`
 
-请求体Type：`multipart/form-data`，参数放在请求体中。
+请求体类型：`multipart/form-data`，参数放在请求体中。
 
 #### Authorization
 

--- a/src/content/docs/next/en/manual/admin/admin-api.md
+++ b/src/content/docs/next/en/manual/admin/admin-api.md
@@ -54,35 +54,35 @@ Nacos 3.X Admin APIs also provide Swagger-style documentation. You can view it a
 
 ### 1.1. 获取当前节点连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取连接到当前Nacos Server节点中的gRPC连接详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/current`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                     | 参数类型         | 描述                                                                                      |
+| Name                                     | Type         | Description                                                                                      |
 |-----------------------------------------|--------------|-----------------------------------------------------------------------------------------|
 | ${connectionId}                         | `object` | 每条 gRPC connection ID. |
 | ${connectionId}.abilityTable            | `object` | Capability list supported by the gRPC connection, namely the client. |
@@ -95,15 +95,15 @@ Nacos 3.X Admin APIs also provide Swagger-style documentation. You can view it a
 | ${connectionId}.metaInfo.clusterSource  | `boolean` | Whether the gRPC connection is an inter-cluster connection. When `true`, `${connectionId}.metaInfo.labels.source` is `cluster`. |
 | ${connectionId}.metaInfo.sdkSource      | `boolean` | Whether the gRPC connection comes from a client. When `true`, `${connectionId}.metaInfo.labels.source` is `naming` or `config`. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/current'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -161,46 +161,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/current'
 
 ### 1.2. 均衡指定数量的连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以指定一定数量的连接到当前Nacos Server节点中的gRPC连接，将这部分连接断开后迁移到其他Nacos Server节点中。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/reloadCurrent`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 类型        | 必填    | 参数描述                           |
+| Name               | Type        | Required    | Description                           |
 |-------------------|-----------|-------|--------------------------------|
-| `count`           | `integer` | **是** | 需要均衡的连接个数                      |
-| `redirectAddress` | `string` | 否     | 预期均衡的Nacos Server目标，仅提供给客户端参考。 |
+| `count`           | `integer` | **Yes** | 需要均衡的连接个数                      |
+| `redirectAddress` | `string` | No     | 预期均衡的Nacos Server目标，仅提供给客户端参考。 |
 
-#### 返回数据
+#### Response Data
 
-成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)
+成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadCurrent' -d "count=100"
 ```
 
-* 返回示例
+* Response example
 
 ```text
 success
@@ -208,46 +208,46 @@ success
 
 ### 1.3. 均衡指定的单个连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将指定的客户端连接(gRPC连接)迁移到其他Nacos Server节点中。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/reloadClient`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 类型       | 必填    | 参数描述                 |
+| Name               | Type       | Required    | Description                 |
 |-------------------|----------|-------|----------------------|
-| `connectionId`    | `string` | **是** | 需要均衡的连接Id            |
-| `redirectAddress` | `string` | 否     | 预期均衡的Nacos Server目标。 |
+| `connectionId`    | `string` | **Yes** | 需要均衡的连接Id            |
+| `redirectAddress` | `string` | No     | 预期均衡的Nacos Server目标。 |
 
-#### 返回数据
+#### Response Data
 
-成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)
+成功则返回`success`，失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadClient' -d "connectionId=1709273546779_127.0.0.1_35042"
 ```
 
-* 返回示例
+* Response example
 
 成功则返回:
 
@@ -271,35 +271,35 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadClient' -d 
 
 ### 1.4. 获取集群连接概览信息
 
-#### 接口描述
+#### Description
 
 通过该接口，查看Nacos Server集群中各节点的连接数概览。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/cluster`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                           | 参数类型        | 描述                        |
+| Name                           | Type        | Description                        |
 |-------------------------------|-------------|---------------------------|
 | `total`                       | `integer` | 该集群中所有节点的连接数总和            |
 | `min`                         | `integer` | 该集群中所有节点的最小连接数            |
@@ -314,15 +314,15 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/reloadClient' -d 
 | `detail[].metric.conCount`    | `integer` | 连接到该节点的总连接数，包含了SDK和集群间的连接 |
 | `detail[].metric.cpu`         | `number` | 节点的CPU使用率，参考值             |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/cluster'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -352,31 +352,31 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/cluster'
 
 ### 1.5. 获取本节点信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos Server集群当前节点的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/node/self`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                           | 参数类型         | 描述                                             |
+| Name                           | Type         | Description                                             |
 |-------------------------------|--------------|------------------------------------------------|
 | `ip`                          | `string` | 节点IP                                           |
 | `port`                        | `integer` | 节点端口                                           |
@@ -393,15 +393,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/cluster'
 | `grpcReportEnabled`           | `boolean` | 标记节点是否支持grpc上报心跳能力，用于适配老版本升级，后续将移除             |
 | ~~extendInfo.readyToUpgrade~~ | `boolean` | 是否ready升级到Nacos2.0，于2.2版本后废弃，即将移除              |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/self'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -478,46 +478,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/self'
 
 ### 1.6. 获取集群所有节点信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos Server集群中所有节点的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/node/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `address` | `string` | 否 | 节点地址，支持按地址过滤。 |
-| `state` | `string` | 否 | Node state: UP/DOWN/SUSPICIOUS |
+| `address` | `string` | No | 节点地址，支持按地址过滤。 |
+| `state` | `string` | No | Node state: UP/DOWN/SUSPICIOUS |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data`字段为[获取本节点信息](#返回数据-4)的返回数据的列表。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data`字段为[获取本节点信息](#返回数据-4)的返回数据的列表。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -623,50 +623,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list'
 
 ### 1.7. 动态修改Server集群地址发现方式
 
-#### 接口描述
+#### Description
 
 通过该接口，可以在不重启Nacos Server的情况下，动态切换Nacos Server集群地址发现的方式，目前支持两种方式：`file`
 和`address-server`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/lookup`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名    | 类型       | 必填 | 参数描述                                  |
+| Name    | Type       | Required | Description                                  |
 |--------|----------|----|---------------------------------------|
-| `type` | `string` | 是 | address-server/file/standalone |
+| `type` | `string` | Yes | address-server/file/standalone |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名    | 参数类型      | 描述                          |
+| Name    | Type      | Description                          |
 |--------|-----------|-----------------------------|
 | `data` | `boolean` | `true`表示更新成功，`false`表示更新失败。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=file"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -678,35 +678,35 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=
 
 ### 1.8. Raft 相关操作
 
-#### 接口描述
+#### Description
 
 通过该接口，可以对Nacos Server集群中的Raft协议进行部分运维操作，如执行快照，主动选主等。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-请求体类型：`application/json`，参数放在请求体中。
+请求体Type：`application/json`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/ops/raft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名       | 类型       | 必填    | 参数描述                                 |
+| Name       | Type       | Required    | Description                                 |
 |-----------|----------|-------|--------------------------------------|
-| `command` | `string` | **是** | Raft运维操作指令，具体的命令请参考下表。 |
-| `value` | `string` | **是** | 命令的参数，具体的命令内容请参考下表。 |
-| `groupId` | `string` | 否 | Raft集群的groupId，如果不输入则对所有Raft Group生效 |
+| `command` | `string` | **Yes** | Raft运维操作指令，具体的命令请参考下表。 |
+| `value` | `string` | **Yes** | 命令的参数，具体的命令内容请参考下表。 |
+| `groupId` | `string` | No | Raft集群的groupId，如果不输入则对所有Raft Group生效 |
 
 命令说明（Swagger 暂不支持该子参数结构，文档保留）：
 
@@ -717,23 +717,23 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/lookup' -d "type=
 - `removePeers`: `${nacos-server-address}:${raft-port}[,${nacos-server-address}:${raft-port}]`
 - `changePeers`: `${nacos-server-address}:${raft-port}[,${nacos-server-address}:${raft-port}]`
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 固定为`null`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/admin/core/ops/raft' -d '{"command":"doSnapshot","value":"nacos-node-0:7848"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -745,34 +745,34 @@ curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/
 
 ### 1.9. 动态修改Nacos Core相关日志级别
 
-#### 接口描述
+#### Description
 
 通过该接口，可以在不重启Nacos Server的情况下，动态修改Nacos Core相关日志级别的配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`，参数放在请求体中。
+请求体Type：`application/json`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/ops/log`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 类型       | 必填    | 参数描述                                                         |
+| Name        | Type       | Required    | Description                                                         |
 |------------|----------|-------|--------------------------------------------------------------|
-| `logName` | `string` | **是** | 具体的日志文件的名称，具体支持的日志名称见下表。 |
-| `logLevel` | `string` | **是** | 日志的级别，可选值为`ALL`、`TRACE`、`DEBUG`、`INFO`、`WARN`、`ERROR`、`OFF`。 |
+| `logName` | `string` | **Yes** | 具体的日志文件的Name，具体支持的日志Name见下表。 |
+| `logLevel` | `string` | **Yes** | 日志的级别，可选值为`ALL`、`TRACE`、`DEBUG`、`INFO`、`WARN`、`ERROR`、`OFF`。 |
 
 | logName        | 对应的具体日志文件             |
 |----------------|-----------------------|
@@ -781,23 +781,23 @@ curl -X POST -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/
 | `core-distro`  | `protocol-distro.log` |
 | `core-cluster` | `nacos-cluster.log`   |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 固定为`null`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/admin/core/ops/log' -d '{"logName":"core-distro","logLevel":"DEBUG"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -809,7 +809,7 @@ curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/a
 
 ### 1.10. 自动均衡指定数量的连接
 
-#### 接口描述
+#### Description
 
 通过该接口，可以根据负载因子(loaderFactor)自动均衡整个集群的客户端连接。
 
@@ -819,29 +819,29 @@ curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/a
    1-loaderFactor))、节点连接数上限阈值`overLimitCount`(=avg * (1+loaderFactor))
 2. 将高负载节点的部分客户端连接重定向到低负载节点。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/loader/smartReloadCluster`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型       | 必填    | 参数描述           |
+| Name                | Type       | Required    | Description           |
 |--------------------|----------|-------|----------------|
-| `loaderFactor` | `number` | 否 | - |
+| `loaderFactor` | `number` | No | - |
 
-#### 返回数据
+#### Response Data
 
 成功则返回:
 
@@ -863,15 +863,15 @@ curl -X PUT -H 'Content-Type:application/json' 'http://127.0.0.1:8848/nacos/v3/a
 }
 ```
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/loader/smartReloadCluster' -d "loaderFactor=0.1"
 ```
 
-* 返回示例
+* Response example
 
 ```text
 success
@@ -879,37 +879,37 @@ success
 
 ### 1.11. 获取ID生成器信息
 
-#### 接口描述
+#### Description
 
 通过该接口，获取ID生成器的当前ID,workerId. 只有使用内置数据库时该接口才会返回有效数据.
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/ops/ids`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-| 参数名              | 参数类型     | 描述       |
+| Name              | Type     | Description       |
 |------------------|----------|----------|
-| `resource`       | `string` | 生产器名称    |
+| `resource`       | `string` | 生产器Name    |
 | `info`           | `object` | 生产器详情    |
 | `info.currentId` | `integer` | 当前ID     |
 | `info.workerId`  | `integer` | workerID |
@@ -942,15 +942,15 @@ success
 }
 ```
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/ops/ids'
 ```
 
-* 返回示例
+* Response example
 
 ```text
 success
@@ -958,41 +958,41 @@ success
 
 ### 1.12. 更新集群节点信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新当前节点中的Nacos节点列表的详细信息。**注意：** 该接口会覆盖当前节点中列表中的详细信息，仅更新传入的节点中存在于集群中的节点，并`不能`通过此接口添加和减少集群中的节点。同时，Nacos自身的健康探测`report`任务也会对当前节点中列表中的节点进行健康探测及更新详细信息，若调用此接口后，探测任务发现节点信息有变更，则任务也会覆盖当前节点中列表中的节点信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/cluster/node/list`
 
-#### 请求参数
+#### Request Parameters
 
 请求体为 JSON 数组，数组元素为节点信息（Member），包含 ip、port、state、extendInfo 等字段。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | 是否更新成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list' \
@@ -1000,7 +1000,7 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list' \
   -d '[{"ip":"127.0.0.1","port":8848,"state":"UP","address":"127.0.0.1:8848"}]'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1012,54 +1012,54 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/cluster/node/list' \
 
 ### 1.13. 获取命名空间详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定命名空间的详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | 命名空间 ID |
+| `namespaceId` | `string` | **Yes** | 命名空间 ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | namespace | `string` | 命名空间 ID |
 | namespaceShowName | `string` | 命名空间展示名 |
-| namespaceDesc | `string` | 命名空间描述 |
+| namespaceDesc | `string` | 命名空间Description |
 | quota | `integer` | 配置数量配额 |
 | configCount | `integer` | 当前配置数量 |
-| type | `integer` | 类型 |
+| type | `integer` | Type |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1078,48 +1078,48 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=pub
 
 ### 1.14. 更新命名空间
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的名称和描述。
+通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的Name和Description。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | 命名空间 ID |
-| `namespaceName` | `string` | **是** | 命名空间展示名 |
-| `namespaceDesc` | `string` | 否 | 命名空间描述 |
+| `namespaceId` | `string` | **Yes** | 命名空间 ID |
+| `namespaceName` | `string` | **Yes** | 命名空间展示名 |
+| `namespaceDesc` | `string` | No | 命名空间Description |
 
-#### 返回数据
+#### Response Data
 
-成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
   -d 'namespaceId=test' -d 'namespaceName=test' -d 'namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1131,48 +1131,48 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
 
 ### 1.15. 创建新命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建新的命名空间。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | 命名空间 ID，不传则由服务端生成 |
-| `namespaceName` | `string` | **是** | 命名空间展示名 |
-| `namespaceDesc` | `string` | 否 | 命名空间描述 |
+| `namespaceId` | `string` | No | 命名空间 ID，不传则由服务端生成 |
+| `namespaceName` | `string` | **Yes** | 命名空间展示名 |
+| `namespaceDesc` | `string` | No | 命名空间Description |
 
-#### 返回数据
+#### Response Data
 
-成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
   -d 'namespaceName=test' -d 'namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1184,45 +1184,45 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace' \
 
 ### 1.16. 删除命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除命名空间。默认命名空间`public`无法被删除。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | 命名空间 ID |
+| `namespaceId` | `string` | **Yes** | 命名空间 ID |
 
-#### 返回数据
+#### Response Data
 
-成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+成功则返回统一返回体，`data` 为 `true` 表示成功；失败则返回[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1234,45 +1234,45 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace?namespaceId=
 
 ### 1.17. 检查命名空间是否存在
 
-#### 接口描述
+#### Description
 
 通过该接口，可以检查命名空间ID是否存在。应该在创建命名空间前调用，确认自定义的命名空间ID是否已经存在，以防冲突。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace/check`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | **是** | - |
+| `namespaceId` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为 `true` 表示已存在，`false` 表示不存在。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为 `true` 表示已存在，`false` 表示不存在。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/check?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1284,43 +1284,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/check?namespace
 
 ### 1.18. 获取Nacos命名空间列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取当前Nacos集群的命名空间列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/namespace/list`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。`data` 为命名空间对象数组，每项包含 namespace、namespaceShowName、namespaceDesc、quota、configCount、type 等字段。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。`data` 为命名空间对象数组，每项包含 namespace、namespaceShowName、namespaceDesc、quota、configCount、type 等字段。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1341,43 +1341,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/namespace/list'
 
 ### 1.19. 获取Nacos集群状态信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取到Nacos 集群的基础状态和开关信息，例如：版本号，运行模式，鉴权是否开启等；该接口不会返回Nacos 集群的节点信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/state`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为键值对，包含版本号（version）、运行模式（startup_mode）、鉴权开关（auth_enabled）等集群状态与配置项。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为键值对，包含版本号（version）、运行模式（startup_mode）、鉴权开关（auth_enabled）等集群状态与配置项。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1392,47 +1392,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state'
 
 ### 1.20. 获取Nacos集群的存活状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos集群的存活状态，Nacos集群是否可正常接受和响应请求。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/state/liveness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 存活状态，如 "ok" |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/liveness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1444,47 +1444,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/liveness'
 
 ### 1.21. 获取Nacos集群的可读状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos集群的是否处于可读取状态，即Nacos集群是否可以读取到数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/state/readiness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 可读状态，如 "ok" |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1496,53 +1496,53 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 ### 1.22. 更新插件配置
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。支持 localOnly 仅作用于当前节点。
+通过该接口，可以更新插件的配置。需要提供插件Type、Name及配置内容。支持 localOnly 仅作用于当前节点。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`。
+请求体Type：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/config`
 
-#### 请求参数
+#### Request Parameters
 
 请求体为 JSON，包含以下字段：
 
-| 参数名         | 类型       | 必填 | 参数描述           |
+| Name         | Type       | Required | Description           |
 |-------------|----------|----|----------------|
-| `pluginType` | `string` | **是** | 插件类型，如 auth。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `config` | `string` | **是** | 插件配置项。 |
-| `localOnly` | `boolean` | 否 | 是否仅写本地，不持久化。 |
+| `pluginType` | `string` | **Yes** | 插件Type，如 auth。 |
+| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `config` | `string` | **Yes** | 插件配置项。 |
+| `localOnly` | `boolean` | No | 是否仅写本地，不持久化。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为字符串表示操作结果。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为字符串表示操作结果。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
   -H 'Content-Type: application/json' -d '{}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1554,57 +1554,57 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
 
 ### 1.23. 获取插件详情
 
-#### 接口描述
+#### Description
 
-通过该接口，可以按类型和名称获取指定插件的详情信息。
+通过该接口，可以按Type和Name获取指定插件的详情信息。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 auth |
-| `pluginName` | `string` | **是** | 插件名称 |
+| `pluginType` | `string` | **Yes** | 插件Type，如 auth |
+| `pluginName` | `string` | **Yes** | 插件Name |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | pluginId | `string` | 插件 ID |
-| pluginType | `string` | 插件类型 |
-| pluginName | `string` | 插件名称 |
+| pluginType | `string` | 插件Type |
+| pluginName | `string` | 插件Name |
 | enabled | `boolean` | 是否启用 |
 | critical | `boolean` | 是否关键插件 |
 | configurable | `boolean` | 是否可配置 |
 | config | `object` | 配置内容 |
 | configDefinitions | `array` | 配置定义列表 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=auth&pluginName=nacos-default-auth-plugin'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1625,45 +1625,45 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=
 
 ### 1.24. 获取插件列表
 
-#### 接口描述
+#### Description
 
-通过该接口，可以获取所有插件列表，可按插件类型筛选。
+通过该接口，可以获取所有插件列表，可按插件Type筛选。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | 否 | 插件类型，不传则返回全部 |
+| `pluginType` | `string` | No | 插件Type，不传则返回全部 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为插件对象数组。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为插件对象数组。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=auth'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1685,53 +1685,53 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 ### 1.25. 启用或禁用插件
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新插件的启用状态（启用或禁用）。支持 localOnly 仅作用于当前节点。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`。
+请求体Type：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/core/plugin/status`
 
-#### 请求参数
+#### Request Parameters
 
 请求体为 JSON，包含以下字段：
 
-| 参数名         | 类型        | 必填 | 参数描述       |
+| Name         | Type        | Required | Description       |
 |-------------|-----------|----|------------|
-| `pluginType` | `string` | **是** | 插件类型。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `enabled` | `boolean` | **是** | 是否启用。 |
-| `localOnly` | `boolean` | 否 | 是否仅写本地。 |
+| `pluginType` | `string` | **Yes** | 插件Type。 |
+| `pluginName` | `string` | **Yes** | 插件Name。 |
+| `enabled` | `boolean` | **Yes** | 是否启用。 |
+| `localOnly` | `boolean` | No | 是否仅写本地。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，`data` 为字符串表示操作结果。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，`data` 为字符串表示操作结果。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
   -H 'Content-Type: application/json' -d '{}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1745,35 +1745,35 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
 
 ### 2.1. 查看Naming模块的相关开关
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查看Nacos Naming模块的相关开关。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/switches`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                      | 参数类型      | 描述                                                                                                      |
+| Name                      | Type      | Description                                                                                                      |
 |--------------------------|-----------|---------------------------------------------------------------------------------------------------------|
 | `clientBeatInterval`     | `integer` | Nacos1.X客户端的默认心跳间隔                                                                                      |
 | `defaultCacheMillis`     | `integer` | 客户端订阅的服务列表的默认缓存时间                                                                                       |
@@ -1787,15 +1787,15 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
 
 > 注意： 其余未列出的参数，均为Nacos旧版本的开关或配置内容，已废弃或即将废弃，请谨慎使用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' 
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1854,49 +1854,49 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches'
 
 ### 2.2. 修改Naming模块的相关开关
 
-#### 接口描述
+#### Description
 
 通过该接口，可以修改Nacos Naming模块的相关开关。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/switches`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名     | 类型        | 必填    | 参数描述                                              |
+| Name     | Type        | Required    | Description                                              |
 |---------|-----------|-------|---------------------------------------------------|
-| `entry` | `string` | **是** | 修改的开关或配置名称 |
-| `value` | `string` | **是** | 开关或配置的新值，不同的开关或配置的类型不同，具体请参考[开关和配置参数](#返回数据-10) |
-| `debug` | `boolean` | 否 | 是否开启调试模式，开启后，修改的配置不会同步到集群其他节点中，仅在本节点生效，默认为`false` |
+| `entry` | `string` | **Yes** | 修改的开关或配置Name |
+| `value` | `string` | **Yes** | 开关或配置的新值，不同的开关或配置的Type不同，具体请参考[开关和配置参数](#返回数据-10) |
+| `debug` | `boolean` | No | 是否开启调试模式，开启后，修改的配置不会同步到集群其他节点中，仅在本节点生效，默认为`false` |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 成功为`ok` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' -d "entry=pushEnabled&value=false"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1908,39 +1908,39 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' -d "entry=pus
 
 ### 2.3. 查询系统当前数据指标
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询系统当前数据指标。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/metrics`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名          | 参数类型      | 是否必填 | 默认值    | 参数描述  |
+| Name          | Type      | Required | Default    | Description  |
 |--------------|-----------|------|--------|-------|
-| `onlyStatus` | `boolean` | 否    | `true` | 只显示状态 |
+| `onlyStatus` | `boolean` | No    | `true` | 只显示状态 |
 
 > 当`onlyStatus`设置为`true`时，只返回表示系统状态的字符串
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                           | 参数类型     | 描述说明    |
+| Name                           | Type     | Description    |
 |-------------------------------|----------|---------|
 | `status`                      | `string` | 系统状态    |
 | `serviceCount`                | `integer` | 服务数量    |
@@ -1952,15 +1952,15 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/switches' -d "entry=pus
 | `persistentIpPortClientCount` | `integer` | 持久客户端数量 |
 | `responsibleClientCount`      | `integer` | 响应客户端数  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/metrics?onlyStatus=false'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1982,55 +1982,55 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/metrics?onlyStatus=fals
 
 ### 2.4. 修改日志级别
 
-#### 接口描述
+#### Description
 
 通过该接口，可以动态修改指定日志的级别。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-请求体类型：`application/json`。
+请求体Type：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/ops/log`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 类型       | 必填 | 参数描述        |
+| Name   | Type       | Required | Description        |
 |-------|----------|---|-------------|
 
 请求体字段：
 
-| 参数名       | 类型       | 必填    | 参数描述      |
+| Name       | Type       | Required    | Description      |
 |-----------|----------|-------|-----------|
-| `logName`  | `string` | **是** | 需要修改的日志名称。 |
-| `logLevel` | `string` | **是** | 日志级别的新值。   |
+| `logName`  | `string` | **Yes** | 需要修改的日志Name。 |
+| `logLevel` | `string` | **Yes** | 日志级别的新值。   |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 成功为`ok` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/log' -H 'Content-Type: application/json' -d '{"logName":"com.example.Logger","logLevel":"DEBUG"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2042,39 +2042,39 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/ops/log' -H 'Content-Type: 
 
 ### 2.5 查询所有客户端列表
 
-#### 接口描述
+#### Description
 
 查询所有客户端的列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/list`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型           | 描述      |
+| Name    | Type           | Description      |
 |--------|----------------|---------|
 | `data` | `array` | Client ID list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/list'
@@ -2094,57 +2094,57 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/list'
 
 ### 2.6 查询客户端详细信息
 
-#### 接口描述
+#### Description
 
 根据客户端ID查询客户端的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填  | 描述    |
+| Name        | Type     | Required  | Description    |
 |------------|----------|-------|-------|
-| `clientId` | `string` | **是** | 客户端ID |
+| `clientId` | `string` | **Yes** | 客户端ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型      | 描述                 |
+| Name               | Type      | Description                 |
 |-------------------|-----------|--------------------|
 | `clientId`        | `string` | 客户端的唯一 ID。         |
 | `ephemeral`       | `boolean` | 客户端是否为临时客户端        |
 | `lastUpdatedTime` | `integer` | 客户端的最后更新时间（时间戳）    |
-| `clientType`      | `string` | 客户端类型              |
-| `connectType`     | `string` | 连接类型（仅适用于 2.x 客户端） |
-| `appName`         | `string` | 客户端所属的应用名称         |
+| `clientType`      | `string` | 客户端Type              |
+| `connectType`     | `string` | 连接Type（仅适用于 2.x 客户端） |
+| `appName`         | `string` | 客户端所属的应用Name         |
 | `version`         | `string` | 客户端的版本号            |
 | `clientIp`        | `string` | 客户端的 IP 地址         |
 | `clientPort`      | `string` | 客户端的端口号            |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client?clientId=1741748952410_127.0.0.1_53863'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2186,37 +2186,37 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client?clientId=17417489524
 
 ### 2.7 查询客户端注册的服务列表
 
-#### 接口描述
+#### Description
 
 查询指定客户端注册的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/publish/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填  | 描述    |
+| Name        | Type     | Required  | Description    |
 |------------|----------|-------|-------|
-| `clientId` | `string` | **是** | 客户端ID |
+| `clientId` | `string` | **Yes** | 客户端ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                         | 参数类型     | 描述说明      |
+| Name                         | Type     | Description      |
 |-----------------------------|----------|-----------|
 | `namespaceId`               | `string` | 命名空间      |
 | `groupName`                 | `string` | 分组名       |
@@ -2226,15 +2226,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client?clientId=17417489524
 | `publisherInfo.port`        | `integer` | 端口号       |
 | `publisherInfo.clusterName` | `string` | 集群名       |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/publish/list?clientId=1664527081276_127.0.0.1_4400'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2259,37 +2259,37 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/publish/list?clientI
 
 ### 2.8 查询客户端订阅的服务列表
 
-#### 接口描述
+#### Description
 
 查询指定客户端订阅的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/subscribe/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填 | 描述    |
+| Name        | Type     | Required | Description    |
 |------------|----------|------|-------|
-| `clientId` | `string` | **是** | 客户端ID |
+| `clientId` | `string` | **Yes** | 客户端ID |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                      | 参数类型     | 描述说明  |
+| Name                      | Type     | Description  |
 |--------------------------|----------|-------|
 | `namespaceId`            | `string` | 命名空间  |
 | `groupName`              | `string` | 分组名   |
@@ -2299,15 +2299,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/publish/list?clientI
 | `subscriberInfo.agent`   | `string` | 客户端信息 |
 | `subscriberInfo.address` | `string` | 地址    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/subscribe/list?clientId=1664527081276_127.0.0.1_4400'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2332,56 +2332,56 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/subscribe/list?clien
 
 ### 2.9 查询注册指定服务的客户端列表
 
-#### 接口描述
+#### Description
 
 查询注册指定服务的客户端列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/service/publisher/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值               | 描述说明                     |
+| Name           | Type      | Required  | Default               | Description                     |
 |---------------|-----------|-------|-------------------|--------------------------|
-| `namespaceId` | `string` | 否 | `"public"` |
-| `groupName` | `string` | 否 | `"DEFAULT_GROUP"` |
-| `serviceName` | `string` | **是** | 无 |
-| `ip` | `string` | 否 | 无 |
-| `port` | `integer` | 否 | None |
+| `namespaceId` | `string` | No | `"public"` |
+| `groupName` | `string` | No | `"DEFAULT_GROUP"` |
+| `serviceName` | `string` | **Yes** | None |
+| `ip` | `string` | No | None |
+| `port` | `integer` | No | None |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型     | 描述说明    |
+| Name           | Type     | Description    |
 |---------------|----------|---------|
 | `clientId`    | `string` | 客户端`id` |
 | `ip`          | `string` | 实例的`IP` |
 | `port`        | `integer` | 实例的端口   |
 | `clusterName` | `string` | 实例的集群名  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/publisher/list?serviceName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2400,56 +2400,56 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/publisher/li
 
 ### 2.10 查询订阅指定服务的客户端列表
 
-#### 接口描述
+#### Description
 
 查询订阅指定服务的客户端列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/service/subscriber/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值               | 描述说明                     |
+| Name           | Type      | Required  | Default               | Description                     |
 |---------------|-----------|-------|-------------------|--------------------------|
-| `namespaceId` | `string` | 否 | `"public"` |
-| `groupName` | `string` | 否 | `"DEFAULT_GROUP"` |
-| `serviceName` | `string` | **是** | 无 |
-| `ip` | `string` | 否 | 无 |
-| `port` | `integer` | 否 | None |
+| `namespaceId` | `string` | No | `"public"` |
+| `groupName` | `string` | No | `"DEFAULT_GROUP"` |
+| `serviceName` | `string` | **Yes** | None |
+| `ip` | `string` | No | None |
+| `port` | `integer` | No | None |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名        | 参数类型     | 描述说明                             |
+| Name        | Type     | Description                             |
 |------------|----------|----------------------------------|
 | `clientId` | `string` | 客户端`id`                          |
 | `address`  | `string` | 订阅者客户端的`IP`                      |
 | `agent`    | `string` | 订阅者客户端的版本                        |
 | `appName`  | `string` | 订阅者客户端的应用名，`unknown`表示未配置或客户端不支持 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/subscriber/list?serviceName=service1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2468,52 +2468,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/service/subscriber/l
 
 ### 2.11 查询客户端的负责服务器
 
-#### 接口描述
+#### Description
 
 根据客户端的IP和端口查询其负责的服务器，仅针对持久化服务实例或通过运维API注册的临时实例。使用2.X以上客户端注册的临时实例无法通过此接口定位负责服务器节点。
 
 > 对于使用1.X客户端注册的实例也适用此接口， 但1.X客户端将在未来版本不再支持。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/client/distro`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名    | 参数类型     | 是否必填  | 描述    |
+| Name    | Type     | Required  | Description    |
 |--------|----------|-------|-------|
-| `ip`   | `string` | **是** | 客户端IP |
-| `port` | `integer` | **是** | Client port. |
+| `ip`   | `string` | **Yes** | 客户端IP |
+| `port` | `integer` | **Yes** | Client port. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                 | 参数类型     | 描述       |
+| Name                 | Type     | Description       |
 |---------------------|----------|----------|
 | `responsibleServer` | `string` | 负责的服务器信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/distro?ip=127.0.0.1&port=8080'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2527,54 +2527,54 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/client/distro?ip=127.0.0.1&
 
 ### 2.12 更新集群信息
 
-#### 接口描述
+#### Description
 
 更新指定集群的元数据信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/cluster`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型                  | 是否必填  | 描述                |
+| Name                     | Type                  | Required  | Description                |
 |-------------------------|-----------------------|-------|-------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `clusterName` | `string` | **是** | 集群名称 |
-| `checkPort` | `integer` | 否 | 健康检查端口 |
-| `useInstancePort4Check` | `boolean` | 否 | 是否使用实例端口进行健康检查 |
-| `healthChecker` | `string` | 否 | 健康检查器配置（JSON 字符串） |
-| `metadata` | `string` | 否 | 集群的扩展元数据，默认为`""` |
-| `groupName` | `string` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间ID |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `clusterName` | `string` | **Yes** | 集群Name |
+| `checkPort` | `integer` | No | 健康检查端口 |
+| `useInstancePort4Check` | `boolean` | No | 是否使用实例端口进行健康检查 |
+| `healthChecker` | `string` | No | 健康检查器配置（JSON 字符串） |
+| `metadata` | `string` | No | 集群的扩展元数据，默认为`""` |
+| `groupName` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/cluster' -d 'serviceName=test&clusterName=DEFAULT&checkPort=80&useInstancePort4Check=true&healthChecker={"type":"none"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2586,56 +2586,56 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/cluster' -d 'serviceName=te
 
 ### 2.13 更新实例健康状态
 
-#### 接口描述
+#### Description
 
 更新指定实例的健康状态。
 
 > 仅对持久化服务的实例有效， 且该服务的健康检查方式为`NONE`。
-> 临时实例的健康状态由连接（客户端）维护，其他健康检查类型的持久化服务，健康检查任务会自动维护健康状态，即使更新成功了，也很快会被健康检查任务重制。
+> 临时实例的健康状态由连接（客户端）维护，其他健康检查Type的持久化服务，健康检查任务会自动维护健康状态，即使更新成功了，也很快会被健康检查任务重制。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/health/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 描述                      |
+| Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `healthy` | `boolean` | **是** | 健康状态（`true` 为健康） |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `healthy` | `boolean` | **Yes** | 健康状态（`true` 为健康） |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/instance' -d 'namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&clusterName=cluster1&ip=127.0.0.1&port=8080&healthy=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2647,45 +2647,45 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/instance' -d 'namesp
 
 ### 2.14 获取所有健康检查器
 
-#### 接口描述
+#### Description
 
-获取系统中支持的所有健康检查器类型及其配置。
+获取系统中支持的所有健康检查器Type及其配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/health/checkers`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型                                 | 描述          |
+| Name    | Type                                 | Description          |
 |--------|--------------------------------------|-------------|
-| `data` | `Map<String, AbstractHealthChecker>` | 健康检查器类型及其配置 |
+| `data` | `Map<String, AbstractHealthChecker>` | 健康检查器Type及其配置 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/checkers'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2710,58 +2710,58 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/health/checkers'
 
 ### 2.15 注册实例
 
-#### 接口描述
+#### Description
 
 注册一个新的实例到指定服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型                  | 是否必填  | 描述                      |
+| Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `weight` | `number` | 否 | 实例权重，默认为`1.0` |
-| `healthy` | `boolean` | 否 | 健康状态，默认为`true` |
-| `enabled` | `boolean` | 否 | 是否启用，默认为`true` |
-| `metadata` | `string` | 否 | 实例元数据 |
-| `ephemeral` | `boolean` | 否 | 是否临时实例 |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `weight` | `number` | No | 实例权重，默认为`1.0` |
+| `healthy` | `boolean` | No | 健康状态，默认为`true` |
+| `enabled` | `boolean` | No | 是否启用，默认为`true` |
+| `metadata` | `string` | No | 实例元数据 |
+| `ephemeral` | `boolean` | No | 是否临时实例 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 -d 'namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&clusterName=cluster1&ip=127.0.0.1&port=8080&weight=1.0&healthy=true&enabled=true&metadata={"key1=value1"}&ephemeral=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2773,52 +2773,52 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 
 ### 2.16 注销实例
 
-#### 接口描述
+#### Description
 
 从指定服务中注销一个实例。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 描述                      |
+| Name           | Type      | Required  | Description                      |
 |---------------|-----------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&clusterName=cluster1&ip=127.0.0.1&port=8080&ephemeral=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2830,7 +2830,7 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=pub
 
 ### 2.17 更新实例
 
-#### 接口描述
+#### Description
 
 更新指定实例的信息。
 
@@ -2843,54 +2843,54 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=pub
 > 同时该接口将会完全覆盖之前更新过的元数据信息，例如，先使用`k1=v1`更新元数据，再使用`k2=v2`
 > 更新元数据，此时读取到的元数据为`k2=v2`，而不是`k1=v1,k2=v2`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型                  | 是否必填  | 描述                      |
+| Name           | Type                  | Required  | Description                      |
 |---------------|-----------------------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `weight` | `number` | 否 | 实例权重，默认为`1.0` |
-| `healthy` | `boolean` | 否 | 健康状态，默认为`true` |
-| `enabled` | `boolean` | 否 | 是否启用，默认为`true` |
-| `metadata` | `string` | 否 | 实例元数据 |
-| `ephemeral` | `boolean` | 否 | 是否临时实例 |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `weight` | `number` | No | 实例权重，默认为`1.0` |
+| `healthy` | `boolean` | No | 健康状态，默认为`true` |
+| `enabled` | `boolean` | No | 是否启用，默认为`true` |
+| `metadata` | `string` | No | 实例元数据 |
+| `ephemeral` | `boolean` | No | 是否临时实例 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 -d 'serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&ip=1.1.1.1&port=3306&ephemeral=true&weight=100&enabled=false&metadata=%7B%22%E5%95%A6%E5%95%A6%E5%95%A6%26%E5%95%B5%E5%95%B5%E5%95%B5%22%3A%22xxx%22%7D'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2902,53 +2902,53 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance' \
 
 ### 2.18 批量更新实例元数据
 
-#### 接口描述
+#### Description
 
 批量更新指定实例的元数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/metadata/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 参数类型                  | 是否必填  | 描述                                                                                           |
+| Name               | Type                  | Required  | Description                                                                                           |
 |-------------------|-----------------------|-------|----------------------------------------------------------------------------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `instances` | `string` | 否 | 实例列表（JSON数组 字符串）默认为`""`表示所有实例更新；若指定时，每个元素代表一个需要更新的实例，必须需要包含`ip`和`port`字段，`clusterName`字段为可选, |
-| `metadata` | `string` | **是** | 元数据 |
-| `consistencyType` | `string` | 否 | 一致性类型`ephemeral`和`persist`，对应服务的`ephemeral`，默认为`ephemeral` |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `instances` | `string` | No | 实例列表（JSON数组 字符串）默认为`""`表示所有实例更新；若指定时，每个元素代表一个需要更新的实例，必须需要包含`ip`和`port`字段，`clusterName`字段为可选, |
+| `metadata` | `string` | **Yes** | 元数据 |
+| `consistencyType` | `string` | No | 一致性Type`ephemeral`和`persist`，对应服务的`ephemeral`，默认为`ephemeral` |
 
-#### 返回数据
+#### Response Data
 
-| **参数名**   | **参数类型**       | **描述**  |
+| **Name**   | **Type**       | **Description**  |
 |-----------|----------------|---------|
 | `updated` | `array` | Updated instance list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch' \
 -d 'namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&instances=[{"ip":"127.0.0.1","port":8080}]&metadata={"key1":"value1"}&consistencyType=ephemeral'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2964,53 +2964,53 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch' \
 
 ### 2.19 批量删除实例元数据
 
-#### 接口描述
+#### Description
 
 批量删除指定实例的元数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/metadata/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名               | 参数类型                  | 是否必填  | 描述                      |
+| Name               | Type                  | Required  | Description                      |
 |-------------------|-----------------------|-------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `instances` | `string` | 否 | 实例列表（JSON 字符串），默认为`""` |
-| `metadata` | `string` | **是** | 元数据 |
-| `consistencyType` | `string` | 否 | 一致性类型，默认为`""` |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `instances` | `string` | No | 实例列表（JSON 字符串），默认为`""` |
+| `metadata` | `string` | **Yes** | 元数据 |
+| `consistencyType` | `string` | No | 一致性Type，默认为`""` |
 
-#### 返回数据
+#### Response Data
 
-| **参数名**        | **参数类型**                           | **描述**  |
+| **Name**        | **Type**                           | **Description**  |
 |----------------|------------------------------------|---------|
 | `data`         | `InstanceMetadataBatchOperationVo` | 操作结果信息  |
 | `data.updated` | `array`                     | Updated instance list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch?namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&instances=%5B%7B%22ip%22%3A%22127.0.0.1%22%2C%22port%22%3A8080%7D%5D&metadata=%7B%22key1%22%3A%22value1%22%7D&consistencyType=ephemeral'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3026,60 +3026,60 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/metadata/batch?
 
 ### 2.20 部分更新实例
 
-#### 接口描述
+#### Description
 
 部分更新指定实例的信息。
 
 > 不同于[更新实例](#217-更新实例)，该接口支持部分更新实例信息，例如：先使用`k1=v1`更新元数据，再使用`k2=v2`
 > 更新元数据，此时读取到的元数据为`k1=v1,k2=v2`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/partial`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型**  | **是否必填** | **描述**             |
+| **Name**       | **Type**  | **Required** | **Description**             |
 |---------------|-----------|----------|--------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `ip` | `string` | **是** | 实例IP |
-| `port` | `integer` | **是** | 实例端口 |
-| `clusterName` | `string` | 否 | 集群名称，默认为`DEFAULT` |
-| `weight` | `number` | 否 | 实例权重，默认为1.0 |
-| `enabled` | `boolean` | 否 | 是否启用，默认启用 |
-| `metadata` | `string` | 否 | 实例元数据（JSON 字符串） |
-| `ephemeral` | `boolean` | 否 | - |
-| `groupName` | `string` | 否 | - |
-| `healthy` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `ip` | `string` | **Yes** | 实例IP |
+| `port` | `integer` | **Yes** | 实例端口 |
+| `clusterName` | `string` | No | 集群Name，默认为`DEFAULT` |
+| `weight` | `number` | No | 实例权重，默认为1.0 |
+| `enabled` | `boolean` | No | 是否启用，默认启用 |
+| `metadata` | `string` | No | 实例元数据（JSON 字符串） |
+| `ephemeral` | `boolean` | No | - |
+| `groupName` | `string` | No | - |
+| `healthy` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 操作结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'namespaceId=public&serviceName=example-service&ip=127.0.0.1&clusterName=DEFAULT&port=8080&weight=1.0&enabled=true&metadata={"key":"value"}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3091,44 +3091,44 @@ curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'names
 
 ### 2.21 查询服务实例列表
 
-#### 接口描述
+#### Description
 
 查询指定服务的所有实例列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance/list`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型**  | **是否必填** | **描述**                  |
+| **Name**       | **Type**  | **Required** | **Description**                  |
 |---------------|-----------|----------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认`public` |
-| `groupName` | `string` | 否 | 分组名称，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `clusterName` | `string` | 否 | Cluster name. If not provided, instances of all clusters will be returned. |
-| `healthyOnly` | `boolean` | 否 | 是否只返回健康实例，默认为`false` |
+| `namespaceId` | `string` | No | 命名空间ID，默认`public` |
+| `groupName` | `string` | No | 分组Name，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `clusterName` | `string` | No | Cluster name. If not provided, instances of all clusters will be returned. |
+| `healthyOnly` | `boolean` | No | 是否只返回健康实例，默认为`false` |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型      | 描述说明                              |
+| Name           | Type      | Description                              |
 |---------------|-----------|-----------------------------------|
 | `serviceName` | `string` | 服务名,格式为`groupName`@@`serviceName` |
-| `clusterName` | `string` | 实例所在的集群名称                         |
+| `clusterName` | `string` | 实例所在的集群Name                         |
 | `ip`          | `string` | 实例`IP`                            |
 | `port`        | `integer` | 实例端口号                             |
 | `weight`      | `number` | 实例权重                              |
@@ -3141,15 +3141,15 @@ curl -X PUT "http://127.0.0.1:8848/nacos/v3/admin/ns/instance/partial" -d 'names
 > 关于心跳的参数`instanceHeartBeatInterval`, `instanceHeartBeatTimeOut`和`ipDeleteTimeout`
 > 用于兼容1.X客户端的心跳模式数据，后续版本可能会移除对1.X客户端的支持，届时这3个参数将被废弃。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/list?namespaceId=public&serviceName=service1&healthyOnly=true'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3179,45 +3179,45 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/list?namespaceId=p
 
 ### 2.22 查询实例详情
 
-#### 接口描述
+#### Description
 
 查询指定实例的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **描述说明**               |
+| **Name**       | **Type** | **Required** | **Description**               |
 |---------------|----------|----------|------------------------|
-| `namespaceId` | `string` | 否        | 命名空间Id，默认为`public`     |
-| `groupName`   | `string` | 否    | Group name. Defaults to `DEFAULT_GROUP`. |
-| `serviceName` | `string` | **是**    | 服务名                    |
-| `clusterName` | `string` | 否        | 集群名称，默认为`DEFAULT`      |
-| `ip`          | `string` | **是**    | `IP`地址                 |
-| `port`        | `integer` | **是**    | 端口号                    |
+| `namespaceId` | `string` | No        | 命名空间Id，默认为`public`     |
+| `groupName`   | `string` | No    | Group name. Defaults to `DEFAULT_GROUP`. |
+| `serviceName` | `string` | **Yes**    | 服务名                    |
+| `clusterName` | `string` | No        | 集群Name，默认为`DEFAULT`      |
+| `ip`          | `string` | **Yes**    | `IP`地址                 |
+| `port`        | `integer` | **Yes**    | 端口号                    |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型      | 描述说明                              |
+| Name           | Type      | Description                              |
 |---------------|-----------|-----------------------------------|
 | `serviceName` | `string` | 服务名,格式为`groupName`@@`serviceName` |
-| `clusterName` | `string` | 实例所在的集群名称                         |
+| `clusterName` | `string` | 实例所在的集群Name                         |
 | `ip`          | `string` | 实例`IP`                            |
 | `port`        | `integer` | 实例端口号                             |
 | `weight`      | `number` | 实例权重                              |
@@ -3230,15 +3230,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance/list?namespaceId=p
 > 关于心跳的参数`instanceHeartBeatInterval`, `instanceHeartBeatTimeOut`和`ipDeleteTimeout`
 > 用于兼容1.X客户端的心跳模式数据，后续版本可能会移除对1.X客户端的支持，届时这3个参数将被废弃。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=public&serviceName=service1&ip=1.1.1.1&port=3306'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3268,47 +3268,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/instance?namespaceId=public
 
 ### 2.23 创建服务
 
-#### 接口描述
+#### Description
 
 创建一个新的持久化服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型           | 是否必填  | 描述说明                   |
+| Name                | Type           | Required  | Description                   |
 |--------------------|----------------|-------|------------------------|
-| `namespaceId` | `string` | 否 | 命名空间`Id`，默认为`public` |
-| `groupName` | `string` | 否 | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名 |
-| `metadata` | `string` | 否 | 服务元数据，默认为空 |
-| `ephemeral` | `boolean` | 否 | 是否为临时实例，默认为`false` |
-| `protectThreshold` | `number` | 否 | 保护阈值，默认为`0` |
-| `selector` | `string` | 否 | 访问策略，默认为空 |
+| `namespaceId` | `string` | No | 命名空间`Id`，默认为`public` |
+| `groupName` | `string` | No | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名 |
+| `metadata` | `string` | No | 服务元数据，默认为空 |
+| `ephemeral` | `boolean` | No | 是否为临时实例，默认为`false` |
+| `protectThreshold` | `number` | No | 保护阈值，默认为`0` |
+| `selector` | `string` | No | 访问策略，默认为空 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -d 'serviceName=nacos.test.1' \
@@ -3317,7 +3317,7 @@ curl -d 'serviceName=nacos.test.1' \
   -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ns/service'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3329,49 +3329,49 @@ curl -d 'serviceName=nacos.test.1' \
 
 ### 2.24 删除服务
 
-#### 接口描述
+#### Description
 
 删除指定服务
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述说明                   |
+| Name           | Type     | Required  | Description                   |
 |---------------|----------|-------|------------------------|
-| `namespaceId` | `string` | 否     | 命名空间`Id`，默认为`public`   |
-| `groupName`   | `string` | 否     | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名                    |
+| `namespaceId` | `string` | No     | 命名空间`Id`，默认为`public`   |
+| `groupName`   | `string` | No     | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名                    |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.test.1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3383,39 +3383,39 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=naco
 
 ### 2.25 查询服务详情
 
-#### 接口描述
+#### Description
 
 查询指定服务的详细信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述说明                   |
+| Name           | Type     | Required  | Description                   |
 |---------------|----------|-------|------------------------|
-| `namespaceId` | `string` | 否     | 命名空间`Id`，默认为`public`   |
-| `groupName`   | `string` | 否     | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名                    |
+| `namespaceId` | `string` | No     | 命名空间`Id`，默认为`public`   |
+| `groupName`   | `string` | No     | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名                    |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                                 | 参数类型         | 描述                                   |
+| Name                                                 | Type         | Description                                   |
 |-----------------------------------------------------|--------------|--------------------------------------|
 | `namespaceId`                                       | `string` | 服务所属的namespaceId。                    |
 | `groupName`                                         | `string` | 服务所属的groupName。                      |
@@ -3431,15 +3431,15 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=naco
 | `clusterMap`.$ClusterName.`useInstancePortForCheck` | `boolean` | 是否使用所注册的实例的`IP:Port`进行健康检查。          |
 | `clusterMap`.$ClusterName.`metadata`                | `map<string, string>` | Cluster metadata. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.test.1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3474,43 +3474,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.t
 
 ### 2.26 查询服务列表
 
-#### 接口描述
+#### Description
 
 查询所有服务的列表，支持分页和条件过滤。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型           | 是否必填  | 描述说明                   |
+| Name           | Type           | Required  | Description                   |
 |---------------|----------------|-------|------------------------|
-| `namespaceId` | `string` | 否 | 命名空间`Id`，默认为`public` |
-| `pageNo` | `integer` | **是** | 当前页，默认为`1` |
-| `pageSize` | `integer` | **是** | 页条目数，默认为`20`，最大为`500` |
-| `groupNameParam` | `string` | 否 | - |
-| `ignoreEmptyService` | `boolean` | 否 | - |
-| `serviceNameParam` | `string` | 否 | - |
-| `withInstances` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间`Id`，默认为`public` |
+| `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
+| `pageSize` | `integer` | **Yes** | 页条目数，默认为`20`，最大为`500` |
+| `groupNameParam` | `string` | No | - |
+| `ignoreEmptyService` | `boolean` | No | - |
+| `serviceNameParam` | `string` | No | - |
+| `withInstances` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                   | 参数类型     | 描述说明         |
+| Name                                   | Type     | Description         |
 |---------------------------------------|----------|--------------|
 | `totalCount`                          | `integer` | 符合条件的服务的总数。  |
 | `pageNumber`                          | `integer` | 当前页码，起始为`1`。 |
@@ -3523,15 +3523,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service?serviceName=nacos.t
 | `pageItems`[i].`healthyInstanceCount` | `string` | 服务下的健康实例数量。  |
 | `pageItems`[i].`triggerFlag`          | `string` | 是否触发了服务的保护。  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3565,50 +3565,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/list'
 
 ### 2.27 更新服务
 
-#### 接口描述
+#### Description
 
 更新指定服务的配置信息。
 
 > 该接口将会完全覆盖之前更新过的元数据信息，例如，先使用`k1=v1`更新元数据，再使用`k2=v2`
 > 更新元数据，此时读取到的元数据为`k2=v2`，而不是`k1=v1,k2=v2`。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型           | 是否必填  | 描述说明                   |
+| Name                | Type           | Required  | Description                   |
 |--------------------|----------------|-------|------------------------|
-| `namespaceId` | `string` | 否 | 命名空间`Id`，默认为`public` |
-| `groupName` | `string` | 否 | 分组名，默认为`DEFAULT_GROUP` |
-| `serviceName` | `string` | **是** | 服务名 |
-| `metadata` | `string` | 否 | 服务元数据，默认为空 |
-| `protectThreshold` | `number` | 否 | 保护阈值，默认为`0` |
-| `selector` | `string` | 否 | 访问策略，默认为空 |
-| `ephemeral` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | 命名空间`Id`，默认为`public` |
+| `groupName` | `string` | No | 分组名，默认为`DEFAULT_GROUP` |
+| `serviceName` | `string` | **Yes** | 服务名 |
+| `metadata` | `string` | No | 服务元数据，默认为空 |
+| `protectThreshold` | `number` | No | 保护阈值，默认为`0` |
+| `selector` | `string` | No | 访问策略，默认为空 |
+| `ephemeral` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -d 'serviceName=nacos.test.1' \
@@ -3616,7 +3616,7 @@ curl -d 'serviceName=nacos.test.1' \
   -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ns/service'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3628,42 +3628,42 @@ curl -d 'serviceName=nacos.test.1' \
 
 ### 2.28 查询订阅者列表
 
-#### 接口描述
+#### Description
 
 查询指定服务的订阅者列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service/subscribers`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型**  | **是否必填** | **描述**                  |
+| **Name**       | **Type**  | **Required** | **Description**                  |
 |---------------|-----------|----------|-------------------------|
-| `namespaceId` | `string` | 否 | 命名空间ID，默认为`public` |
-| `serviceName` | `string` | **是** | 服务名称 |
-| `groupName` | `string` | 否 | 分组名称，默认是`DEFAULT_GROUP` |
-| `pageNo` | `integer` | **是** | 页码 |
-| `pageSize` | `integer` | **是** | 每页大小 |
-| `aggregation` | `boolean` | 否 | 是否聚合,默认为`true` |
+| `namespaceId` | `string` | No | 命名空间ID，默认为`public` |
+| `serviceName` | `string` | **Yes** | 服务Name |
+| `groupName` | `string` | No | 分组Name，默认是`DEFAULT_GROUP` |
+| `pageNo` | `integer` | **Yes** | 页码 |
+| `pageSize` | `integer` | **Yes** | 每页大小 |
+| `aggregation` | `boolean` | No | 是否聚合,默认为`true` |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型      | 描述                   |
+| Name                          | Type      | Description                   |
 |------------------------------|-----------|----------------------|
 | `totalCount`                 | `integer` | 符合条件的服务的总数。          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。         |
@@ -3678,15 +3678,15 @@ curl -d 'serviceName=nacos.test.1' \
 | `pageItems`[i].`groupName`   | `string` | 订阅的分组名。              |
 | `pageItems`[i].`serviceName` | `string` | 订阅的服务名。              |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/subscribers?namespaceId=public&serviceName=service1&groupName=DEFAULT_GROUP&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3712,47 +3712,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/subscribers?namespa
 }
 ```
 
-### 2.29 查询选择器类型
+### 2.29 查询选择器Type
 
-#### 接口描述
+#### Description
 
-查询系统中支持的所有选择器类型。
+查询系统中支持的所有选择器Type。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ns/service/selector/types`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型           | 描述      |
+| Name    | Type           | Description      |
 |--------|----------------|---------|
 | `data` | `array` | Selector type list. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/selector/types'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3769,65 +3769,65 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ns/service/selector/types'
 
 ### 3.1. 获取配置
 
-#### 接口描述
+#### Description
 
 获取指定配置
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **类型**   | **必填** | **默认值**  | **参数描述** |
+| **Name**       | **Type**   | **Required** | **Default**  | **Description** |
 |---------------|----------|--------|----------|----------|
-| `namespaceId` | `string` | 否      | `public` | 命名空间     |
-| `groupName`   | `string` | **是**  | 无        | 配置分组名    |
-| `dataId`      | `string` | **是**  | 无        | 配置名      |
+| `namespaceId` | `string` | No      | `public` | 命名空间     |
+| `groupName`   | `string` | **Yes**  | None        | 配置分组名    |
+| `dataId`      | `string` | **Yes**  | None        | 配置名      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                         |
+| Name                | Type     | Description                         |
 |--------------------|----------|----------------------------|
-| `id`               | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `id`               | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
 | `dataId`           | `string` | 配置ID。                      |
 | `groupName`        | `string` | 配置分组。                      |
 | `namespaceId`      | `string` | 命名空间ID。                    |
 | `content`          | `string` | 配置内容。                      |
-| `desc`             | `string` | 配置描述。                      |
+| `desc`             | `string` | 配置Description。                      |
 | `md5`              | `string` | 配置内容的MD5值。                 |
 | `configTags`       | `string` | 配置的标签。                     |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。     |
-| `appName`          | `string` | 配置所属的应用名称。                 |
-| `type`             | `string` | 配置类型。                      |
+| `appName`          | `string` | 配置所属的应用Name。                 |
+| `type`             | `string` | 配置Type。                      |
 | `createTime`       | `integer` | 配置创建时间。                    |
 | `modifyTime`       | `integer` | 配置修改时间。                    |
 | `createUser`       | `string` | 配置创建人。                     |
 | `createIp`         | `string` | 配置创建IP。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3855,53 +3855,53 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.example
 
 ### 3.2. 发布配置
 
-#### 接口描述
+#### Description
 
 发布指定配置
 
 > 当配置已存在时，则对配置进行更新
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填    | 默认值      | 参数描述            |
+| Name           | Type       | Required    | Default      | Description            |
 |---------------|----------|-------|----------|-----------------|
-| `namespaceId` | `string` | 否 | `public` |
-| `groupName` | `string` | **是** | 无 |
-| `dataId` | `string` | **是** | 无 |
-| `content` | `string` | **是** | 无 |
-| `appName` | `string` | 否 | 无 |
-| `configTags` | `string` | 否 | 无 |
-| `desc` | `string` | 否 | 无 |
-| `type` | `string` | 否 | 无 |
-| `encryptedDataKey` | `string` | 否 | - |
-| `srcUser` | `string` | 否 | - |
-| `tag` | `string` | 否 | - |
+| `namespaceId` | `string` | No | `public` |
+| `groupName` | `string` | **Yes** | None |
+| `dataId` | `string` | **Yes** | None |
+| `content` | `string` | **Yes** | None |
+| `appName` | `string` | No | None |
+| `configTags` | `string` | No | None |
+| `desc` | `string` | No | None |
+| `type` | `string` | No | None |
+| `encryptedDataKey` | `string` | No | - |
+| `srcUser` | `string` | No | - |
+| `tag` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -d 'dataId=nacos.example' \
@@ -3911,7 +3911,7 @@ curl -d 'dataId=nacos.example' \
  -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3923,49 +3923,49 @@ curl -d 'dataId=nacos.example' \
 
 ### 3.3. 删除配置
 
-#### 接口描述
+#### Description
 
 删除指定配置
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填    | 默认值      | 参数描述  |
+| Name           | Type       | Required    | Default      | Description  |
 |---------------|----------|-------|----------|-------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间  |
-| `groupName`   | `string` | **是** | 无        | 配置分组名 |
-| `dataId`      | `string` | **是** | 无        | 配置名   |
+| `namespaceId` | `string` | No     | `public` | 命名空间  |
+| `groupName`   | `string` | **Yes** | None        | 配置分组名 |
+| `dataId`      | `string` | **Yes** | None        | 配置名   |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述     |
+| Name    | Type      | Description     |
 |--------|-----------|--------|
 | `data` | `boolean` | 是否执行成功 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3977,47 +3977,47 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config?dataId=nacos.exam
 
 ### 3.4 批量删除配置
 
-#### 接口描述
+#### Description
 
 根据配置ID批量删除配置
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 参数类型         | 是否必填  | 描述     |
+| Name   | Type         | Required  | Description     |
 |-------|--------------|-------|--------|
-| `ids` | `array` | **是** | Config ID list. Separate multiple IDs with commas. |
+| `ids` | `array` | **Yes** | Config ID list. Separate multiple IDs with commas. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/batch?ids=1,2,3'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4029,53 +4029,53 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/batch?ids=1,2,3'
 
 ### 3.5 查询配置的监听者
 
-#### 接口描述
+#### Description
 
 查询指定配置的监听者信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/listener`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值      | 描述        |
+| Name           | Type      | Required  | Default      | Description        |
 |---------------|-----------|-------|----------|-----------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间      |
-| `dataId`      | `string` | **是** | 无        | 配置ID      |
-| `groupName`   | `string` | **是** | 无        | 分组名称      |
-| `aggregation` | `boolean` | 否 | `true`   | Whether to aggregate data from other nodes. |
+| `namespaceId` | `string` | No     | `public` | 命名空间      |
+| `dataId`      | `string` | **Yes** | None        | 配置ID      |
+| `groupName`   | `string` | **Yes** | None        | 分组Name      |
+| `aggregation` | `boolean` | No | `true`   | Whether to aggregate data from other nodes. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                    |
+| Name               | Type                  | Description                                    |
 |-------------------|-----------------------|---------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`config`。                 |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`config`。                 |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅者IP，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/listener?namespaceId=public&dataId=example&groupName=DEFAULT_GROUP'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4092,70 +4092,70 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/listener?namespaceId
 
 ### 3.6 通过配置内容查询配置列表
 
-#### 接口描述
+#### Description
 
 根据配置详情（如内容、标签等）搜索配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名            | 参数类型      | 是否必填  | 默认值      | 描述                                                     |
+| Name            | Type      | Required  | Default      | Description                                                     |
 |----------------|-----------|-------|----------|--------------------------------------------------------|
-| `pageNo` | `integer` | **是** | 1 |
-| `pageSize` | `integer` | **是** | 100 |
-| `namespaceId` | `string` | 否 | `public` |
-| `dataId` | `string` | **是** | `""` |
-| `groupName` | `string` | **是** | `""` |
-| `appName` | `string` | 否 |  |
-| `configTags` | `string` | 否 |  |
-| `type` | `string` | 否 |  |
-| `configDetail` | `string` | **是** |  |
-| `search` | `string` | 否 | Search mode: `blur` or `accurate`. Defaults to `blur`. |
+| `pageNo` | `integer` | **Yes** | 1 |
+| `pageSize` | `integer` | **Yes** | 100 |
+| `namespaceId` | `string` | No | `public` |
+| `dataId` | `string` | **Yes** | `""` |
+| `groupName` | `string` | **Yes** | `""` |
+| `appName` | `string` | No |  |
+| `configTags` | `string` | No |  |
+| `type` | `string` | No |  |
+| `configDetail` | `string` | **Yes** |  |
+| `search` | `string` | No | Search mode: `blur` or `accurate`. Defaults to `blur`. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                         |
+| Name                          | Type     | Description                         |
 |------------------------------|----------|----------------------------|
 | `totalCount`                 | `integer` | 符合规则的配置总数。                 |
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `array`   | Configurations matching the query criteria. |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为LongType的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
 | `pageItems`[i].`md5`         | `string` | 配置内容的MD5值。                 |
-| `pageItems`[i].`appName`     | `string` | 配置所属的应用名称。                 |
-| `pageItems`[i].`type`        | `string` | 配置类型。                      |
+| `pageItems`[i].`appName`     | `string` | 配置所属的应用Name。                 |
+| `pageItems`[i].`type`        | `string` | 配置Type。                      |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/list?pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4195,51 +4195,51 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/list?pageNo=1&pageSi
 
 ### 3.7 停止Beta配置
 
-#### 接口描述
+#### Description
 
 停止指定配置的Beta配置
 
 > 只有在[发布配置](#32-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能停止BETA发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 默认值      | 描述   |
+| Name           | Type     | Required  | Default      | Description   |
 |---------------|----------|-------|----------|------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间 |
-| `dataId`      | `string` | **是** | 无        | 配置ID |
-| `groupName`   | `string` | **是** | 无        | 分组名称 |
+| `namespaceId` | `string` | No     | `public` | 命名空间 |
+| `dataId`      | `string` | **Yes** | None        | 配置ID |
+| `groupName`   | `string` | **Yes** | None        | 分组Name |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=public&dataId=example&groupName=DEFAULT_GROUP'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4251,68 +4251,68 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=
 
 ### 3.8 查询Beta配置
 
-#### 接口描述
+#### Description
 
 查询指定配置的Beta配置
 
 > 只有在[发布配置](#32-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能停止BETA发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 默认值      | 描述   |
+| Name           | Type     | Required  | Default      | Description   |
 |---------------|----------|-------|----------|------|
-| `namespaceId` | `string` | 否     | `public` | 命名空间 |
-| `dataId`      | `string` | **是** | 无        | 配置ID |
-| `groupName`   | `string` | **是** | 无        | 分组名称 |
+| `namespaceId` | `string` | No     | `public` | 命名空间 |
+| `dataId`      | `string` | **Yes** | None        | 配置ID |
+| `groupName`   | `string` | **Yes** | None        | 分组Name |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                                  |
+| Name                | Type     | Description                                  |
 |--------------------|----------|-------------------------------------|
 | `id`               | `string` | beta配置的存储ID。                        |
 | `dataId`           | `string` | 配置的dataId。                          |
 | `groupName`        | `string` | 配置的groupName。                       |
 | `namespaceId`      | `string` | 配置所属的命名空间。                          |
-| `desc`             | `string` | 配置描述。                               |
+| `desc`             | `string` | 配置Description。                               |
 | `md5`              | `string` | 配置内容的MD5值。                          |
 | `configTags`       | `string` | 配置的标签。                              |
 | `encryptedDataKey` | `string` | 加密配置内容的密钥，使用配置加密插件时存在。              |
-| `appName`          | `string` | 配置所属的应用名称。                          |
-| `type`             | `string` | 配置类型。                               |
+| `appName`          | `string` | 配置所属的应用Name。                          |
+| `type`             | `string` | 配置Type。                               |
 | `createTime`       | `integer` | 配置创建时间。                             |
 | `modifyTime`       | `integer` | 配置修改时间。                             |
 | `createUser`       | `string` | 配置创建人。                              |
 | `createIp`         | `string` | 配置创建IP。                             |
-| `grayName`         | `string` | 灰度发布规则名称, 固定为`beta`。                |
+| `grayName`         | `string` | 灰度发布规则Name, 固定为`beta`。                |
 | `grayRule`         | `string` | 灰度发布规则，格式为JSON，其中的`expr`为beta的ip列表。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=public&dataId=example&groupName=DEFAULT_GROUP'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4342,46 +4342,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/beta?namespaceId=pub
 
 ### 3.9 导入并发布配置
 
-#### 接口描述
+#### Description
 
 导入配置并发布到指定命名空间
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 Request body type: `multipart/form-data`. Parameters are sent in the request body.
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/import`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型               | 是否必填 | 默认值      | 描述     |
+| Name           | Type               | Required | Default      | Description     |
 |---------------|--------------------|------|----------|--------|
-| `namespaceId` | `string` | 否 | `public` |
-| `src_user` | `string` | 否 | 无 |
-| `policy` | `string` | 否 | `ABORT` |
-| `file` | `MultipartFile` | 否 | ZIP file containing skill package |
+| `namespaceId` | `string` | No | `public` |
+| `src_user` | `string` | No | None |
+| `policy` | `string` | No | `ABORT` |
+| `file` | `MultipartFile` | No | ZIP file containing skill package |
 
-#### 返回数据
+#### Response Data
 
-| 参数名              | 参数类型                  | 描述     |
+| Name              | Type                  | Description     |
 |------------------|-----------------------|--------|
 | `data`           | `map<string, object>` | Import result. |
 | `data.succCount` | `integer` | 成功导入数量 |
 | `data.skipCount` | `integer` | 跳过导入数量 |
 
-#### 示例
+#### Examples
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/import' \
@@ -4390,7 +4390,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/import' \
 -F 'file=@/path/to/config.zip'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4405,45 +4405,45 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/import' \
 
 ### 3.10 导出配置
 
-#### 接口描述
+#### Description
 
 导出指定配置为ZIP文件。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/export`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型         | 是否必填 | 默认值      | 描述     |
+| Name           | Type         | Required | Default      | Description     |
 |---------------|--------------|------|----------|--------|
-| `namespaceId` | `string` | 否 | `public` |
-| `groupName` | `string` | 否 | `""` |
-| `dataId` | `string` | 否 | `""` |
-| `ids` | `array` | 否 | None |
-| `appName` | `string` | 否 | - |
+| `namespaceId` | `string` | No | `public` |
+| `groupName` | `string` | No | `""` |
+| `dataId` | `string` | No | `""` |
+| `ids` | `array` | No | None |
+| `appName` | `string` | No | - |
 
 > 使用时建议分开使用 `ids` 和 `dataId` + `groupName` 的组合，只选择一种方式，另一类传入空字符串，否则可能导致导出文件为空内容。
 
-#### 返回数据
+#### Response Data
 
 返回体为ZIP文件，包含配置内容和元数据
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/export?namespaceId=public&ids=' --output config.zip
@@ -4451,50 +4451,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/export?namespaceId=p
 
 ### 3.11 克隆配置
 
-#### 接口描述
+#### Description
 
 克隆配置到指定命名空间
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/clone`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名       | 参数类型               | 是否必填 | 默认值     | 描述       |
+| Name       | Type               | Required | Default     | Description       |
 |-----------|--------------------|------|---------|----------|
-| `namespaceId` | `string` | **是** | `public` |
-| `policy` | `string` | 否 | `ABORT` |
-| `src_user` | `string` | 否 | - |
+| `namespaceId` | `string` | **Yes** | `public` |
+| `policy` | `string` | No | `ABORT` |
+| `src_user` | `string` | No | - |
 
-#### 请求参数
+#### Request Parameters
 
-请求体类型为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
+请求体Type为 `application/json`，为配置列表数组，每项为 `SameNamespaceCloneConfigBean`（`cfgId`、`dataId`、`group`）。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型      | 描述     |
+| Name         | Type      | Description     |
 |-------------|-----------|--------|
 | `succCount` | `integer` | 成功导入数量 |
 | `skipCount` | `integer` | 跳过导入数量 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespaceId=test&policy=ABORT" \
@@ -4502,7 +4502,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 -d "[{\"cfgId\":\"838029534438625280\",\"dataId\":\"111\",\"group\":\"DEFAULT_GROUP\"},{\"cfgId\":\"838033747294031872\",\"dataId\":\"qtc-user.yaml\",\"group\":\"DEFAULT_GROUP\"}]"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4517,41 +4517,41 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 
 ### 3.12. 查询配置历史列表
 
-#### 接口描述
+#### Description
 
 获取指定配置的历史版本列表
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填    | 默认值             | 参数描述  |
+| Name           | Type       | Required    | Default             | Description  |
 |---------------|----------|-------|-----------------|-------|
-| `namespaceId` | `string` | 否     | `public`        | 命名空间  |
-| `groupName`   | `string` | **是** | 无               | 配置分组名 |
-| `dataId`      | `string` | **是** | 无               | 配置名   |
-| `pageNo`      | `integer` | **是** | `1`             | 当前页   |
-| `pageSize`    | `integer` | **是** | `100`（最大为`500`） | 页条目数  |
+| `namespaceId` | `string` | No     | `public`        | 命名空间  |
+| `groupName`   | `string` | **Yes** | None               | 配置分组名 |
+| `dataId`      | `string` | **Yes** | None               | 配置名   |
+| `pageNo`      | `integer` | **Yes** | `1`             | 当前页   |
+| `pageSize`    | `integer` | **Yes** | `100`（最大为`500`） | 页条目数  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                                |
+| Name                          | Type     | Description                                |
 |------------------------------|----------|-----------------------------------|
 | `totalCount`                 | `integer` | 历史记录的总数。                          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。                      |
@@ -4562,22 +4562,22 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/clone' -d "namespac
 | `pageItems`[i].`groupName`   | `string` | 配置的groupName。                     |
 | `pageItems`[i].`namespaceId` | `string` | 配置所属的命名空间。                        |
 | `pageItems`[i].`appName`     | `string` | 配置所属的appName。                     |
-| `pageItems`[i].`opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。        |
-| `pageItems`[i].`publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。 |
+| `pageItems`[i].`opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。        |
+| `pageItems`[i].`publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。 |
 | `pageItems`[i].`srcIp`       | `string` | 发布的来源IP。                          |
 | `pageItems`[i].`srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。       |
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                           |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                           |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public&pageNo=1&pageSize=100'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4625,40 +4625,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.e
 
 ### 3.13. 查询配置某一历史版本详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的某次历史变更记录。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名         | 类型       | 必填    | 默认值      | 参数描述   |
+| Name         | Type       | Required    | Default      | Description   |
 |-------------|----------|-------|----------|--------|
-| namespaceId | `string` | 否     | `public` | 命名空间   |
-| groupName   | `string` | **是** | 无        | 配置分组名  |
-| dataId      | `string` | **是** | 无        | 配置名    |
-| nid         | `integer` | **是** | 无        | 配置历史Id |
+| namespaceId | `string` | No     | `public` | 命名空间   |
+| groupName   | `string` | **Yes** | None        | 配置分组名  |
+| dataId      | `string` | **Yes** | None        | 配置名    |
+| nid         | `integer` | **Yes** | None        | 配置历史Id |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -4666,24 +4666,24 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/list?dataId=nacos.e
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupName=DEFAULT_GROUP&nid=7'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4713,40 +4713,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupN
 
 ### 3.14. 查询配置上一版本信息
 
-#### 接口描述
+#### Description
 
 获取指定配置的上一版本
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history/previous`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名         | 类型       | 必填    | 默认值      | 参数描述  |
+| Name         | Type       | Required    | Default      | Description  |
 |-------------|----------|-------|----------|-------|
-| namespaceId | `string` | 否     | `public` | 命名空间  |
-| groupName   | `string` | **是** | 无        | 配置分组名 |
-| dataId      | `string` | **是** | 无        | 配置名   |
-| id          | `integer` | **是** | 无        | 配置Id  |
+| namespaceId | `string` | No     | `public` | 命名空间  |
+| groupName   | `string` | **Yes** | None        | 配置分组名 |
+| dataId      | `string` | **Yes** | None        | 配置名   |
+| id          | `integer` | **Yes** | None        | 配置Id  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -4754,24 +4754,24 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/??dataId=111&groupN
 | `namespaceId` | `string` | 配置所属的命名空间。                                                                  |
 | `content`     | `string`     |
 | `appName`     | `string` | 配置所属的appName。                                                               |
-| `opType`      | `string` | 操作类型，`I`为插入、`U`为更新、`D`为删除。                                                  |
-| `publishType` | `string` | 发布类型，`formal`为普通发布，`gray`为beta发布。                                           |
+| `opType`      | `string` | 操作Type，`I`为插入、`U`为更新、`D`为删除。                                                  |
+| `publishType` | `string` | 发布Type，`formal`为普通发布，`gray`为beta发布。                                           |
 | `srcIp`       | `string` | 发布的来源IP。                                                                    |
 | `srcUser`     | `string` | 发布的用户，仅在开启鉴权并登录用户后才发布配置才存在。                                                 |
 | `createTime`  | `integer` | 配置创建时间。                                                                     |
 | `modifyTime`  | `integer` | 配置修改时间。                                                                     |
-| `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
+| `grayName`    | `string` | 灰度发布规则Name, 固定为`beta`。                                                        |
 | `extInfo`     | `string` | Extended information. It currently includes `src_user`, `type`, and `c_desc`; when `publishType` is `gray`, it also includes `grayRule`. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/previous?id=101&dataId=nacos.example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4801,52 +4801,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/previous?id=101&dat
 
 ### 3.15. 查询指定命名空间下的配置列表
 
-#### 接口描述
+#### Description
 
 获取指定命名空间下的配置信息列表
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/history/configs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名         | 类型       | 必填    | 默认值 | 参数描述 |
+| Name         | Type       | Required    | Default | Description |
 |-------------|----------|-------|-----|------|
-| namespaceId | `string` | **是** | 无   | 命名空间 |
+| namespaceId | `string` | **Yes** | None   | 命名空间 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型     | 描述            |
+| Name         | Type     | Description            |
 |-------------|----------|---------------|
 | `dataId`    | `string` | 配置的dataId。    |
 | `groupName` | `string` | 配置的groupName。 |
 
 > 其他字段均无用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/configs?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4881,43 +4881,43 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/configs?namespaceId
 
 ### 3.16 查询容量信息
 
-#### 接口描述
+#### Description
 
 查询指定分组或命名空间的容量信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/capacity`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填 | 默认值 | 描述     |
+| Name           | Type     | Required | Default | Description     |
 |---------------|----------|------|-----|--------|
-| `groupName`   | `string` | 否    | 无   | 分组名称   |
-| `namespaceId` | `string` | 否    | 无   | 命名空间ID |
+| `groupName`   | `string` | No    | None   | 分组Name   |
+| `namespaceId` | `string` | No    | None   | 命名空间ID |
 
 **注意** ：`groupName` 和 `namespaceId` 至少需要提供一个。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型      | 描述         |
+| Name                | Type      | Description         |
 |--------------------|-----------|------------|
 | `id`               | `integer` | 容量信息的唯一ID  |
-| `groupName`        | `string` | 分组名称       |
+| `groupName`        | `string` | 分组Name       |
 | `namespaceId`      | `string` | 命名空间ID     |
 | `quota`            | `integer` | 配额         |
 | `usage`            | `integer` | 当前使用量      |
@@ -4927,15 +4927,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/history/configs?namespaceId
 | ~~`maxAggrCount`~~ | `integer` | 未使用，将废弃    |
 | ~~`maxAggrSize`~~  | `integer` | 未使用，将废弃    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4957,52 +4957,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity?namespaceId=public
 
 ### 3.17 更新容量信息
 
-#### 接口描述
+#### Description
 
 更新指定分组或命名空间的容量信息。如果容量信息未初始化，则会自动初始化
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/capacity`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 描述                   |
+| Name           | Type      | Required  | Description                   |
 |---------------|-----------|-------|----------------------|
-| `groupName` | `string` | **是** | 分组名称，与命名空间ID 两者必须有其一 |
-| `namespaceId` | `string` | 否 | 命名空间ID，与分组名称 两者必须有其一 |
-| `quota` | `integer` | 否 | 配额 |
-| `maxSize` | `integer` | 否 | 最大大小 |
-| `maxAggrCount` | `integer` | 否 | - |
-| `maxAggrSize` | `integer` | 否 | - |
+| `groupName` | `string` | **Yes** | 分组Name，与命名空间ID 两者必须有其一 |
+| `namespaceId` | `string` | No | 命名空间ID，与分组Name 两者必须有其一 |
+| `quota` | `integer` | No | 配额 |
+| `maxSize` | `integer` | No | 最大大小 |
+| `maxAggrCount` | `integer` | No | - |
+| `maxAggrSize` | `integer` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity' -d 'namespaceId=public&quota=200&maxSize=2048'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5014,45 +5014,45 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/capacity' -d 'namespaceId=
 
 ### 3.18 手动触发本地缓存更新
 
-#### 接口描述
+#### Description
 
 手动触发从存储中加载所有配置数据到本地缓存。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/localCache`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述   |
+| Name    | Type     | Description   |
 |--------|----------|------|
 | `data` | `string` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/localCache'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5064,48 +5064,48 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/localCache'
 
 ### 3.19 设置日志级别
 
-#### 接口描述
+#### Description
 
 动态设置指定模块的日志级别
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/log`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 参数类型     | 是否必填  | 默认值 | 描述                    |
+| Name        | Type     | Required  | Default | Description                    |
 |------------|----------|-------|-----|-----------------------|
-| `logName`  | `string` | **是** | 无   | 模块名称                  |
-| `logLevel` | `string` | **是** | 无   | 日志级别（如`INFO`、`DEBUG`） |
+| `logName`  | `string` | **Yes** | None   | 模块Name                  |
+| `logLevel` | `string` | **Yes** | None   | 日志级别（如`INFO`、`DEBUG`） |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述   |
+| Name    | Type     | Description   |
 |--------|----------|------|
 | `data` | `string` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/log' -d "logName=config-server&logLevel=DEBUG"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5117,49 +5117,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/log' -d "logName=config
 
 ### 3.20 执行Derby数据库操作
 
-#### 接口描述
+#### Description
 
 执行Derby数据库的查询操作（仅支持 `SELECT` 语句）
 
 > **注意** 此接口需要开启`nacos.config.derby.ops.enabled`配置，且数据库为`Derby` 时才可使用，仅提供给运维人员进行Derby数据库排查数据问题时使用。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/derby`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 参数类型     | 是否必填  | 默认值 | 描述       |
+| Name   | Type     | Required  | Default | Description       |
 |-------|----------|-------|-----|----------|
-| `sql` | `string` | **是** | 无   | SQL 查询语句 |
+| `sql` | `string` | **Yes** | None   | SQL 查询语句 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型                        | 描述   |
+| Name    | Type                        | Description   |
 |--------|-----------------------------|------|
 | `data` | `array` | Query result. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby?sql=SELECT%20*%20FROM%20config_info'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5201,45 +5201,45 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby?sql=SELECT%20*%20
 
 ### 3.21 导入Derby数据库数据
 
-#### 接口描述
+#### Description
 
 从外部数据源导入数据到Derby数据库
 
 > **注意** 此接口需要开启`nacos.config.derby.ops.enabled`配置，且数据库为`Derby` 时才可使用，仅提供给运维人员进行Derby数据库排查数据问题时使用。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-请求体类型：`multipart/form-data`，参数放在请求体中。
+请求体Type：`multipart/form-data`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/ops/derby/import`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名    | 参数类型            | 是否必填 | 默认值 | 描述           |
+| Name    | Type            | Required | Default | Description           |
 |--------|-----------------|------|-----|--------------|
-| `file` | `MultipartFile` | 否    | 无   | 导入文件（SQL 文件）。 |
+| `file` | `MultipartFile` | No    | None   | 导入文件（SQL 文件）。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名    | 参数类型     | 描述     |
+| Name    | Type     | Description     |
 |--------|----------|--------|
 | `data` | `string` | 导入结果信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby/import' \
@@ -5247,7 +5247,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby/import' \
 -F 'file=@data.sql'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5259,53 +5259,53 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/ops/derby/import' \
 
 ### 3.22 获取客户端订阅信息
 
-#### 接口描述
+#### Description
 
 获取指定 IP 客户端的订阅配置信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/listener`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型      | 是否必填  | 默认值      | 描述         |
+| Name           | Type      | Required  | Default      | Description         |
 |---------------|-----------|-------|----------|------------|
-| `ip`          | `string` | **是** | 无        | 客户端 IP 地址  |
-| `all`         | `boolean` | 否     | `false`  | 是否返回所有配置信息 |
-| `namespaceId` | `string` | 否     | `public` | 命名空间ID     |
-| `aggregation` | `boolean` | 否     | `true`   | 是否从其他节点聚合  |
+| `ip`          | `string` | **Yes** | None        | 客户端 IP 地址  |
+| `all`         | `boolean` | No     | `false`  | 是否返回所有配置信息 |
+| `namespaceId` | `string` | No     | `public` | 命名空间ID     |
+| `aggregation` | `boolean` | No     | `true`   | 是否从其他节点聚合  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                                                            |
+| Name               | Type                  | Description                                                                            |
 |-------------------|-----------------------|-------------------------------------------------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`ip`。                                                             |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`ip`。                                                             |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅的配置信息，格式为`dataId`+`groupName`+`namespaceId`，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/listener?ip=127.0.0.1&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5322,40 +5322,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/listener?ip=127.0.0.1&names
 
 ### 3.23 获取集群客户端指标
 
-#### 接口描述
+#### Description
 
 获取集群中指定 IP 客户端的配置指标信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/metrics/cluster`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **默认值**  | **描述**    |
+| **Name**       | **Type** | **Required** | **Default**  | **Description**    |
 |---------------|----------|----------|----------|-----------|
-| `ip`          | `string` | **是**    | 无        | 客户端 IP 地址 |
-| `dataId`      | `string` | 否        | 无        | 配置ID      |
-| `groupName`   | `string` | 否        | 无        | 分组名称      |
-| `namespaceId` | `string` | 否        | `public` | 命名空间ID    |
+| `ip`          | `string` | **Yes**    | None        | 客户端 IP 地址 |
+| `dataId`      | `string` | No        | None        | 配置ID      |
+| `groupName`   | `string` | No        | None        | 分组Name      |
+| `namespaceId` | `string` | No        | `public` | 命名空间ID    |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                            | 参数类型      | 描述说明     |
+| Name                                            | Type      | Description     |
 |------------------------------------------------|-----------|----------|
 | `data`                                         |           | 服务信息     |
 | `data.{namespaceId}.isFixedServer`             | `boolean` | 是否固定服务器  |
@@ -5366,15 +5366,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/listener?ip=127.0.0.1&names
 | `data.{namespaceId}.metricValues.cacheData`    | `string` | 缓存数据md5值 |
 | `data.{namespaceId}.metricValues.snapshotData` | `string` | 快照数据md5值 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.1&dataId=example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5398,40 +5398,40 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.
 
 ### 3.24 获取本地客户端指标
 
-#### 接口描述
+#### Description
 
 获取本地机器上指定 IP 客户端指标信息
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/metrics/ip`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **默认值**  | **描述**    |
+| **Name**       | **Type** | **Required** | **Default**  | **Description**    |
 |---------------|----------|----------|----------|-----------|
-| `ip`          | `string` | **是**    | 无        | 客户端 IP 地址 |
-| `dataId`      | `string` | 否        | 无        | 配置ID      |
-| `groupName`   | `string` | 否        | 无        | 分组名称      |
-| `namespaceId` | `string` | 否        | `public` | 命名空间      |
+| `ip`          | `string` | **Yes**    | None        | 客户端 IP 地址 |
+| `dataId`      | `string` | No        | None        | 配置ID      |
+| `groupName`   | `string` | No        | None        | 分组Name      |
+| `namespaceId` | `string` | No        | `public` | 命名空间      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                            | 参数类型      | 描述说明     |
+| Name                                            | Type      | Description     |
 |------------------------------------------------|-----------|----------|
 | `data`                                         |           | 服务信息     |
 | `data.{namespaceId}.isFixedServer`             | `boolean` | 是否固定服务器  |
@@ -5442,15 +5442,15 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.
 | `data.{namespaceId}.metricValues.cacheData`    | `string` | 缓存数据md5值 |
 | `data.{namespaceId}.metricValues.snapshotData` | `string` | 快照数据md5值 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/ip?ip=127.0.0.1&dataId=example&groupName=DEFAULT_GROUP&namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5474,47 +5474,47 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/metrics/ip?ip=127.0.0.1&dat
 
 ### 3.25. 更新配置元数据
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新配置的元数据信息：仅能更新`描述`和`标签`。
+通过该接口，可以更新配置的元数据信息：仅能更新`Description`和`标签`。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/metadata`
 
-#### 请求参数
+#### Request Parameters
 
-| **参数名**       | **参数类型** | **是否必填** | **默认值**  | **描述** |
+| **Name**       | **Type** | **Required** | **Default**  | **Description** |
 |---------------|----------|----------|----------|--------|
-| `dataId`      | `string` | **是**    | 无        | 配置ID   |
-| `groupName`   | `string` | **是**    | 无        | 分组名称   |
-| `namespaceId` | `string` | 否        | `public` | 命名空间   |
-| `desc`        | `string` | 否        | null     | 配置的新描述 |
-| `configTags`  | `string` | 否        | null     | 配置的新标签 |
+| `dataId`      | `string` | **Yes**    | None        | 配置ID   |
+| `groupName`   | `string` | **Yes**    | None        | 分组Name   |
+| `namespaceId` | `string` | No        | `public` | 命名空间   |
+| `desc`        | `string` | No        | null     | 配置的新Description |
+| `configTags`  | `string` | No        | null     | 配置的新标签 |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述   |
+| Name    | Type      | Description   |
 |--------|-----------|------|
 | `data` | `boolean` | 操作结果 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT '127.0.0.1:8848/v3/admin/cs/config/metadata' \
@@ -5524,7 +5524,7 @@ curl -X PUT '127.0.0.1:8848/v3/admin/cs/config/metadata' \
 -d 'desc=testDesc' \
 -d 'configTags=customTag'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5536,38 +5536,38 @@ curl -X PUT '127.0.0.1:8848/v3/admin/cs/config/metadata' \
 
 ### 3.26. Get Gray Configuration
 
-#### 接口描述
+#### Description
 
 This interface retrieves the details of a specified gray configuration.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/gray`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public` when omitted. |
-| `groupName` | `string` | **是** | Configuration group name. |
-| `dataId` | `string` | **是** | Configuration ID. |
-| `grayName` | `string` | **是** | Gray configuration name. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public` when omitted. |
+| `groupName` | `string` | **Yes** | Configuration group name. |
+| `dataId` | `string` | **Yes** | Configuration ID. |
+| `grayName` | `string` | **Yes** | Gray configuration name. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.dataId | `string` | Configuration ID. |
 | data.groupName | `string` | Configuration group name. |
@@ -5576,15 +5576,15 @@ This interface retrieves the details of a specified gray configuration.
 | data.grayName | `string` | Gray configuration name. |
 | data.grayRule | `string` | Gray matching rule. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=public&groupName=DEFAULT_GROUP&dataId=example&grayName=gray'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5596,52 +5596,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=pub
 
 ### 3.27. Publish Gray Configuration
 
-#### 接口描述
+#### Description
 
 This interface publishes a gray configuration using tagv2 gray matching rules.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/gray`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public` when omitted. |
-| `groupName` | `string` | **是** | Configuration group name. |
-| `dataId` | `string` | **是** | Configuration ID. |
-| `content` | `string` | **是** | Gray configuration content. |
-| `grayName` | `string` | **是** | Gray configuration name. |
-| `grayType` | `string` | 否 | Gray rule type. |
-| `grayMatchRuleExp` | `string` | **是** | Gray matching rule expression. |
-| `grayVersion` | `string` | **是** | Gray version. |
-| `grayPriority` | `integer` | 否 | Gray rule priority. |
-| `type` | `string` | 否 | Configuration type. |
-| `srcUser` | `string` | 否 | Operator username. |
-| `encryptedDataKey` | `string` | 否 | Data key for encrypted configuration content. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public` when omitted. |
+| `groupName` | `string` | **Yes** | Configuration group name. |
+| `dataId` | `string` | **Yes** | Configuration ID. |
+| `content` | `string` | **Yes** | Gray configuration content. |
+| `grayName` | `string` | **Yes** | Gray configuration name. |
+| `grayType` | `string` | No | Gray rule type. |
+| `grayMatchRuleExp` | `string` | **Yes** | Gray matching rule expression. |
+| `grayVersion` | `string` | **Yes** | Gray version. |
+| `grayPriority` | `integer` | No | Gray rule priority. |
+| `type` | `string` | No | Configuration type. |
+| `srcUser` | `string` | No | Operator username. |
+| `encryptedDataKey` | `string` | No | Data key for encrypted configuration content. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | Whether the gray configuration was published successfully. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray' \
@@ -5656,7 +5656,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray' \
   -d 'grayPriority=1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5668,50 +5668,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray' \
 
 ### 3.28. Delete Gray Configuration
 
-#### 接口描述
+#### Description
 
 This interface deletes a specified gray configuration.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/cs/config/gray`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public` when omitted. |
-| `groupName` | `string` | **是** | Configuration group name. |
-| `dataId` | `string` | **是** | Configuration ID. |
-| `grayName` | `string` | **是** | Gray configuration name. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public` when omitted. |
+| `groupName` | `string` | **Yes** | Configuration group name. |
+| `dataId` | `string` | **Yes** | Configuration ID. |
+| `grayName` | `string` | **Yes** | Gray configuration name. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | Whether the gray configuration was deleted successfully. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=public&groupName=DEFAULT_GROUP&dataId=example&grayName=gray'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5725,41 +5725,41 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=
 
 ### 4.1. 查询MCP服务的服务列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的MCP服务的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                                     |
+| Name           | Type     | Required  | Description                                                     |
 |---------------|----------|-------|--------------------------------------------------------|
-| `pageNo` | `integer` | **是** | 当前页，默认为`1` |
-| `pageSize` | `integer` | **是** | 页条目数，默认为`20`，最大为`500` |
-| `namespaceId` | `string` | 否 | MCP服务的命名空间ID，默认为`public` |
-| `mcpName` | `string` | 否 | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
-| `search` | `string` | 否 | Search mode: `blur` or `accurate`. Defaults to `blur`. |
+| `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
+| `pageSize` | `integer` | **Yes** | 页条目数，默认为`20`，最大为`500` |
+| `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
+| `mcpName` | `string` | No | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
+| `search` | `string` | No | Search mode: `blur` or `accurate`. Defaults to `blur`. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                           | 参数类型                  | 描述                                                                                              |
+| Name                                           | Type                  | Description                                                                                              |
 |-----------------------------------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `totalCount`                                  | `integer` | 符合条件的服务的总数。                                                                                     |
 | `pageNumber`                                  | `integer` | 当前页码，起始为`1`。                                                                                    |
@@ -5780,20 +5780,20 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/cs/config/gray?namespaceId=
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP service version.       |
 | `release_date` | `string` | MCP service release time.  |
 | `is_latest`    | `boolean` | Whether this is the latest version of the MCP service. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5836,47 +5836,47 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&nam
 
 ### 4.2. 查询MCP服务的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定MCP服务的服务的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
-| `mcpId`       | `string` | 否     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
-| `mcpName`     | `string` | 否     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是返回最新版本                      |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
+| `mcpId`       | `string` | No     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
+| `mcpName`     | `string` | No     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
+| `version`     | `string` | No     | MCP服务的版本，未传入是返回最新版本                      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID。                                                                               |
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `namespaceId`        | `string` | MCP服务所属的命名空间ID。                                                                                 |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的描述。                                                                                       |
+| `description`        | `string` | MCP服务的Description。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |                                                                                          |
 | `versionDetail`      | `object`              | Queried version information of the MCP service.                                                        |
 | `localServerConfig`  | `map<string, object>` | Startup information for a local MCP service when the MCP service type is **stdio**.                    |
@@ -5889,20 +5889,20 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp/list?pageNo=1&pageSize=100&nam
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP service version.       |
 | `release_date` | `string` | MCP service release time.  |
 | `is_latest`    | `boolean` | Whether this is the latest version of the MCP service. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5942,48 +5942,48 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 ### 4.3. 更新MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                             |
+| Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
-| `namespaceId` | `string` | 否 | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **是** | MCP服务的描述详情 |
-| `toolSpecification` | `string` | 否 | MCP服务的工具描述详情 |
-| `endpointSpecification` | `string` | 否 | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
-| `overrideExisting` | `boolean` | 否 | MCP服务更新时是否覆盖原 endpointSpecification，仅在非`stdio`协议时生效 |
-| `latest` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
+| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
+| `overrideExisting` | `boolean` | No | MCP服务更新时是否覆盖原 endpointSpecification，仅在非`stdio`协议时生效 |
+| `latest` | `boolean` | No | - |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，必须传入，用于定位待更新的MCP服务。                                                            |
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的描述。                                                                                       |
+| `description`        | `string` | MCP服务的Description。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -5994,7 +5994,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -6002,7 +6002,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `array`                   | Tool list provided by the MCP Server. See the standard MCP protocol definition of MCP Tool. |
 | `toolsMeta`       | `map<string, object>`     | Extra metadata for tools provided by the MCP Server. This can extend information not defined in the standard MCP protocol. The key is the `name` of `McpTool`, and the value is the extended metadata. |
@@ -6010,15 +6010,15 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的名称                                     |
-| `description` | `string` | MCP 工具的描述                                     |
+| `name`        | `string` | MCP 工具的Name                                     |
+| `description` | `string` | MCP 工具的Description                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -6026,33 +6026,33 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=tes
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
+| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务更新结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
@@ -6060,7 +6060,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"d7a64724-a556-4fe4-82fa-e806d43e00dc","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6072,46 +6072,46 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 ### 4.4. 创建MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的MCP服务，可以是存量API转换的MCP服务，也可以是MCP市场中的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                             |
+| Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
-| `namespaceId` | `string` | 否 | MCP服务的命名空间ID，默认为`public` |
-| `serverSpecification` | `string` | **是** | MCP服务的描述详情 |
-| `toolSpecification` | `string` | 否 | MCP服务的工具描述详情 |
-| `endpointSpecification` | `string` | 否 | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
+| `namespaceId` | `string` | No | MCP服务的命名空间ID，默认为`public` |
+| `serverSpecification` | `string` | **Yes** | MCP服务的Description详情 |
+| `toolSpecification` | `string` | No | MCP服务的工具Description详情 |
+| `endpointSpecification` | `string` | No | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，无需传入，系统自动生成。                                                                   |
 | `name`               | `string` | MCP服务名。                                                                                         |
 | `protocol`           | `string` | MCP的协议，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。                                             |
 | `frontProtocol`      | `string` | MCP的前端暴露协议，一般是提供给协议转换器（如网关）使用，若无转换器，则与`protocol`相同，如`stdio`,`sse`,`streamable`,`http`,`dubbo`等。 |
-| `description`        | `string` | MCP服务的描述。                                                                                       |
+| `description`        | `string` | MCP服务的Description。                                                                                       |
 | `repository`         | `string` | MCP服务的存储仓库。                                                                                     |    |
 | `versionDetail`      | `object`              | MCP service version information.                                                                      |
 | `version`            | `string` | MCP服务的简易版本版本信息，主要用于兼容，若已设置`versionDetail`,则该字段无效。                                               |    |
@@ -6122,7 +6122,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -6130,7 +6130,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `array`                   | Tool list provided by the MCP Server. See the standard MCP protocol definition of MCP Tool. |
 | `toolsMeta`       | `map<string, object>`     | Extra metadata for tools provided by the MCP Server. This can extend information not defined in the standard MCP protocol. The key is the `name` of `McpTool`, and the value is the extended metadata. |
@@ -6138,15 +6138,15 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
-| `name`        | `string` | MCP 工具的名称                                     |
-| `description` | `string` | MCP 工具的描述                                     |
+| `name`        | `string` | MCP 工具的Name                                     |
+| `description` | `string` | MCP 工具的Description                                     |
 | `inputSchema` | `map<string, object>` | MCP tool input schema. See the standard MCP protocol; it mainly includes type, required flag, and description. |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -6154,33 +6154,33 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
-| `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
-| `scheme`            | `string` | 安全方案的子方案类型。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
+| `type`              | `string` | 安全方案的Type。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
+| `scheme`            | `string` | 安全方案的子方案Type。当 `type` 为 `http` 时使用。可能的值包括：`basic` 或 `bearer`。                       |
 | `in`                | `string` | 安全方案的位置。可能的值有：`query`、`header`。                                                   |
-| `name`              | `string` | 安全方案的名称。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥名称或 `localEnv` 的环境名称。 |
+| `name`              | `string` | 安全方案的Name。当 `type` 为 `apiKey` 或 `localEnv` 时使用。例如，`apiKey` 的密钥Name或 `localEnv` 的环境Name。 |
 | `defaultCredential` | `string` | 当配置参数中未输入身份时的默认凭证。可选。                                                             |
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
+| `type` | `string` | MCP endpoint的后端服务Type，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 新建MCP服务的id。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
@@ -6188,7 +6188,7 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6200,51 +6200,51 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/mcp' \
 
 ### 4.5. 删除MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.1`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
-| `mcpId`       | `string` | 否     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
-| `mcpName`     | `string` | 否     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是为最新版本                       |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
+| `mcpId`       | `string` | No     | MCP服务的ID，一般为UUID，与`mcpName`二选一输入，建议传入此值。 |
+| `mcpName`     | `string` | No     | MCP服务的名字模版，与`mcpId`二选一输入，建议传入`mcpId`。    |
+| `version`     | `string` | No     | MCP服务的版本，未传入是为最新版本                       |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6258,52 +6258,52 @@ curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/mcp?namespaceId=public&mcpName=
 
 ### 5.1. 查询指定AgentCard的版本列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定托管在Nacos上的AgentCard的版本列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a/version/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的Name                |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                   | 参数类型      | 描述              |
+| Name                   | Type      | Description              |
 |-----------------------|-----------|-----------------|
 | `data`[i].`version`   | `string` | AgentCard的版本号。  |
 | `data`[i].`createdAt` | `string` | 该版本的创建时间。       |
 | `data`[i].`updatedAt` | `string` | 该版本的最后更新时间。     |
 | `data`[i].`latest`    | `boolean` | 该版本是否标记为最新发布版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6320,41 +6320,41 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=publi
 
 ### 5.2. 查询AgentCard的列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的AgentCard的列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                              |
+| Name           | Type     | Required  | Description                                              |
 |---------------|----------|-------|-------------------------------------------------|
-| `pageNo` | `integer` | **是** | 当前页，默认为`1` |
-| `pageSize` | `integer` | **是** | 页条目数，默认为`100` |
-| `namespaceId` | `string` | 否 | AgentCard的命名空间ID，默认为`public` |
-| `agentName` | `string` | 否 | AgentCard的名称，为空是查询所有AgentCard |
-| `search` | `string` | 否 | blur or accurate |
+| `pageNo` | `integer` | **Yes** | 当前页，默认为`1` |
+| `pageSize` | `integer` | **Yes** | 页条目数，默认为`100` |
+| `namespaceId` | `string` | No | AgentCard的命名空间ID，默认为`public` |
+| `agentName` | `string` | No | AgentCard的Name，为空是查询所有AgentCard |
+| `search` | `string` | No | blur or accurate |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                     | 参数类型                       | 描述                                                                                                     |
+| Name                                     | Type                       | Description                                                                                                     |
 |-----------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------|
 | `totalCount`                            | `integer` | 符合条件的服务的总数。                                                                                            |
 | `pageNumber`                            | `integer` | 当前页码，起始为`1`。                                                                                           |
@@ -6373,21 +6373,21 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/version/list?namespaceId=publi
 
 其中`AgentVersionDetail`包含内容如下：
 
-| 参数名         | 参数类型      | 描述              |
+| Name         | Type      | Description              |
 |-------------|-----------|-----------------|
 | `version`   | `string` | AgentCard version. |
 | `createdAt` | `string` | Creation time of this version. |
 | `updatedAt` | `string` | Last update time of this version. |
 | `latest`    | `boolean` | Whether this version is marked as the latest published version. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6441,44 +6441,44 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 
 ### 5.3. 查询AgentCard的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定AgentCard的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`读`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型     | 是否必填  | 描述                                                                                 |
+| Name                | Type     | Required  | Description                                                                                 |
 |--------------------|----------|-------|------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                        |
-| `agentName`        | `string` | **是** | AgentCard的名称                                                                       |
-| `version`          | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情                                                          |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                        |
+| `agentName`        | `string` | **Yes** | AgentCard的Name                                                                       |
+| `version`          | `string` | No     | AgentCard的版本号，为空时返回最新版本详情                                                          |
+| `registrationType` | `string` | No     | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                 | 参数类型                              | 描述                                                                                                       |
+| Name                                 | Type                              | Description                                                                                                       |
 |-------------------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `protocolVersion`                   | `string` | AgentCard的A2A协议版本。                                                                                       |
-| `name`                              | `string` | AgentCard的名称。                                                                                            |
-| `description`                       | `string` | AgentCard的描述。                                                                                            |
+| `name`                              | `string` | AgentCard的Name。                                                                                            |
+| `description`                       | `string` | AgentCard的Description。                                                                                            |
 | `version`                           | `string` | AgentCard的版本号。                                                                                           |
 | `iconUrl`                           | `string` | AgentCard的iconURL。                                                                                       |
 | `capabilities`                      | `object`                         | AgentCard capabilities, matching [A2A standard capabilities](https://a2a-protocol.org/latest/specification/#552-agentcapabilities-object). |
@@ -6493,17 +6493,17 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&nam
 | `defaultInputModes`                 | `array`                          | All default input modes of the AgentCard. |
 | `defaultOutputModes`                | `array`                          | All default output modes of the AgentCard. |
 | `supportsAuthenticatedExtendedCard` | `string` | AgentCard是否支持认证的扩展卡。                                                                                     |
-| `registrationType`                  | `string` | AgentCard的默认注册类型，可选`URL`和`SERVICE`。                                                                      |
+| `registrationType`                  | `string` | AgentCard的默认注册Type，可选`URL`和`SERVICE`。                                                                      |
 | `latestVersion`                     | `string` | AgentCard当前版本时否为最新版本。                                                                                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0&registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6575,46 +6575,46 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 
 ### 5.4. 更新AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId` | `string` | 否 | AgentCard所属的命名空间，默认`public` |
-| `agentCard` | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否 | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
-| `setAsLatest` | `boolean` | 否 | 是否设置此版本为最新发布版本，默认为false |
+| `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
+| `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `setAsLatest` | `boolean` | No | 是否设置此版本为最新发布版本，默认为false |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述               |
+| Name    | Type     | Description               |
 |--------|----------|------------------|
 | `data` | `string` | AgentCard服务更新结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
@@ -6623,7 +6623,7 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'registrationType=SERVICE' \
 -d 'setAsLatest=true'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6635,45 +6635,45 @@ curl -X PUT '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 
 ### 5.5. 创建AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId` | `string` | 否 | AgentCard所属的命名空间，默认`public` |
-| `agentCard` | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否 | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认值为`URL` |
+| `namespaceId` | `string` | No | AgentCard所属的命名空间，默认`public` |
+| `agentCard` | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No | AgentCard的默认注册Type，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, Default为`URL` |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard发布结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
@@ -6681,7 +6681,7 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 -d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '\''1600 Amphitheatre Parkway, Mountain View, CA'\'' to '\''San Francisco International Airport'\'' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \ 
 -d 'registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6693,50 +6693,50 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 
 ### 5.6. 删除AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需对应命名空间的`写`权限
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
-| `version`     | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情   |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的Name                |
+| `version`     | `string` | No     | AgentCard的版本号，为空时返回最新版本详情   |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6750,53 +6750,53 @@ curl -X DELETE '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentNam
 
 ### 6.1. Publish Prompt
 
-#### 接口描述
+#### Description
 
 This API publishes a new Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. Defaults to `public`. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version. |
-| `template` | `string` | 否 | Template content. |
-| `commitMsg` | `string` | 否 | Commit message. |
-| `description` | `string` | 否 | Description. |
-| `bizTags` | `string` | 否 | Business tags. |
-| `variables` | `string` | 否 | Prompt template variable definitions as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. Defaults to `public`. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version. |
+| `template` | `string` | No | Template content. |
+| `commitMsg` | `string` | No | Commit message. |
+| `description` | `string` | No | Description. |
+| `bizTags` | `string` | No | Business tags. |
+| `variables` | `string` | No | Prompt template variable definitions as a JSON string. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt' \
   -d 'namespaceId=public' -d 'promptKey=my-prompt' -d 'version=1.0.0' -d 'template=hello'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6808,46 +6808,46 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt' \
 
 ### 6.2. Delete Prompt
 
-#### 接口描述
+#### Description
 
 This API deletes the specified Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6859,49 +6859,49 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt?namespaceId=publi
 
 ### 6.3. Get Prompt Detail
 
-#### 接口描述
+#### Description
 
 This API queries Prompt details by version or label.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version. |
-| `label` | `string` | 否 | Label. |
-| `md5` | `string` | 否 | Content MD5. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version. |
+| `label` | `string` | No | Label. |
+| `md5` | `string` | No | Content MD5. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` contains fields such as `promptKey`, `version`, `template`, `commitMsg`, and `md5`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` contains fields such as `promptKey`, `version`, `template`, `commitMsg`, and `md5`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/detail?namespaceId=public&promptKey=my-prompt&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6917,49 +6917,49 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/detail?namespaceId=p
 
 ### 6.4. Bind Label
 
-#### 接口描述
+#### Description
 
 This API binds a label to the specified Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/label`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `label` | `string` | **是** | Label name. |
-| `version` | `string` | **是** | Version. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `label` | `string` | **Yes** | Label name. |
+| `version` | `string` | **Yes** | Version. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label' \
   -d 'namespaceId=public' -d 'promptKey=my-prompt' -d 'label=stable' -d 'version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6971,47 +6971,47 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label' \
 
 ### 6.5. Unbind Label
 
-#### 接口描述
+#### Description
 
 This API unbinds a label from a Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/label`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `label` | `string` | **是** | Label name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `label` | `string` | **Yes** | Label name. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label?namespaceId=public&promptKey=my-prompt&label=stable'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7023,50 +7023,50 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/label?namespaceId
 
 ### 6.6. List Prompts
 
-#### 接口描述
+#### Description
 
 This API queries Prompts by page.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Number of records per page. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | 否 | Prompt key filter. |
-| `search` | `string` | 否 | Search mode: `blur` or `accurate`. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Number of records per page. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | No | Prompt key filter. |
+| `search` | `string` | No | Search mode: `blur` or `accurate`. |
+| `bizTags` | `string` | No | Business tags. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` is a paginated object that contains fields such as `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` is a paginated object that contains fields such as `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/list?pageNo=1&pageSize=10&namespaceId=public&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7088,46 +7088,46 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/list?pageNo=1&pageSi
 
 ### 6.7. Get Prompt Metadata
 
-#### 接口描述
+#### Description
 
 This API queries metadata of the specified Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/metadata`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` contains fields such as `promptKey`, `description`, `bizTags`, `latestVersion`, `versions`, and `labels`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` contains fields such as `promptKey`, `description`, `bizTags`, `latestVersion`, `versions`, and `labels`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7143,49 +7143,49 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata?namespaceId
 
 ### 6.8. Update Prompt Metadata
 
-#### 接口描述
+#### Description
 
 This API updates Prompt metadata, such as description and business tags.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/metadata`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `description` | `string` | 否 | Description. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `description` | `string` | No | Description. |
+| `bizTags` | `string` | No | Business tags. |
 
-#### 返回数据
+#### Response Data
 
-On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, the API returns the common response body with `data` set to `true`; on failure, it returns the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata' \
   -d 'namespaceId=public' -d 'promptKey=my-prompt' -d 'description=desc'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7197,48 +7197,48 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/metadata' \
 
 ### 6.9. List Prompt Versions
 
-#### 接口描述
+#### Description
 
 This API queries versions of the specified Prompt by page.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/versions`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Number of records per page. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Number of records per page. |
 
-#### 返回数据
+#### Response Data
 
-The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` is a paginated object that contains `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`; each item contains fields such as `version`, `commitMsg`, and `gmtModified`.
+The response body follows the [Nacos OpenAPI common response format](../user/overview/api-overview.md#32-http-api-response-format). `data` is a paginated object that contains `totalCount`, `pageNumber`, `pagesAvailable`, and `pageItems`; each item contains fields such as `version`, `commitMsg`, and `gmtModified`.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/versions?namespaceId=public&promptKey=my-prompt&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7260,506 +7260,506 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/prompt/versions?namespaceId
 
 ### 6.10. Update Prompt Business Tags
 
-#### 接口描述
+#### Description
 
 This API updates Prompt business tags.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `bizTags` | `string` | No | Business tags. |
 
 ### 6.11. Update Prompt Description
 
-#### 接口描述
+#### Description
 
 This API updates the Prompt description.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/description`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `description` | `string` | **是** | Description. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `description` | `string` | **Yes** | Description. |
 
 ### 6.12. Create Prompt Draft
 
-#### 接口描述
+#### Description
 
 This API creates a Prompt draft version, or recreates a draft from an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `basedOnVersion` | `string` | 否 | Version to base the draft on. |
-| `targetVersion` | `string` | 否 | Target version. |
-| `template` | `string` | 否 | Template content. |
-| `variables` | `string` | 否 | Prompt template variable definitions as a JSON string. |
-| `commitMsg` | `string` | 否 | Commit message. |
-| `description` | `string` | 否 | Description. |
-| `bizTags` | `string` | 否 | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `basedOnVersion` | `string` | No | Version to base the draft on. |
+| `targetVersion` | `string` | No | Target version. |
+| `template` | `string` | No | Template content. |
+| `variables` | `string` | No | Prompt template variable definitions as a JSON string. |
+| `commitMsg` | `string` | No | Commit message. |
+| `description` | `string` | No | Description. |
+| `bizTags` | `string` | No | Business tags. |
 
 ### 6.13. Update Prompt Draft
 
-#### 接口描述
+#### Description
 
 This API updates the current Prompt draft content.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `template` | `string` | **是** | Template content. |
-| `variables` | `string` | 否 | Prompt template variable definitions as a JSON string. |
-| `commitMsg` | `string` | 否 | Commit message. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `template` | `string` | **Yes** | Template content. |
+| `variables` | `string` | No | Prompt template variable definitions as a JSON string. |
+| `commitMsg` | `string` | No | Commit message. |
 
 ### 6.14. Delete Prompt Draft
 
-#### 接口描述
+#### Description
 
 This API deletes the current Prompt draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
 ### 6.15. Force Publish Prompt Version
 
-#### 接口描述
+#### Description
 
 This API force-publishes a Prompt version while bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 6.16. Get Prompt Governance Details
 
-#### 接口描述
+#### Description
 
 This API retrieves Prompt metadata, version governance information, and version summaries.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/governance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
 
 ### 6.17. Update Prompt Labels
 
-#### 接口描述
+#### Description
 
 This API updates the runtime routing labels of a Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `labels` | `string` | **是** | Label JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `labels` | `string` | **Yes** | Label JSON string. |
 
 ### 6.18. Offline Prompt Version
 
-#### 接口描述
+#### Description
 
 This API takes a specified Prompt version offline.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 6.19. Online Prompt Version
 
-#### 接口描述
+#### Description
 
 This API brings a specified Prompt version online.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 6.20. Publish Prompt Version
 
-#### 接口描述
+#### Description
 
 This API publishes an approved Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 6.21. Redraft Prompt Version
 
-#### 接口描述
+#### Description
 
 This API converts a reviewed Prompt version back to a draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 6.22. Submit Prompt Version for Review
 
-#### 接口描述
+#### Description
 
 This API submits a Prompt version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version number. |
 
 ### 6.23. Get Prompt Version Details
 
-#### 接口描述
+#### Description
 
 This API retrieves details of a specified Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version number. |
 
 ### 6.24. Download Prompt Version
 
-#### 接口描述
+#### Description
 
 This API downloads a specified Prompt version as a Markdown file.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/prompt/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `promptKey` | `string` | **是** | Prompt key. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `promptKey` | `string` | **Yes** | Prompt key. |
+| `version` | `string` | No | Version number. |
 
 ## 7. AI Skills Management
 
 ### 7.1. Get Skill Details
 
-#### 接口描述
+#### Description
 
 This API obtains the details of a specified skill by namespace and skill name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
 
-#### 返回数据
+#### Response Data
 
-The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` contains fields such as name, description, instruction, resource, version, inputModes, and outputModes.
+The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format). `data` contains fields such as name, description, instruction, resource, version, inputModes, and outputModes.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=public&skillName=my-skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7777,50 +7777,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=public&s
 
 ### 7.2. Create Skill Draft Version
 
-#### 接口描述
+#### Description
 
 This API creates a draft version of a skill based on an existing version or a new SkillCard.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | 否 | Skill name. |
-| `basedOnVersion` | `string` | 否 | Create the draft based on this version. |
-| `targetVersion` | `string` | 否 | Target version. |
-| `skillCard` | `string` | 否 | Skill card JSON; required if basedOnVersion is not set |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | No | Skill name. |
+| `basedOnVersion` | `string` | No | Create the draft based on this version. |
+| `targetVersion` | `string` | No | Target version. |
+| `skillCard` | `string` | No | Skill card JSON; required if basedOnVersion is not set |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as a string indicating the draft creation result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as a string indicating the draft creation result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
   -d 'namespaceId=public' -d 'skillName=my-skill' -d 'basedOnVersion=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7832,48 +7832,48 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
 
 ### 7.3. Update Skill Draft Content
 
-#### 接口描述
+#### Description
 
 This API updates the SkillCard content of the current skill draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillCard` | `string` | **是** | Skill card JSON string containing complete Skill information |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillCard` | `string` | **Yes** | Skill card JSON string containing complete Skill information |
+| `skillName` | `string` | **Yes** | Skill name. |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as a string indicating the draft update result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as a string indicating the draft update result. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
   -d 'namespaceId=public' -d 'skillName=my-skill' -d 'skillCard={}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7885,46 +7885,46 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/draft' \
 
 ### 7.4. Delete Skill
 
-#### 接口描述
+#### Description
 
 This API deletes a skill from Nacos by namespace and skill name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as a string indicating the operation result, such as "ok". On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as a string indicating the operation result, such as "ok". On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=public&skillName=my-skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7936,50 +7936,50 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills?namespaceId=publi
 
 ### 7.5. List Skills
 
-#### 接口描述
+#### Description
 
 This API filters and paginates the skill list by query conditions.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Page size. |
-| `filterableForm` | `string` | **是** | Filter condition form. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | 否 | Skill name filter. |
-| `search` | `string` | 否 | Search mode: accurate or blur |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Page size. |
+| `filterableForm` | `string` | **Yes** | Filter condition form. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | No | Skill name filter. |
+| `search` | `string` | No | Search mode: accurate or blur |
 
-#### 返回数据
+#### Response Data
 
-The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式). `data` is a pagination structure containing totalCount, pageNumber, pagesAvailable, and pageItems. Each item includes fields such as name, description, and updateTime.
+The response follows the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format). `data` is a pagination structure containing totalCount, pageNumber, pagesAvailable, and pageItems. Each item includes fields such as name, description, and updateTime.
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8002,52 +8002,52 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/list?pageNo=1&pageSi
 
 ### 7.6. Upload Skill from ZIP File
 
-#### 接口描述
+#### Description
 
 This API uploads a ZIP package in multipart/form-data format and registers the skill. The file must be a valid skill package.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-请求体类型：`multipart/form-data`，参数放在请求体中。
+请求体Type：`multipart/form-data`，参数放在请求体中。
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID. Defaults to `public`. |
-| `overwrite` | `boolean` | 否 | Whether to overwrite an existing skill with the same name. |
-| `targetVersion` | `string` | 否 | Target version after upload. |
-| `commitMsg` | `string` | 否 | Commit message. |
-| `file` | `file` | 否 | ZIP file containing skill package. |
+| `namespaceId` | `string` | No | Namespace ID. Defaults to `public`. |
+| `overwrite` | `boolean` | No | Whether to overwrite an existing skill with the same name. |
+| `targetVersion` | `string` | No | Target version after upload. |
+| `commitMsg` | `string` | No | Commit message. |
+| `file` | `file` | No | ZIP file containing skill package. |
 
-#### 返回数据
+#### Response Data
 
-On success, returns the unified response body with `data` as the uploaded skill name. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-统一返回体格式).
+On success, returns the unified response body with `data` as the uploaded skill name. On failure, returns the [Nacos open API unified response format](../user/overview/api-overview.md#32-http-api-response-format).
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload' \
   -F "file=@skill.zip" -F "namespaceId=public" -F "overwrite=false" -F "targetVersion=1.0.0" -F "commitMsg=initial"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8059,100 +8059,100 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload' \
 
 ### 7.7. Delete Skill Draft Version
 
-#### 接口描述
+#### Description
 
 This API deletes the current draft version of a specified skill.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
 
 ### 7.8. Update Skill Business Tags
 
-#### 接口描述
+#### Description
 
 This API updates the business tag list of a skill without changing the version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `bizTags` | `string` | **是** | Business tags. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `bizTags` | `string` | **Yes** | Business tags. |
 
 ### 7.9. Update Skill Version Labels
 
-#### 接口描述
+#### Description
 
 This API updates the version routing labels of a skill, such as latest.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `labels` | `string` | **是** | Label JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `labels` | `string` | **Yes** | Label JSON string. |
 
 ### 7.10. Skill Version Online, Offline, and Publish Operations
 
-#### 接口描述
+#### Description
 
 The following APIs are used to control the skill version publishing workflow.
 
-#### 请求参数
+#### Request Parameters
 
 | Method | Request URL | Key parameters |
 |--------|----------|----------|
@@ -8164,93 +8164,93 @@ The following APIs are used to control the skill version publishing workflow.
 
 ### 7.11. Get Skill Version Details
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | No | Version number. |
 
 ### 7.12. Download Skill Version ZIP Package
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | No | Version number. |
 
 ### 7.13. Offline Skill
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire skill, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `scope` | `string` | 否 | Use 'skill' for skill-level offline; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `scope` | `string` | No | Use 'skill' for skill-level offline; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/offline' -d "namespaceId=namespaceId&skillName=skillName&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8262,50 +8262,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/offline' -d "namesp
 
 
 ### 7.14. Online Skill
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire skill, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `scope` | `string` | 否 | Use 'skill' for skill-level online; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `scope` | `string` | No | Use 'skill' for skill-level online; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/online' -d "namespaceId=namespaceId&skillName=skillName&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8316,50 +8316,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/online' -d "namespa
 ```
 
 ### 7.15. Publish Skill Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved skill version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | **是** | Version identifier. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | **Yes** | Version identifier. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/publish' -d "namespaceId=namespaceId&skillName=skillName&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8370,49 +8370,49 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/publish' -d "namesp
 ```
 
 ### 7.16. Update Skill Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of a skill to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/scope' -d "namespaceId=namespaceId&skillName=skillName&scope=scope"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8423,49 +8423,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/scope' -d "namespace
 ```
 
 ### 7.17. Submit Skill Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting a skill draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/submit' -d "namespaceId=namespaceId&skillName=skillName&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8477,100 +8477,100 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/submit' -d "namespa
 
 ### 7.18. Force Publish Skill Version
 
-#### 接口描述
+#### Description
 
 This API force-publishes a Skill version while bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 7.19. Redraft Skill Version
 
-#### 接口描述
+#### Description
 
 This API converts a reviewed Skill version back to a draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `skillName` | `string` | **是** | Skill name. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace. |
+| `skillName` | `string` | **Yes** | Skill name. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 7.20. Batch Upload Skills
 
-#### 接口描述
+#### Description
 
 This API batch uploads Skills from a ZIP file that contains multiple Skill subdirectories.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 Request body type: `multipart/form-data`. Parameters are sent in the request body.
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/skills/upload/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `overwrite` | `boolean` | 否 | Whether to overwrite existing skills with the same names. |
-| `file` | `file` | 否 | ZIP package containing multiple Skill subdirectories. |
+| `namespaceId` | `string` | No | Namespace. |
+| `overwrite` | `boolean` | No | Whether to overwrite existing skills with the same names. |
+| `file` | `file` | No | ZIP package containing multiple Skill subdirectories. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload/batch' \
@@ -8580,34 +8580,34 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/skills/upload/batch' \
 ## 8. AgentSpec Management
 
 ### 8.1. Get AgentSpec
-#### 接口描述
+#### Description
 This interface allows getting the latest published version of an AgentSpec by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -8626,15 +8626,15 @@ This interface allows getting the latest published version of an AgentSpec by na
 | data.data.downloadCount | `integer` | - |
 | data.data.versions | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=public&agentSpecName=my-agentspec'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8645,48 +8645,48 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=publ
 ```
 
 ### 8.2. Delete AgentSpec
-#### 接口描述
+#### Description
 This interface allows deleting an AgentSpec and all its versions by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=public&agentSpecName=my-agentspec'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8697,49 +8697,49 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs?namespaceId=p
 ```
 
 ### 8.3. Update AgentSpec Business Tags
-#### 接口描述
+#### Description
 This interface allows updating the business tag list of an AgentSpec without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `bizTags` | `string` | **是** | Business tags; pass multiple tags using the agreed format. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `bizTags` | `string` | **Yes** | Business tags; pass multiple tags using the agreed format. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/biz-tags' -d "namespaceId=public&agentSpecName=my-agentspec&bizTags=demo"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8750,49 +8750,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/biz-tags' -d "na
 ```
 
 ### 8.4. Create AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows creating an AgentSpec draft version based on an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `basedOnVersion` | `string` | 否 | Base version used to create the draft. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `basedOnVersion` | `string` | No | Base version used to create the draft. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agentspec&basedOnVersion=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8803,49 +8803,49 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "name
 ```
 
 ### 8.5. Update AgentSpec Draft Content
-#### 接口描述
+#### Description
 This interface allows updating the card content of the current AgentSpec draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | 否 | AgentSpec name. |
-| `agentSpecCard` | `string` | **是** | AgentSpec card JSON string containing complete AgentSpec information |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | No | AgentSpec name. |
+| `agentSpecCard` | `string` | **Yes** | AgentSpec card JSON string containing complete AgentSpec information |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agentspec&agentSpecCard={}"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8856,48 +8856,48 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft' -d "names
 ```
 
 ### 8.6. Delete AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows deleting the current draft version of a specified AgentSpec.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft?namespaceId=public&agentSpecName=my-agentspec'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8908,49 +8908,49 @@ curl -X DELETE 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/draft?namespa
 ```
 
 ### 8.7. Update AgentSpec Version Labels
-#### 接口描述
+#### Description
 This interface allows updating AgentSpec version routing labels (e.g. latest label) without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `labels` | `string` | **是** | Version labels, usually as a JSON string. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `labels` | `string` | **Yes** | Version labels, usually as a JSON string. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/labels' -d "namespaceId=public&agentSpecName=my-agentspec&labels={\"latest\":\"1.0.0\"}"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8961,52 +8961,52 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/labels' -d "name
 ```
 
 ### 8.8. List AgentSpecs
-#### 接口描述
+#### Description
 This interface allows paginated listing of AgentSpecs by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | Page number, starting from 1. |
-| `pageSize` | `integer` | **是** | Number of items per page. |
-| `filterableForm` | `string` | **是** | Filter condition form. |
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | 否 | AgentSpec name. |
-| `search` | `string` | 否 | Search mode: `accurate` or `blur`. |
-#### 返回数据
+| `pageNo` | `integer` | **Yes** | Page number, starting from 1. |
+| `pageSize` | `integer` | **Yes** | Number of items per page. |
+| `filterableForm` | `string` | **Yes** | Filter condition form. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | No | AgentSpec name. |
+| `search` | `string` | No | Search mode: `accurate` or `blur`. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/list?pageNo=1&pageSize=20&namespaceId=public&agentSpecName=my-agentspec&search=accurate'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9017,50 +9017,50 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/list?pageNo=1&pa
 ```
 
 ### 8.9. Offline AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire AgentSpec, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level offline; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level offline; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/offline' -d "namespaceId=public&agentSpecName=my-agentspec&scope=agentspec&version=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9071,50 +9071,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/offline' -d "na
 ```
 
 ### 8.10. Online AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire AgentSpec, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level online; otherwise version-level |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level online; otherwise version-level |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/online' -d "namespaceId=public&agentSpecName=my-agentspec&scope=agentspec&version=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9125,50 +9125,50 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/online' -d "nam
 ```
 
 ### 8.11. Publish AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved AgentSpec version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | **是** | Version identifier. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | **Yes** | Version identifier. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/publish' -d "namespaceId=public&agentSpecName=my-agentspec&version=1.0.0&updateLatestLabel=true"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9179,49 +9179,49 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/publish' -d "na
 ```
 
 ### 8.12. Update AgentSpec Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of an AgentSpec to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/scope' -d "namespaceId=public&agentSpecName=my-agentspec&scope=PUBLIC"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9232,49 +9232,49 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/scope' -d "names
 ```
 
 ### 8.13. Submit AgentSpec Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting an AgentSpec draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/submit' -d "namespaceId=public&agentSpecName=my-agentspec&version=1.0.0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9285,52 +9285,52 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/submit' -d "nam
 ```
 
 ### 8.14. Upload AgentSpec
-#### 接口描述
+#### Description
 This interface allows uploading a ZIP-packaged AgentSpec; the package is parsed and the AgentSpec is created or updated.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 Request body type: `multipart/form-data`. Parameters are sent in the request body.
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `overwrite` | `boolean` | 否 | Whether to overwrite an existing resource with the same name. |
-| `file` | `file` | 否 | ZIP file containing AgentSpec package. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `overwrite` | `boolean` | No | Whether to overwrite an existing resource with the same name. |
+| `file` | `file` | No | ZIP file containing AgentSpec package. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/upload' -F "file=@agentspec.zip" -F "namespaceId=public" -F "overwrite=false"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9341,35 +9341,35 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/upload' -F "fil
 ```
 
 ### 8.15. Get AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows getting a specific version of an AgentSpec by namespace, name, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | 否 | Version identifier. |
-#### 返回数据
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | No | Version identifier. |
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -9380,15 +9380,15 @@ This interface allows getting a specific version of an AgentSpec by namespace, n
 | data.data.content | `string` | - |
 | data.data.resource | `object` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/version?namespaceId=public&agentSpecName=my-agentspec&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9400,147 +9400,147 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/agentspecs/version?namespac
 
 ### 8.16. Force Publish AgentSpec Version
 
-#### 接口描述
+#### Description
 
 This API force-publishes an AgentSpec version while bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | **是** | Version number. |
-| `updateLatestLabel` | `boolean` | 否 | Whether to update the `latest` label after publishing. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | **Yes** | Version number. |
+| `updateLatestLabel` | `boolean` | No | Whether to update the `latest` label after publishing. |
 
 ### 8.17. Redraft AgentSpec Version
 
-#### 接口描述
+#### Description
 
 This API converts a reviewed AgentSpec version back to a draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | **是** | Version number. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | **Yes** | Version number. |
 
 ### 8.18. Get AgentSpec Version Metadata
 
-#### 接口描述
+#### Description
 
 This API retrieves metadata for a specified AgentSpec version without reading resource file content.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/agentspecs/version/meta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace ID, default is `public`. |
-| `agentSpecName` | `string` | **是** | AgentSpec name. |
-| `version` | `string` | 否 | Version number. |
+| `namespaceId` | `string` | No | Namespace ID, default is `public`. |
+| `agentSpecName` | `string` | **Yes** | AgentSpec name. |
+| `version` | `string` | No | Version number. |
 
 ## 9. Pipeline Execution Records
 
 ### 9.1. List Pipeline Execution Records
 
-#### 接口描述
+#### Description
 
 This API lists Pipeline execution records by resource type, resource name, namespace, and version with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | Resource type. |
-| `resourceName` | `string` | 否 | Resource name. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `version` | `string` | 否 | Resource version. |
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Page size. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `resourceName` | `string` | No | Resource name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `version` | `string` | No | Resource version. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Page size. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
 | data.data | `string` | Paginated Pipeline execution records. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines?resourceType=agentspec&resourceName=my-agentspec&namespaceId=public&version=1.0.0&pageNo=1&pageSize=20'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9552,35 +9552,35 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines?resourceType=agen
 
 ### 9.2. Get Pipeline Execution Record Details
 
-#### 接口描述
+#### Description
 
 This API retrieves Pipeline execution record details by Pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines/{pipelineId}`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | Pipeline ID. |
+| `pipelineId` | `string` | **Yes** | Pipeline ID. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
@@ -9594,15 +9594,15 @@ This API retrieves Pipeline execution record details by Pipeline ID.
 | data.data.createTime | `integer` | Creation time. |
 | data.data.updateTime | `integer` | Update time. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/pipeline-001'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9614,54 +9614,54 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/pipeline-001'
 
 ### 9.3. List Pipeline Execution Records
 
-#### 接口描述
+#### Description
 
 This API lists Pipeline execution records by resource type, resource name, namespace, and version with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | Resource type. |
-| `resourceName` | `string` | 否 | Resource name. |
-| `namespaceId` | `string` | 否 | Namespace. |
-| `version` | `string` | 否 | Resource version. |
-| `pageNo` | `integer` | **是** | Page number. |
-| `pageSize` | `integer` | **是** | Page size. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `resourceName` | `string` | No | Resource name. |
+| `namespaceId` | `string` | No | Namespace. |
+| `version` | `string` | No | Resource version. |
+| `pageNo` | `integer` | **Yes** | Page number. |
+| `pageSize` | `integer` | **Yes** | Page size. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
 | data.data | `string` | Paginated Pipeline execution records. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/list?resourceType=agentspec&resourceName=my-agentspec&namespaceId=public&version=1.0.0&pageNo=1&pageSize=20'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9673,35 +9673,35 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/list?resourceType
 
 ### 9.4. Get Pipeline Execution Record Details
 
-#### 接口描述
+#### Description
 
 This API retrieves Pipeline execution record details by Pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/pipelines/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | Pipeline ID. |
+| `pipelineId` | `string` | **Yes** | Pipeline ID. |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | Response code. |
 | data.message | `string` | Response message. |
@@ -9715,15 +9715,15 @@ This API retrieves Pipeline execution record details by Pipeline ID.
 | data.data.createTime | `integer` | Creation time. |
 | data.data.updateTime | `integer` | Update time. |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/detail?pipelineId=pipeline-001'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -9737,130 +9737,130 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/detail?pipelineId
 
 ### 10.1. List AI Resource Import Sources
 
-#### 接口描述
+#### Description
 
 This API lists the currently configured AI resource import sources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/sources`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | 否 | Resource type. |
+| `resourceType` | `string` | No | Resource type. |
 
 ### 10.2. Search External AI Resources
 
-#### 接口描述
+#### Description
 
 This API searches importable external AI resources from a specified import source.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/search`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `resourceType` | `string` | **是** | Resource type. |
-| `sourceId` | `string` | **是** | Import source ID. |
-| `query` | `string` | 否 | Search keyword. |
-| `cursor` | `string` | 否 | Pagination cursor. |
-| `limit` | `integer` | 否 | Result limit. |
-| `options` | `string` | 否 | Extension options as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `sourceId` | `string` | **Yes** | Import source ID. |
+| `query` | `string` | No | Search keyword. |
+| `cursor` | `string` | No | Pagination cursor. |
+| `limit` | `integer` | No | Result limit. |
+| `options` | `string` | No | Extension options as a JSON string. |
 
 ### 10.3. Validate AI Resource Import Items
 
-#### 接口描述
+#### Description
 
 This API validates whether selected external AI resources can be imported.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/validate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `resourceType` | `string` | **是** | Resource type. |
-| `sourceId` | `string` | **是** | Import source ID. |
-| `selectedItems` | `string` | **是** | Resource items to validate as a JSON string. |
-| `overwriteExisting` | `boolean` | 否 | Whether to overwrite existing resources. |
-| `options` | `string` | 否 | Extension options as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `sourceId` | `string` | **Yes** | Import source ID. |
+| `selectedItems` | `string` | **Yes** | Resource items to validate as a JSON string. |
+| `overwriteExisting` | `boolean` | No | Whether to overwrite existing resources. |
+| `options` | `string` | No | Extension options as a JSON string. |
 
 ### 10.4. Execute AI Resource Import
 
-#### 接口描述
+#### Description
 
 This API imports the selected external AI resources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
-需管理员权限
+Administrator permissions required.
 
-#### 请求URL
+#### Request URL
 
 `/nacos/v3/admin/ai/import/execute`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | Namespace. |
-| `resourceType` | `string` | **是** | Resource type. |
-| `sourceId` | `string` | **是** | Import source ID. |
-| `selectedItems` | `string` | **是** | Resource items to import as a JSON string. |
-| `overwriteExisting` | `boolean` | 否 | Whether to overwrite existing resources. |
-| `skipInvalid` | `boolean` | 否 | Whether to skip invalid resource items. |
-| `validationToken` | `string` | 否 | Validation token. |
-| `options` | `string` | 否 | Extension options as a JSON string. |
+| `namespaceId` | `string` | No | Namespace. |
+| `resourceType` | `string` | **Yes** | Resource type. |
+| `sourceId` | `string` | **Yes** | Import source ID. |
+| `selectedItems` | `string` | **Yes** | Resource items to import as a JSON string. |
+| `overwriteExisting` | `boolean` | No | Whether to overwrite existing resources. |
+| `skipInvalid` | `boolean` | No | Whether to skip invalid resource items. |
+| `validationToken` | `string` | No | Validation token. |
+| `options` | `string` | No | Extension options as a JSON string. |

--- a/src/content/docs/next/en/manual/admin/console-api.md
+++ b/src/content/docs/next/en/manual/admin/console-api.md
@@ -54,33 +54,33 @@ Nacos 3.X Console APIs also provide Swagger-style documentation. You can view it
 
 ### 1.1. 获取集群状态信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取到Nacos 集群的基础状态和开关信息，例如：版本号，运行模式，鉴权是否开启等；该接口不会返回Nacos 集群的节点信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/server/state`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名                           | 参数类型      | 描述                                                                        |
+| Name                           | Type      | Description                                                                        |
 |-------------------------------|-----------|---------------------------------------------------------------------------|
 | version                       | `string` | Nacos集群的版本号，例如`3.0.0`                                                     |
 | startup_mode                  | `string` | Nacos集群的模式，例如`standalone`、`cluster`                                       |
@@ -93,7 +93,7 @@ Nacos 3.X Console APIs also provide Swagger-style documentation. You can view it
 | auth_system_type              | `string` | Nacos鉴权的插件类型，例如`nacos`等，若为``时，说明使用默认鉴权系统类型                                |
 | login_page_enabled            | `boolean` | Nacos控制台是否启用登录页                                                           |
 | plugin_datasource_log_enabled | `boolean` | Nacos是否启用打印数据源访问Debug日志                                                   |
-| config_retention_days         | `integer` | Nacos集群的配置历史数据保留天数，单位为天                                                   | 
+| config_retention_days         | `integer` | Nacos集群的配置历史数据保留天数，单位为天                                                   |
 | isManageCapacity              | `boolean` | Nacos是否启用配置容量限制检查，默认为`true`，开启时仅会统计当前配置的使用量，在超过限额时不会拒绝请求。                 |
 | isCapacityLimitCheck          | `boolean` | Nacos是否启用配置容量限制检查，默认为`false`，开启后当配置容量超出限额时，会拒绝配置的变更请求。                    |
 | defaultMaxSize                | `integer` | Nacos集群的配置文件大小限制，单位为Byte，默认为`102400`，即100KB。                              |
@@ -104,15 +104,15 @@ Nacos 3.X Console APIs also provide Swagger-style documentation. You can view it
 | ~~defaultMaxAggrSize~~        | `integer` | 未实际使用，已废弃                                                                 |
 | ~~defaultMaxAggrCount~~       | `integer` | 未实际使用，已废弃                                                                 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/server/state'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -145,49 +145,49 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/server/state'
 
 ### 1.2. 获取控制台公告信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取到Nacos 控制台希望在浏览器中显示的公告信息。Nacos默认控制台UI会在未开启鉴权时调用此接口，返回集群未开启鉴权的提示。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/server/announcement`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 类型       | 必填 | 参数描述                                        |
+| Name        | Type       | Required | Description                                        |
 |------------|----------|----|---------------------------------------------|
-| `language` | `string` | 否  | 访问的语言i18n值，默认为`zh-CN`，目前仅支持`zh-CN`和`en-US`。 |
+| `language` | `string` | No  | 访问的语言i18n值，默认为`zh-CN`，目前仅支持`zh-CN`和`en-US`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 控制台公告内容 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/server/announcement?language=zh-CN'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -199,47 +199,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/server/announcement?language=zh-CN
 
 ### 1.3. 获取控制台引导内容
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos控制台的引导信息。Nacos默认控制台UI会在关闭Nacos控制台UI时调用，以获取引导信息，相关详情请参考[控制台手册-关闭默认控制台](./console/#33-关闭默认控制台)。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/server/guide`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
-| `data` | `string` | 控制台引导内容 | 
+| `data` | `string` | 控制台引导内容 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/server/guide'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -251,47 +251,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/server/guide'
 
 ### 1.4. 获取Nacos控制台的存活状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos控制台的存活状态，Nacos控制台是否可正常接受和响应请求。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/health/liveness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述      |
+| Name    | Type     | Description      |
 |--------|----------|---------|
 | `data` | `string` | 固定为`ok` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/health/liveness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -303,47 +303,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/health/liveness'
 
 ### 1.5. 获取Nacos控制台的可读状态
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos控制台的是否处于可读取状态，即Nacos控制台是否可以读取到数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 公开接口，无需身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/health/readiness`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述                               |
+| Name    | Type     | Description                               |
 |--------|----------|----------------------------------|
 | `data` | `string` | 若为可读状态时，固定为`ok`，否则为不可读的模块即对应原因信息 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/health/readiness'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -355,46 +355,46 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/health/readiness'
 
 ### 1.6. 获取Nacos节点运行信息
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取Nacos节点运行信息，包括节点ip，节点运行状态，节点元数据等。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/cluster/nodes`
 
-#### 请求参数
+#### Request Parameters
 
 无。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |-----|------|----|
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/cluster/nodes'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -466,37 +466,37 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/cluster/nodes'
 
 ### 1.7. 获取Nacos命名空间列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取当前Nacos集群的命名空间列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 任意有效鉴权身份信息。
 
 > 由于命名空间是Nacos的基础隔离概念，因此大多数数据查询的接口都需要选择某个命名空间才能进行查询。因此，获取命名空间列表的能力应该是任意有效身份信息用户均可访问。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace/list`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                 | 参数类型      | 描述                                           |
+| Name                 | Type      | Description                                           |
 |---------------------|-----------|----------------------------------------------|
 | `namespace`         | `string` | 命名空间id                                       |
 | `namespaceShowName` | `string` | 命名空间名称                                       |
@@ -505,15 +505,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/cluster/nodes'
 | `quota`             | `integer` | 命名空间的配置个数配额，需开启配置配额功能才会实际生效，默认不开启，仅做预留字段。    |
 | `type`              | `integer` | 命名空间的类型，预留字段，目前为`0`时为默认命名空间、`2`时为自定义创建的命名空间。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/list'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -534,37 +534,37 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/list'
 
 ### 1.8. 获取命名空间详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定命名空间的详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述    |
+| Name           | Type       | Required | Description    |
 |---------------|----------|----|---------|
-| `namespaceId` | `string` | 是  | 命名空间id。 |
+| `namespaceId` | `string` | Yes  | 命名空间id。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                 | 参数类型      | 描述                                           |
+| Name                 | Type      | Description                                           |
 |---------------------|-----------|----------------------------------------------|
 | `namespace`         | `string` | 命名空间id                                       |
 | `namespaceShowName` | `string` | 命名空间名称                                       |
@@ -573,15 +573,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/list'
 | `quota`             | `integer` | 命名空间的配置个数配额，需开启配置配额功能才会实际生效，默认不开启，仅做预留字段。    |
 | `type`              | `integer` | 命名空间的类型，预留字段，目前为`0`时为默认命名空间、`2`时为自定义创建的命名空间。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=public'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -600,51 +600,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=public'
 
 ### 1.9. 创建新命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建新的命名空间。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                 | 类型       | 必填 | 参数描述                     |
+| Name                 | Type       | Required | Description                     |
 |---------------------|----------|----|--------------------------|
-| `customNamespaceId` | `string` | 否  | 命名空间id，未填入时将会使用UUID生成ID。 |
-| `namespaceName`     | `string` | 是  | 命名空间名称。                  |
-| `namespaceDesc`     | `string` | 否  | 命名空间描述。                  |
+| `customNamespaceId` | `string` | No  | 命名空间id，未填入时将会使用UUID生成ID。 |
+| `namespaceName`     | `string` | Yes  | 命名空间名称。                  |
+| `namespaceDesc`     | `string` | No  | 命名空间描述。                  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述          |
+| Name    | Type      | Description          |
 |--------|-----------|-------------|
-| `data` | `boolean` | 创建命名空间是否成功。 | 
+| `data` | `boolean` | 创建命名空间是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceName=test&namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -656,51 +656,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceName
 
 ### 1.10. 更新命名空间
 
-#### 接口描述
+#### Description
 
-通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的名称和描述。
+通过该接口，可以更新命名空间的信息，无法更新命名空间ID，仅能更新命名空间的Name和Description。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名             | 类型       | 必填 | 参数描述    |
+| Name             | Type       | Required | Description    |
 |-----------------|----------|----|---------|
-| `namespaceId`   | `string` | 是  | 命名空间ID  |
-| `namespaceName` | `string` | 是  | 命名空间名称。 |
-| `namespaceDesc` | `string` | 否  | 命名空间描述。 |
+| `namespaceId`   | `string` | Yes  | 命名空间ID  |
+| `namespaceName` | `string` | Yes  | 命名空间名称。 |
+| `namespaceDesc` | `string` | No  | 命名空间描述。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述          |
+| Name    | Type      | Description          |
 |--------|-----------|-------------|
-| `data` | `boolean` | 更新命名空间是否成功。 | 
+| `data` | `boolean` | 更新命名空间是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceId=test&namespaceName=test&namespaceDesc=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -712,49 +712,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/core/namespace' -d 'namespaceId=te
 
 ### 1.11. 删除命名空间
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除命名空间。默认命名空间`public`无法被删除。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要Nacos 管理员用户权限。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述    |
+| Name           | Type       | Required | Description    |
 |---------------|----------|----|---------|
-| `namespaceId` | `string` | 是  | 命名空间ID。 |
+| `namespaceId` | `string` | Yes  | 命名空间ID。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述          |
+| Name    | Type      | Description          |
 |--------|-----------|-------------|
-| `data` | `boolean` | 删除命名空间是否成功。 | 
+| `data` | `boolean` | 删除命名空间是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -766,49 +766,49 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/core/namespace?namespaceId=test
 
 ### 1.12. 检查命名空间是否存在
 
-#### 接口描述
+#### Description
 
 通过该接口，可以检查命名空间ID是否存在。默认控制台ID将在创建命名空间前调用，确认自定义的命名空间ID是否已经存在，以防冲突。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 任意有效鉴权身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/core/namespace/exist`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                 | 类型       | 必填 | 参数描述                          |
+| Name                 | Type       | Required | Description                          |
 |---------------------|----------|----|-------------------------------|
-| `customNamespaceId` | `string` | 是  | 命名空间ID，传入空字符串时认为是需要自动生成的UUID。 |
+| `customNamespaceId` | `string` | Yes  | 命名空间ID，传入空字符串时认为是需要自动生成的UUID。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述                             |
+| Name    | Type      | Description                             |
 |--------|-----------|--------------------------------|
 | `data` | `boolean` | 命名空间是否存在，存在是为`true`，否则为`false` |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespaceId=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -820,36 +820,36 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespa
 
 ### 1.13. 获取插件详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以按类型和名称获取指定插件的详情信息。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 `auth`（鉴权）、`control`（控制）、`datasource`（数据源）等。 |
-| `pluginName` | `string` | **是** | 插件名称，如 `nacos-default-auth-plugin`。 |
+| `pluginType` | `string` | **Yes** | 插件类型，如 `auth`（鉴权）、`control`（控制）、`datasource`（数据源）等。 |
+| `pluginName` | `string` | **Yes** | 插件名称，如 `nacos-default-auth-plugin`。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.pluginId | `string` | 插件唯一标识。 |
 | data.pluginType | `string` | 插件类型。 |
@@ -860,15 +860,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespa
 | data.config | `object` | 插件当前配置项。 |
 | data.configDefinitions | `array` | 插件配置项定义列表，用于渲染配置表单。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=nacos-default-auth-plugin'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -885,46 +885,46 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=
 
 ### 1.14. 查询插件在集群节点上的可用性
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定插件在各集群节点上的可用情况。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/availability`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 `auth`、`control`、`datasource` 等。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
+| `pluginType` | `string` | **Yes** | 插件类型，如 `auth`、`control`、`datasource` 等。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
 
-#### 返回数据
+#### Response Data
 
 返回 data 为 Map&lt;节点地址, 是否可用&gt;，键为 Nacos 节点地址（如 `127.0.0.1:8848`），值为该节点上该插件是否可用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=auth&pluginName=nacos-default-auth-plugin'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -938,43 +938,43 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=aut
 
 ### 1.15. 更新插件配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `config` | `string` | 否 | 插件配置内容，JSON 对象，具体字段由插件定义。 |
+| `pluginType` | `string` | **Yes** | 插件类型。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
+| `config` | `string` | No | 插件配置内容，JSON 对象，具体字段由插件定义。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 操作结果描述信息。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
@@ -983,7 +983,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
   -d 'config={}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -995,45 +995,45 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
 
 ### 1.16. 获取插件列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取插件列表，可按插件类型筛选。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | 否 | 插件类型；不传则返回所有类型的插件列表。 |
+| `pluginType` | `string` | No | 插件类型；不传则返回所有类型的插件列表。 |
 
-#### 返回数据
+#### Response Data
 
-返回 data 为插件信息数组，每项包含插件名称、类型、是否启用等。
+返回 data 为插件信息数组，每项包含插件名称、Type、是否启用等。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1051,44 +1051,44 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 
 ### 1.17. 启用或禁用插件
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新插件的启用状态（启用或禁用）。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/plugin/status`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型。 |
-| `pluginName` | `string` | **是** | 插件名称。 |
-| `enabled` | `boolean` | **是** | 是否启用，`true` 启用、`false` 禁用。 |
-| `localOnly` | `boolean` | 否 | 是否仅更新本地节点插件状态。 |
+| `pluginType` | `string` | **Yes** | 插件类型。 |
+| `pluginName` | `string` | **Yes** | 插件名称。 |
+| `enabled` | `boolean` | **Yes** | 是否启用，`true` 启用、`false` 禁用。 |
+| `localOnly` | `boolean` | No | 是否仅更新本地节点插件状态。 |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `string` | 操作结果描述信息。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
@@ -1097,7 +1097,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
   -d 'enabled=True'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1111,41 +1111,41 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
 
 ### 2.1. 获取配置详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以获取指定配置的详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                |
+| Name           | Type       | Required | Description                |
 |---------------|----------|----|---------------------|
-| `dataId`      | `string` | 是  | 配置ID。               |
-| `groupName`   | `string` | 是  | 配置分组。               |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public` |
+| `dataId`      | `string` | Yes  | 配置ID。               |
+| `groupName`   | `string` | Yes  | 配置分组。               |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public` |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                         |
+| Name                | Type     | Description                         |
 |--------------------|----------|----------------------------|
-| `id`               | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `id`               | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `dataId`           | `string` | 配置ID。                      |
 | `groupName`        | `string` | 配置分组。                      |
 | `namespaceId`      | `string` | 命名空间ID。                    |
@@ -1161,15 +1161,15 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
 | `createUser`       | `string` | 配置创建人。                     |
 | `createIp`         | `string` | 配置创建IP。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1197,59 +1197,59 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName=te
 
 ### 2.2. 发布配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建新的配置或更新已有配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                     |
+| Name           | Type       | Required | Description                     |
 |---------------|----------|----|--------------------------|
-| `dataId`      | `string` | 是  | 配置ID。                    |
-| `groupName`   | `string` | 是  | 配置分组。                    |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`      |
-| `content`     | `string` | 是  | 配置内容。                    |
-| `desc`        | `string` | 否  | 配置描述。                    |
-| `type`        | `string` | 否  | 配置类型，默认值为`text`。         |
-| `configTags`  | `string` | 否  | 配置标签，多个标签之间用英文逗号分隔。      |
-| `appName`     | `string` | 否  | 配置所属应用名称，主要用于标记配置所使用的应用。 |
+| `dataId`      | `string` | Yes  | 配置ID。                    |
+| `groupName`   | `string` | Yes  | 配置分组。                    |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`      |
+| `content`     | `string` | Yes  | 配置内容。                    |
+| `desc`        | `string` | No  | 配置描述。                    |
+| `type`        | `string` | No  | 配置类型，默认为`text`。         |
+| `configTags`  | `string` | No  | 配置标签，多个标签之间用英文逗号分隔。      |
+| `appName`     | `string` | No  | 配置所属应用名称，主要用于标记配置所使用的应用。 |
 
 - 当配置已存在(`dataId`,`groupName`相同)时，再次调用此接口将会对此配置进行更新
 - 同时更新配置时，若请求`Header`中存在`betaIps`，则会将配置标记为BETA配置，在终止BETA或完全发布配置之前，控制台UI需要进行特殊处理。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述        |
+| Name    | Type      | Description        |
 |--------|-----------|-----------|
-| `data` | `boolean` | 创建配置是否成功。 | 
+| `data` | `boolean` | 创建配置是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/cs/config' -d 'dataId=test&groupName=test&namespaceId=public&content=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1261,51 +1261,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/cs/config' -d 'dataId=test&groupN
 
 ### 2.3. 删除配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除指定配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                 |
+| Name           | Type       | Required | Description                 |
 |---------------|----------|----|----------------------|
-| `dataId`      | `string` | 是  | 配置ID。                |
-| `groupName`   | `string` | 是  | 配置分组。                |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。 |
+| `dataId`      | `string` | Yes  | 配置ID。                |
+| `groupName`   | `string` | Yes  | 配置分组。                |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述        |
+| Name    | Type      | Description        |
 |--------|-----------|-----------|
-| `data` | `boolean` | 删除配置是否成功。 | 
+| `data` | `boolean` | 删除配置是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1317,49 +1317,49 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config?dataId=test&groupName
 
 ### 2.4. 批量删除配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以批量删除指定配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/batchDelete`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名   | 类型       | 必填 | 参数描述                                  |
+| Name   | Type       | Required | Description                                  |
 |-------|----------|----|---------------------------------------|
-| `ids` | `array` | 是  | Configuration storage ID list, not a `dataId` list. Separate multiple IDs with commas. |
+| `ids` | `array` | Yes  | Configuration storage ID list, not a `dataId` list. Separate multiple IDs with commas. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型      | 描述        |
+| Name    | Type      | Description        |
 |--------|-----------|-----------|
-| `data` | `boolean` | 删除配置是否成功。 | 
+| `data` | `boolean` | 删除配置是否成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config/batchDelete?ids=838025461287096320,838025489170829312'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1371,51 +1371,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config/batchDelete?ids=83802
 
 ### 2.5. 查询配置列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定命名空间下的配置列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                                                            |
+| Name           | Type        | Required | Description                                                                            |
 |---------------|-----------|----|---------------------------------------------------------------------------------|
-| `pageNo`      | `integer` | 是  | 当前页码，起始值为1。                                                                     |
-| `pageSize`    | `integer` | 是  | 每页显示的配置数量。                                                                      |
-| `dataId`      | `string` | **是** | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
-| `groupName`   | `string` | **是** | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
-| `search`      | `string` | 否  | blur or accurate                            |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。                                                            |
-| `appName`     | `string` | 否  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
-| `configTags`  | `string` | 否  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
-| `type`        | `string` | 否  | 配置的类型，默认值为空，传入时过滤此类型的配置，值为空时查询所有类型的配置。                                          |
+| `pageNo`      | `integer` | Yes  | 当前页码，起始值为1。                                                                     |
+| `pageSize`    | `integer` | Yes  | 每页显示的配置数量。                                                                      |
+| `dataId`      | `string` | **Yes** | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
+| `groupName`   | `string` | **Yes** | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
+| `search`      | `string` | No  | blur or accurate                            |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。                                                            |
+| `appName`     | `string` | No  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
+| `configTags`  | `string` | No  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
+| `type`        | `string` | No  | 配置的Type，默认为空，传入时过滤此Type的配置，值为空时查询所有类型的配置。                                          |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                         |
+| Name                          | Type     | Description                         |
 |------------------------------|----------|----------------------------|
 | `totalCount`                 | `integer` | 符合规则的配置总数。                 |
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `List`   | 符合规则的配置列表。                 |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
@@ -1425,15 +1425,15 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/cs/config/batchDelete?ids=83802
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/list?dataId=&groupName=&appName=&configTags=&pageNo=1&pageSize=10&namespaceId=&type=&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1477,52 +1477,52 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/list?dataId=&groupName=&
 此接口性能较低，过多调用容易造成稳定性问题，请尽量使用其他接口。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以通过配置内容查询对应配置的列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/searchDetail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                                                            |
+| Name           | Type        | Required | Description                                                                            |
 |---------------|-----------|----|---------------------------------------------------------------------------------|
-| `pageNo`      | `integer` | 是  | 当前页码，起始值为1。                                                                     |
-| `pageSize`    | `integer` | 是  | 每页显示的配置数量。                                                                      |
-| `search`      | `string` | 否  | blur or accurate                            |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。                                                            |
-| `dataId`      | `string` | 否  | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
-| `groupName`   | `string` | 否  | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
-| `appName`     | `string` | 否  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
-| `configTags`  | `string` | 否  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
-| `type`         | `string` | 否  | 配置的类型，默认值为空，传入时过滤此类型的配置，值为空时查询所有类型的配置。                                          |
-| `configDetail` | `string` | 是  | 配置内容检索条件，用于按配置内容过滤，支持模糊匹配（如 `*11*`）。                                         |
+| `pageNo`      | `integer` | Yes  | 当前页码，起始值为1。                                                                     |
+| `pageSize`    | `integer` | Yes  | 每页显示的配置数量。                                                                      |
+| `search`      | `string` | No  | blur or accurate                            |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。                                                            |
+| `dataId`      | `string` | No  | 配置ID，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`groupName`条件的配置。 |
+| `groupName`   | `string` | No  | 配置分组，当`search`为`blur`时，可使用`*`进行模糊搜索，例如`test*`，当值为``或缺失时，查询全部符合`dataId`条件的配置。    |
+| `appName`     | `string` | No  | 配置所属应用名称，默认为空，传入时过滤归属于此应用的配置，值为空时查询所有应用的配置。                                     |
+| `configTags`  | `string` | No  | 配置标签，多个标签之间用英文逗号分隔，默认为空，传入时过滤拥有此tag的配置，值为空时查询所有tag的配置。                          |
+| `type`         | `string` | No  | 配置的Type，默认为空，传入时过滤此Type的配置，值为空时查询所有类型的配置。                                          |
+| `configDetail` | `string` | Yes  | 配置内容检索条件，用于按配置内容过滤，支持模糊匹配（如 `*11*`）。                                         |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                         |
+| Name                          | Type     | Description                         |
 |------------------------------|----------|----------------------------|
 | `totalCount`                 | `integer` | 符合规则的配置总数。                 |
 | `pagesAvailable`             | `integer` | 可用页码总数。                    |
 | `pageNumber`                 | `integer` | 当前页码。                      |
 | `pageItems`                  | `List`   | 符合规则的配置列表。                 |
-| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long类型的字符串。 |
+| `pageItems`[i].`id`          | `string` | 配置在存储系统中的ID，一般为Long 类型的字符串。 |
 | `pageItems`[i].`dataId`      | `string` | 配置ID。                      |
 | `pageItems`[i].`groupName`   | `string` | 配置分组。                      |
 | `pageItems`[i].`namespaceId` | `string` | 命名空间ID。                    |
@@ -1532,15 +1532,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/list?dataId=&groupName=&
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                    |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                    |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/searchDetail?dataId=&groupName=&appName=&configTags=&pageNo=1&pageSize=10&namespaceId=&type=&search=blur&configDetail=*11*'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1569,53 +1569,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/searchDetail?dataId=&gro
 
 ### 2.7. 查询配置的监听者列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定配置的监听者列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/listener`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                 |
+| Name           | Type       | Required | Description                 |
 |---------------|----------|----|----------------------|
-| `dataId`      | `string` | 是  | 配置ID。                |
-| `groupName`   | `string` | 是  | 配置分组。                |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。 |
-| `aggregation` | `boolean` | 否  | 是否聚合查询。             |
+| `dataId`      | `string` | Yes  | 配置ID。                |
+| `groupName`   | `string` | Yes  | 配置分组。                |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。 |
+| `aggregation` | `boolean` | No  | 是否聚合查询。             |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                    |
+| Name               | Type                  | Description                                    |
 |-------------------|-----------------------|---------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`config`。                 |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`config`。                 |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅者IP，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener?dataId=test&groupName=test'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1632,53 +1632,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener?dataId=test&gro
 
 ### 2.8. 查询某个订阅者IP订阅了哪些配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询某个订阅者IP订阅了哪些配置。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/listener/ip`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                 |
+| Name           | Type       | Required | Description                 |
 |---------------|----------|----|----------------------|
-| `ip`          | `string` | 是  | 订阅者IP。               |
-| `all`         | `boolean` | 否  | 是否查询全部订阅数据。         |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。 |
-| `aggregation` | `boolean` | 否  | 是否聚合查询。             |
+| `ip`          | `string` | Yes  | 订阅者IP。               |
+| `all`         | `boolean` | No  | 是否查询全部订阅数据。         |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。 |
+| `aggregation` | `boolean` | No  | 是否聚合查询。             |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名               | 参数类型                  | 描述                                                                            |
+| Name               | Type                  | Description                                                                            |
 |-------------------|-----------------------|-------------------------------------------------------------------------------|
-| `queryType`       | `string` | 订阅者查询类型，该接口为`ip`。                                                             |
+| `queryType`       | `string` | 订阅者查询Type，该接口为`ip`。                                                             |
 | `listenersStatus` | `map<string, string>` | 订阅者列表，key为订阅的配置信息，格式为`dataId`+`groupName`+`namespaceId`，value为订阅者订阅当前配置的MD5值。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener/ip?ip=127.0.0.1'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1695,52 +1695,52 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/cs/config/listener/ip?ip=127.0.0.1
 
 ### 2.9. 导出配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将所选或所查询的配置，导出的配置为zip文件，进行备份或导入到其他Nacos集群。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/export2`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                         |
+| Name           | Type       | Required | Description                         |
 |---------------|----------|----|------------------------------|
-| `dataId`      | `string` | 否  | 需要导出的配置ID的pattern，例如`test*`。 |
-| `groupName`   | `string` | 否  | 需要导出的配置分组的pattern，例如`test*`。 |
-| `ids`         | `array` | 否  | Configuration storage ID list. Separate multiple IDs with commas.    |
-| `namespaceId` | `string` | 否  | 命名空间ID，默认值为`public`。         |
-| `appName`     | `string` | 否  | 需要导出的配置所属的应用名称。              |
+| `dataId`      | `string` | No  | 需要导出的配置ID的pattern，例如`test*`。 |
+| `groupName`   | `string` | No  | 需要导出的配置分组的pattern，例如`test*`。 |
+| `ids`         | `array` | No  | Configuration storage ID list. Separate multiple IDs with commas.    |
+| `namespaceId` | `string` | No  | 命名空间ID，默认为`public`。         |
+| `appName`     | `string` | No  | 需要导出的配置所属的应用名称。              |
 
 > 使用时建议分开使用 `ids` 和 `dataId` + `groupName` 的组合，只选择一种方式，另一类传入空字符串，否则可能导致导出文件为空内容。
 
-#### 返回数据
+#### Response Data
 
 导出成功是为byte数组的file
-attachment模式，导出失败时返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)。
+attachment模式，导出失败时返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/cs/config/export2?dataId=&groupId=&ids=" --output ~/test.zip
 ```
 
-* 返回示例
+* Response example
 
 ```shell
 unzip ~/test.zip
@@ -1757,55 +1757,55 @@ unzip ~/test.zip
 接口进行配置文件的导出。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将从Nacos导出的zip文件导入到Nacos的指定命名空间中
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/import`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型                 | 必填 | 参数描述                                                                                                               |
+| Name           | Type                 | Required | Description                                                                                                               |
 |---------------|--------------------|----|--------------------------------------------------------------------------------------------------------------------|
-| `file`        | `MultipartFile`    | 否  | 导入的zip文件。                                                                                                          |
-| `namespaceId` | `string` | 否  | 导入的配置所属的命名空间ID，默认值为`public`。                                                                                       |
-| `policy`      | `string` | 否  | 导入策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的导入策略。可选值有`ABORT(终止导入)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认值为`ABORT`。 |
-| `src_user`    | `string` | 否  | 导入操作来源用户标识。                                                                                                       |
+| `file`        | `MultipartFile`    | No  | 导入的zip文件。                                                                                                          |
+| `namespaceId` | `string` | No  | 导入的配置所属的命名空间ID，默认为`public`。                                                                                       |
+| `policy`      | `string` | No  | 导入策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的导入策略。可选值有`ABORT(终止导入)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认为`ABORT`。 |
+| `src_user`    | `string` | No  | 导入操作来源用户标识。                                                                                                       |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型  | 描述         |
+| Name         | Type  | Description         |
 |-------------|-------|------------|
 | `succCount` | `integer` | 导入成功的配置数量。 |
 | `skipCount` | `integer` | 导入跳过的配置数量。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -vX POST "http://127.0.0.1:8080/v3/console/cs/config/import" -F "file=@/path/to/test.zip" -F "namespaceId=test"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1820,54 +1820,54 @@ curl -vX POST "http://127.0.0.1:8080/v3/console/cs/config/import" -F "file=@/pat
 
 ### 2.11. 克隆配置
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将所选或所查询的配置克隆到其他命名空间。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`，为配置列表数组。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/clone`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名              | 类型       | 必填    | 参数描述                                                                                                               |
+| Name              | Type       | Required    | Description                                                                                                               |
 |------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------|
-| `srcUser`        | `string` | 否     | 克隆操作来源用户标识。                                                                                                        |
-| `targetNamespaceId` | `string` | **是** | 目标命名空间ID。                                                                                                           |
-| `policy`         | `string` | 否     | 克隆策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的克隆策略。可选值有`ABORT(终止克隆)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认值为`ABORT`。 |
+| `srcUser`        | `string` | No     | 克隆操作来源用户标识。                                                                                                        |
+| `targetNamespaceId` | `string` | **Yes** | 目标命名空间ID。                                                                                                           |
+| `policy`         | `string` | No     | 克隆策略，当导入的配置`dataId`和`groupName`相同，存在冲突时，所进行的克隆策略。可选值有`ABORT(终止克隆)`,`SKIP(跳过冲突配置)`,`OVERWRITE(覆盖冲突配置)`。默认为`ABORT`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型  | 描述         |
+| Name         | Type  | Description         |
 |-------------|-------|------------|
 | `succCount` | `integer` | 成功克隆的配置数量。 |
 | `skipCount` | `integer` | 克隆跳过的配置数量。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -H "Content-Type: application/json" -X POST "http://127.0.0.1:8080/v3/console/cs/config/clone?targetNamespaceId=public&policy=ABORT" -d "[{\"cfgId\":838029534438625280,\"dataId\":\"111\",\"group\":\"DEFAULT_GROUP\"},{\"cfgId\":838033747294031872,\"dataId\":\"qtc-user.yaml\",\"group\":\"DEFAULT_GROUP\"}]"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1886,50 +1886,50 @@ curl -H "Content-Type: application/json" -X POST "http://127.0.0.1:8080/v3/conso
 只有在[发布配置](#22-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能停止BETA发布状态。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以将配置从BETA发布状态停止，即回滚配置的Beta发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `dataId`      | `string` | 是  | 配置的`dataId`。              |
-| `groupName`   | `string` | 是  | 配置的`groupName`。           |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `dataId`      | `string` | Yes  | 配置的`dataId`。              |
+| `groupName`   | `string` | Yes  | 配置的`groupName`。           |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |-----|------|----|
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=test&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -1945,39 +1945,39 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=test&grou
 只有在[发布配置](#22-发布配置)时设置了`Header`的`betaIps`后，将配置变更为BETA发布中的状态，调用此接口才能获取到配置详情。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的BETA发布状态。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/config/beta`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `dataId`      | `string` | 是  | 配置的`dataId`。              |
-| `groupName`   | `string` | 是  | 配置的`groupName`。           |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `dataId`      | `string` | Yes  | 配置的`dataId`。              |
+| `groupName`   | `string` | Yes  | 配置的`groupName`。           |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                | 参数类型     | 描述                                  |
+| Name                | Type     | Description                                  |
 |--------------------|----------|-------------------------------------|
 | `id`               | `string` | beta配置的存储ID。                        |
 | `dataId`           | `string` | 配置的dataId。                          |
@@ -1996,15 +1996,15 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=test&grou
 | `grayName`         | `string` | 灰度发布规则名称, 固定为`beta`。                |
 | `grayRule`         | `string` | 灰度发布规则，格式为JSON，其中的`expr`为beta的ip列表。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=111&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2034,41 +2034,41 @@ curl "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=111&groupName=DEFAU
 
 ### 2.14. 查询配置发布历史
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的发布历史。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `pageNo`      | `integer` | 是  | 当前页码，起始为`1`               |
-| `pageSize`    | `integer` | 是  | 每页显示的记录数。                 |
-| `dataId`      | `string` | 是  | 配置的`dataId`。              |
-| `groupName`   | `string` | 是  | 配置的`groupName`。           |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `pageNo`      | `integer` | Yes  | 当前页码，起始为`1`               |
+| `pageSize`    | `integer` | Yes  | 每页显示的记录数。                 |
+| `dataId`      | `string` | Yes  | 配置的`dataId`。              |
+| `groupName`   | `string` | Yes  | 配置的`groupName`。           |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型     | 描述                                |
+| Name                          | Type     | Description                                |
 |------------------------------|----------|-----------------------------------|
 | `totalCount`                 | `integer` | 历史记录的总数。                          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。                      |
@@ -2086,15 +2086,15 @@ curl "http://127.0.0.1:8080/v3/console/cs/config/beta?dataId=111&groupName=DEFAU
 | `pageItems`[i].`createTime`  | `integer` | 配置创建时间。                           |
 | `pageItems`[i].`modifyTime`  | `integer` | 配置修改时间。                           |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history/list?pageNo=1&pageSize=10&dataId=111&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2157,40 +2157,40 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/list?pageNo=1&pageSize=10&data
 
 ### 2.15. 查询配置的某次历史变更记录
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置的某次历史变更记录。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `nid`         | `integer` | 是  | 历史记录的ID。                  |
-| `dataId`      | `string` | 是  | 配置的dataId。                
-| `groupName`   | `string` | 是  | 配置的groupName。             |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `nid`         | `integer` | Yes  | 历史记录的ID。                  |
+| `dataId`      | `string` | Yes  | 配置的dataId。
+| `groupName`   | `string` | Yes  | 配置的groupName。             |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -2207,15 +2207,15 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/list?pageNo=1&pageSize=10&data
 | `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `JsonString` | 扩展信息，目前包括`src_user`、`type`、`c_desc`，若`publishType`为`gray`, 其中还包括`grayRule`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history?dataId=111&groupName=DEFAULT_GROUP&nid=7"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2245,40 +2245,40 @@ curl "http://127.0.0.1:8080/v3/console/cs/history?dataId=111&groupName=DEFAULT_G
 
 ### 2.16. 查询配置最新状态的前一次变更历史
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询配置最新状态的前一次变更历史。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history/previous`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `id`          | `integer` | 是  | 配置的存储ID。                  |
-| `dataId`      | `string` | 是  | 配置的dataId。                |
-| `groupName`   | `string` | 是  | 配置的groupName。             |
-| `namespaceId` | `string` | 否  | 配置所属的命名空间ID，默认值为`public`。 |
+| `id`          | `integer` | Yes  | 配置的存储ID。                  |
+| `dataId`      | `string` | Yes  | 配置的dataId。                |
+| `groupName`   | `string` | Yes  | 配置的groupName。             |
+| `namespaceId` | `string` | No  | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名           | 参数类型         | 描述                                                                          |
+| Name           | Type         | Description                                                                          |
 |---------------|--------------|-----------------------------------------------------------------------------|
 | `id`          | `string` | 历史记录的ID。                                                                    |
 | `dataId`      | `string` | 配置的dataId。                                                                  |
@@ -2295,15 +2295,15 @@ curl "http://127.0.0.1:8080/v3/console/cs/history?dataId=111&groupName=DEFAULT_G
 | `grayName`    | `string` | 灰度发布规则名称, 固定为`beta`。                                                        |
 | `extInfo`     | `JsonString` | 扩展信息，目前包括`src_user`、`type`、`c_desc`，若`publishType`为`gray`, 其中还包括`grayRule`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history/previous?id=838029534438625280&dataId=111&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2333,52 +2333,52 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/previous?id=838029534438625280
 
 ### 2.17. 查询命名空间下的配置列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询命名空间下的配置列表，仅查询dataId和groupName，用于配置历史UI的下拉选择。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/cs/history/configs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                      |
+| Name           | Type       | Required | Description                      |
 |---------------|----------|----|---------------------------|
-| `namespaceId` | `string` | **是** | 配置所属的命名空间ID，默认值为`public`。 |
+| `namespaceId` | `string` | **Yes** | 配置所属的命名空间ID，默认为`public`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名         | 参数类型     | 描述            |
+| Name         | Type     | Description            |
 |-------------|----------|---------------|
 | `dataId`    | `string` | 配置的dataId。    |
 | `groupName` | `string` | 配置的groupName。 |
 
 > 其他字段均无用。
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl "http://127.0.0.1:8080/v3/console/cs/history/configs?namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2415,55 +2415,55 @@ curl "http://127.0.0.1:8080/v3/console/cs/history/configs?namespaceId=public"
 
 ### 3.1. 创建服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建一个空服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型                    | 必填 | 参数描述                                                   |
+| Name                | Type                    | Required | Description                                                   |
 |--------------------|-----------------------|----|--------------------------------------------------------|
-| `serviceName`      | `string` | 是  | 服务名。                                                   |
-| `groupName`        | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。                    |
-| `namespaceId`      | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。                              |
-| `protectThreshold` | `number` | 否  | 服务的防护阈值，默认值为`0.0`。                                     |
-| `selector`         | `string` | 否  | 服务的路由选择器，默认值为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
-| `metadata`         | `string` | 否  | 服务的元数据，默认值为`{}`。                                       |
-| `ephemeral`        | `boolean` | 否  | 服务是否临时，默认值为`false`即持久化服务。                              |
+| `serviceName`      | `string` | Yes  | 服务名。                                                   |
+| `groupName`        | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。                    |
+| `namespaceId`      | `string` | No  | 服务所属的命名空间ID，默认为`public`。                              |
+| `protectThreshold` | `number` | No  | 服务的防护阈值，默认为`0.0`。                                     |
+| `selector`         | `string` | No  | 服务的路由选择器，默认为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
+| `metadata`         | `string` | No  | 服务的元数据，默认为`{}`。                                       |
+| `ephemeral`        | `boolean` | No  | 服务是否临时，默认为`false`即持久化服务。                              |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 创建成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&groupName=DEFAULT_GROUP&namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2479,51 +2479,51 @@ curl -X POST "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&
 此接口为删除服务，而不是删除服务实例（服务提供者），且当服务下还有服务实例存在时，服务会无法删除。
 :::
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除一个服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                                |
+| Name           | Type       | Required | Description                                |
 |---------------|----------|----|-------------------------------------|
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 删除成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test&groupName=DEFAULT_GROUP&namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2535,56 +2535,56 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test&gro
 
 ### 3.3. 更新服务元数据
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新一个服务的元数据。仅能更新服务的元数据，如`metadata`、`selector`
 等。服务的serviceName、groupName、namespaceId等不能更新。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型                    | 必填 | 参数描述                                                   |
+| Name                | Type                    | Required | Description                                                   |
 |--------------------|-----------------------|----|--------------------------------------------------------|
-| `serviceName`      | `string` | 是  | 服务名。                                                   |
-| `groupName`        | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。                    |
-| `namespaceId`      | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。                              |
-| `protectThreshold` | `number` | 否  | 服务的防护阈值，默认值为`0.0`。                                     |
-| `ephemeral`        | `boolean` | 否  | 是否临时实例，如 `true`/`false`。                                  |
-| `selector`         | `string` | 否  | 服务的路由选择器，默认值为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
-| `metadata`         | `string` | 否  | 服务的元数据，默认值为`{}`。                                       |
+| `serviceName`      | `string` | Yes  | 服务名。                                                   |
+| `groupName`        | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。                    |
+| `namespaceId`      | `string` | No  | 服务所属的命名空间ID，默认为`public`。                              |
+| `protectThreshold` | `number` | No  | 服务的防护阈值，默认为`0.0`。                                     |
+| `ephemeral`        | `boolean` | No  | 是否临时实例，如 `true`/`false`。                                  |
+| `selector`         | `string` | No  | 服务的路由选择器，默认为`{"type":"none"}`，无选择器，另外还支持通过label 进行路由。 |
+| `metadata`         | `string` | No  | 服务的元数据，默认为`{}`。                                       |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 更新成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&groupName=DEFAULT_GROUP&namespaceId=public&protectThreshold=0"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2594,50 +2594,50 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service" -d "serviceName=test&g
 }
 ```
 
-### 3.4. 获取支持的服务路由选择器类型列表
+### 3.4. 获取支持的服务路由选择器Type列表
 
-#### 接口描述
+#### Description
 
-通过该接口，可以获取支持的服务路由选择器类型列表，用于控制台UI在创建和更新服务时，选择对应的路由选择器类型的下拉选择框。
+通过该接口，可以获取支持的服务路由选择器Type列表，用于控制台UI在创建和更新服务时，选择对应的路由选择器Type的下拉选择框。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 任意有效鉴权身份信息。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/selector/types`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名     | 参数类型     | 描述                  |
+| Name     | Type     | Description                  |
 |---------|----------|---------------------|
 | `label` | `string` | 通过label表达式进行路由选择过滤。 |
 | `none`  | `string` | 无选择器。               |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/selector/types"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2652,43 +2652,43 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/selector/types"
 
 ### 3.5. 查询服务列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定命名空间下的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                  | 类型        | 必填 | 参数描述                              |
+| Name                  | Type        | Required | Description                              |
 |----------------------|-----------|----|-----------------------------------|
-| `pageNo`             | `integer` | 是  | Page number, starting from `1`. |
-| `pageSize`           | `integer` | 是  | Page size. |
-| `serviceNameParam`   | `string` | 否  | 服务名的pattern，为空时查询所有服务。            |
-| `groupNameParam`     | `string` | 否  | 服务所属的groupName的pattern，为空时查询所有服务。 |
-| `namespaceId`        | `string` | 否  | 服务所属的命名空间ID。                      |
-| `ignoreEmptyService` | `boolean` | 否  | Whether to return only services with instances. Defaults to `false`, meaning empty services are included. |
-| `withInstances`      | `boolean` | 否  | Whether to return service instance details. Defaults to `false`. |
+| `pageNo`             | `integer` | Yes  | Page number, starting from `1`. |
+| `pageSize`           | `integer` | Yes  | Page size. |
+| `serviceNameParam`   | `string` | No  | 服务名的pattern，为空时查询所有服务。            |
+| `groupNameParam`     | `string` | No  | 服务所属的groupName的pattern，为空时查询所有服务。 |
+| `namespaceId`        | `string` | No  | 服务所属的命名空间ID。                      |
+| `ignoreEmptyService` | `boolean` | No  | Whether to return only services with instances. Defaults to `false`, meaning empty services are included. |
+| `withInstances`      | `boolean` | No  | Whether to return service instance details. Defaults to `false`. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                   | 参数类型     | 描述           |
+| Name                                   | Type     | Description           |
 |---------------------------------------|----------|--------------|
 | `totalCount`                          | `integer` | 符合条件的服务的总数。  |
 | `pageNumber`                          | `integer` | 当前页码，起始为`1`。 |
@@ -2701,15 +2701,15 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/selector/types"
 | `pageItems`[i].`healthyInstanceCount` | `string` | 服务下的健康实例数量。  |
 | `pageItems`[i].`triggerFlag`          | `string` | 是否触发了服务的保护。  |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/list?pageNo=1&pageSize=10&namespaceId=public"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2743,42 +2743,42 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/list?pageNo=1&pageSize=
 
 ### 3.6. 查询服务的订阅者列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定服务下的订阅者列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/subscribers`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                |
+| Name           | Type        | Required | Description                                |
 |---------------|-----------|----|-------------------------------------|
-| `pageNo`      | `integer` | 是  | Page number, starting from `1`. |
-| `pageSize`    | `integer` | 是  | Page size. |
-| `serviceName`  | `string` | 是  | 服务名。                                |
-| `groupName`    | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId`  | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `aggregation`  | `boolean` | 否  | Whether to aggregate the query. |
+| `pageNo`      | `integer` | Yes  | Page number, starting from `1`. |
+| `pageSize`    | `integer` | Yes  | Page size. |
+| `serviceName`  | `string` | Yes  | 服务名。                                |
+| `groupName`    | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId`  | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `aggregation`  | `boolean` | No  | Whether to aggregate the query. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型      | 描述                   |
+| Name                          | Type      | Description                   |
 |------------------------------|-----------|----------------------|
 | `totalCount`                 | `integer` | 符合条件的服务的总数。          |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。         |
@@ -2786,22 +2786,22 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/list?pageNo=1&pageSize=
 | `pageItems`                  | `List`    | 服务列表。                |
 | `pageItems`[i].`ip`          | `string` | 订阅者IP。               |
 | `pageItems`[i].`port`        | `integer` | 订阅者端口。               |
-| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 | 
+| `pageItems`[i].`address`     | `string` | 订阅者地址, 一般为`ip:port`。 |
 | `pageItems`[i].`agent`       | `string` | 订阅者客户端版本。            |
 | `pageItems`[i].`appName`     | `string` | 订阅者所属应用。             |
 | `pageItems`[i].`namespaceId` | `string` | 订阅者所属命名空间。           |
 | `pageItems`[i].`groupName`   | `string` | 订阅的分组名。              |
 | `pageItems`[i].`serviceName` | `string` | 订阅的服务名。              |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/subscribers?pageNo=1&pageSize=10&serviceName=test&groupName=DEFAULT_GROUP"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2829,39 +2829,39 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/subscribers?pageNo=1&pa
 
 ### 3.7. 查询服务详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定服务详情。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型       | 必填 | 参数描述                                |
+| Name           | Type       | Required | Description                                |
 |---------------|----------|----|-------------------------------------|
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                                 | 参数类型         | 描述                                   |
+| Name                                                 | Type         | Description                                   |
 |-----------------------------------------------------|--------------|--------------------------------------|
 | `namespaceId`                                       | `string` | 服务所属的namespaceId。                    |
 | `groupName`                                         | `string` | 服务所属的groupName。                      |
@@ -2870,22 +2870,22 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service/subscribers?pageNo=1&pa
 | `protectThreshold`                                  | `number` | 服务防护阈值。                              |
 | `selector`                                          | `jsonObject` | 服务选择器。                               |
 | `metadata`                                          | `jsonObject` | 服务元数据。                               |
-| `clusterMap`                                        | `jsonObject` | 服务集群列表, key为cluster的名称，value为集群详细信息。 |
+| `clusterMap`                                        | `jsonObject` | 服务集群列表, key为cluster的Name，value为集群详细信息。 |
 | `clusterMap`.$ClusterName.`clusterName`             | `string` | 集群名。                                 |
 | `clusterMap`.$ClusterName.`healthChecker`           | `jsonObject` | 健康检查器。                               |
 | `clusterMap`.$ClusterName.`healthyCheckPort`        | `integer` | 健康检查端口。                              |
 | `clusterMap`.$ClusterName.`useInstancePortForCheck` | `boolean` | 是否使用所注册的实例的`IP:Port`进行健康检查。          |
 | `clusterMap`.$ClusterName.`metadata`                | `jsonObject` | 集群元数据。                               |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2920,38 +2920,38 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test"
 
 ### 3.8. 更新服务集群元数据
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新指定服务集群的元数据。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/service/cluster`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 类型                    | 必填 | 参数描述                                |
+| Name                     | Type                    | Required | Description                                |
 |-------------------------|-----------------------|----|-------------------------------------|
-| `clusterName`           | `string` | 是  | 集群名。                                |
-| `serviceName`           | `string` | 是  | 服务名。                                |
-| `checkPort`             | `integer` | 是  | Health check port. |
-| `useInstancePort4Check` | `boolean` | 是  | Whether to use the registered instance `IP:Port` for health checks. |
-| `healthChecker`         | `string` | 是  | 健康检查器。                              |
-| `groupName`             | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId`           | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `metadata`              | `string` | 否  | 服务元数据。                              |
+| `clusterName`           | `string` | Yes  | 集群名。                                |
+| `serviceName`           | `string` | Yes  | 服务名。                                |
+| `checkPort`             | `integer` | Yes  | Health check port. |
+| `useInstancePort4Check` | `boolean` | Yes  | Whether to use the registered instance `IP:Port` for health checks. |
+| `healthChecker`         | `string` | Yes  | 健康检查器。                              |
+| `groupName`             | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId`           | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `metadata`              | `string` | No  | 服务元数据。                              |
 
 > `healthChecker`参数为健康检查器的JSON字符串，目前支持三种健康检查器：
 > 1. `None`: 无健康检查，`{"type":"NONE"}`
@@ -2959,23 +2959,23 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/service?serviceName=test"
 > 3. `HTTP`: HTTP端口检查，`{"type":"HTTP","path":"/liveness","headers":"health"}`, 其中`path`为HTTP的uri，`headers`
      为HTTP请求头。
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 更新成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service/cluster" -d "serviceName=test&clusterName=DEFAULT&checkPort=80&useInstancePort4Check=true&healthChecker={\"type\":\"none\"}"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -2987,42 +2987,42 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service/cluster" -d "serviceNam
 
 ### 3.9. 查询服务的实例列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定服务的实例列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/instance/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型        | 必填 | 参数描述                                |
+| Name           | Type        | Required | Description                                |
 |---------------|-----------|----|-------------------------------------|
-| `pageNo`      | `integer` | 是  | 页码，起始为1。                            |
-| `pageSize`    | `integer` | 是  | 每页记录数。                              |
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId`  | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `clusterName`  | `string` | 否  | 集群名，不传则查询所有集群的实例。                      |
+| `pageNo`      | `integer` | Yes  | 页码，起始为1。                            |
+| `pageSize`    | `integer` | Yes  | 每页记录数。                              |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId`  | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `clusterName`  | `string` | No  | 集群名，不传则查询所有集群的实例。                      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                          | 参数类型                  | 描述                                    |
+| Name                          | Type                  | Description                                    |
 |------------------------------|-----------------------|---------------------------------------|
 | `totalCount`                 | `integer` | 符合条件的实例的总数。                           |
 | `pageNumber`                 | `integer` | 当前页码，起始为`1`。                          |
@@ -3044,15 +3044,15 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/service/cluster" -d "serviceNam
 用于兼容1.X客户端的心跳模式数据，后续版本可能会移除对1.X客户端的支持，届时这3个参数将被废弃。
 :::
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET "http://127.0.0.1:8080/v3/console/ns/instance/list?&serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&pageSize=10&pageNo=1"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3086,59 +3086,59 @@ curl -X GET "http://127.0.0.1:8080/v3/console/ns/instance/list?&serviceName=test
 
 ### 3.10. 更新实例元数据
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新指定服务的实例元数据，包括权重和上下线状态；无法更新实例的服务名、分组名、命名空间、IP及端口。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 类型                    | 必填 | 参数描述                                |
+| Name           | Type                    | Required | Description                                |
 |---------------|-----------------------|----|-------------------------------------|
-| `serviceName` | `string` | 是  | 服务名。                                |
-| `ip`          | `string` | 是  | 实例IP。                               |
-| `port`        | `integer` | 是  | 实例端口。                               |
-| `groupName`   | `string` | 否  | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string` | 否  | 服务所属的命名空间ID，默认值为`public`。           |
-| `clusterName` | `string` | 否  | 实例所属集群, 默认值为`DEFAULT`。              |
-| `ephemeral`   | `boolean` | 否  | 实例是否临时，默认值为`true`。                  |
-| `weight`      | `number` | 否  | 实例权重。                               |
-| `healthy`     | `boolean` | 否  | 实例健康状态。                             |
-| `enabled`     | `boolean` | 否  | 实例是否已上线。                            |
-| `metadata`    | `string` | 否  | 实例元数据。                              |
+| `serviceName` | `string` | Yes  | 服务名。                                |
+| `ip`          | `string` | Yes  | 实例IP。                               |
+| `port`        | `integer` | Yes  | 实例端口。                               |
+| `groupName`   | `string` | No  | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string` | No  | 服务所属的命名空间ID，默认为`public`。           |
+| `clusterName` | `string` | No  | 实例所属集群, 默认为`DEFAULT`。              |
+| `ephemeral`   | `boolean` | No  | 实例是否临时，默认为`true`。                  |
+| `weight`      | `number` | No  | 实例权重。                               |
+| `healthy`     | `boolean` | No  | 实例健康状态。                             |
+| `enabled`     | `boolean` | No  | 实例是否已上线。                            |
+| `metadata`    | `string` | No  | 实例元数据。                              |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | 更新成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT "http://127.0.0.1:8080/v3/console/ns/instance" -d 'serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&ip=1.1.1.1&port=3306&ephemeral=true&weight=100&enabled=false&metadata=%7B%22%E5%95%A6%E5%95%A6%E5%95%A6%26%E5%95%B5%E5%95%B5%E5%95%B5%22%3A%22xxx%22%7D'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3150,59 +3150,59 @@ curl -X PUT "http://127.0.0.1:8080/v3/console/ns/instance" -d 'serviceName=test&
 
 ### 3.11. 删除持久化实例
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除指定服务下的**持久化实例**。该接口仅支持删除`ephemeral=false`的实例，不支持删除临时实例。
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ns/instance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名        | 类型      | 必填 | 参数描述                                       |
+| Name        | Type      | Required | Description                                       |
 | ------------- | --------- | ---- | ---------------------------------------------- |
-| `serviceName` | `string`  | 是   | 服务名。                                       |
-| `ip`          | `string`  | 是   | 实例IP。                                       |
-| `port`        | `integer` | 是   | 实例端口。                                     |
-| `groupName`   | `string`  | 否   | 服务所属的groupName，默认值为`DEFAULT_GROUP`。 |
-| `namespaceId` | `string`  | 否   | 服务所属的命名空间ID，默认值为`public`。       |
-| `clusterName` | `string`  | 否   | 实例所属集群, 默认值为`DEFAULT`。              |
-| `ephemeral`   | `boolean` | 否   | 实例是否临时，仅支持传入`false`，默认值为`false`。 |
-| `healthy`     | `boolean` | 否   | Whether the instance is healthy. |
-| `weight`      | `number`  | 否   | Instance weight. |
-| `enabled`     | `boolean` | 否   | Whether the instance is enabled. |
-| `metadata`    | `string`  | 否   | Instance metadata as a JSON object string. |
+| `serviceName` | `string`  | Yes   | 服务名。                                       |
+| `ip`          | `string`  | Yes   | 实例IP。                                       |
+| `port`        | `integer` | Yes   | 实例端口。                                     |
+| `groupName`   | `string`  | No   | 服务所属的groupName，默认为`DEFAULT_GROUP`。 |
+| `namespaceId` | `string`  | No   | 服务所属的命名空间ID，默认为`public`。       |
+| `clusterName` | `string`  | No   | 实例所属集群, 默认为`DEFAULT`。              |
+| `ephemeral`   | `boolean` | No   | 实例是否临时，仅支持传入`false`，默认为`false`。 |
+| `healthy`     | `boolean` | No   | Whether the instance is healthy. |
+| `weight`      | `number`  | No   | Instance weight. |
+| `enabled`     | `boolean` | No   | Whether the instance is enabled. |
+| `metadata`    | `string`  | No   | Instance metadata as a JSON object string. |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名 | 参数类型 | 描述                     |
+| Name | Type | Description                     |
 | ------ | -------- | ------------------------ |
 | `data` | `string` | 删除成功时，固定为`ok`。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/instance?serviceName=test&clusterName=DEFAULT&groupName=DEFAULT_GROUP&ip=1.1.1.1&port=3306&ephemeral=false"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3216,40 +3216,40 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/instance?serviceName=test&cl
 
 ### 4.1. 查询MCP服务的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定MCP服务的服务的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
 | `mcpId`       | `string` | One of two required | MCP service ID (usually UUID). One of `mcpId` and `mcpName` must be provided (OpenAPI cannot express this constraint; at least one is required in practice). Prefer `mcpId`. |
 | `mcpName`     | `string` | One of two required | MCP service name template. One of `mcpId` and `mcpName` must be provided; prefer `mcpId`.    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是返回最新版本                      |
+| `version`     | `string` | No     | MCP服务的版本，未传入是返回最新版本                      |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID。                                                                               |
 | `name`               | `string` | MCP服务名。                                                                                         |
@@ -3269,20 +3269,20 @@ curl -X DELETE "http://127.0.0.1:8080/v3/console/ns/instance?serviceName=test&cl
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
 | `is_latest`    | `boolean` | MCP服务的版本是否为最新版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3322,42 +3322,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 ### 4.2. 更新MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                                                      |
+| Name                     | Type         | Required  | Description                                                      |
 |-------------------------|--------------|-------|---------------------------------------------------------|
-| `namespaceId`           | `string` | 否     | MCP服务的命名空间ID，默认为`public`                                |
-| `latest`                | `boolean` | 否     | 是否按最新版本更新，如 `true`。                                      |
-| `serverSpecification`   | `string` | **是** | MCP服务的描述详情                                              |
-| `toolSpecification`     | `string` | 否     | MCP服务的工具描述详情                                            |
-| `endpointSpecification` | `string` | 否     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效                          |
-| `overrideExisting`      | `boolean` | 否     | MCP服务更新时是否覆盖原endpointSpecification，默认不覆盖，仅在非`stdio`协议时生效 |
+| `namespaceId`           | `string` | No     | MCP服务的命名空间ID，默认为`public`                                |
+| `latest`                | `boolean` | No     | 是否按最新版本更新，如 `true`。                                      |
+| `serverSpecification`   | `string` | **Yes** | MCP服务的描述详情                                              |
+| `toolSpecification`     | `string` | No     | MCP服务的工具描述详情                                            |
+| `endpointSpecification` | `string` | No     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效                          |
+| `overrideExisting`      | `boolean` | No     | MCP服务更新时是否覆盖原endpointSpecification，默认不覆盖，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，必须传入，用于定位待更新的MCP服务。                                                            |
 | `name`               | `string` | MCP服务名。                                                                                         |
@@ -3374,7 +3374,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -3382,7 +3382,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `List<McpTool>`            | 该MCP Server所提供的工具列表，参考标准MCP协议中对于MCP Tool的定义                                             |
 | `toolsMeta`       | `Map<String, McpToolMeta>` | 该MCP Server所提供的工具的额外元数据信息，可用于扩展标准MCP协议中未定义但又使用中需要的信息。key为`McpTool`的`name`, value为拓展元数据。 |
@@ -3390,15 +3390,15 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
 | `name`        | `string` | MCP 工具的名称                                     |
 | `description` | `string` | MCP 工具的描述                                     |
-| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`类型`,`是否必须`,`描述` 等。 |
+| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`Type`,`是否必须`,`Description` 等。 |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -3406,7 +3406,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
 | `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
@@ -3417,22 +3417,22 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务更新结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
@@ -3440,7 +3440,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"d7a64724-a556-4fe4-82fa-e806d43e00dc","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3452,40 +3452,40 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 ### 4.3. 创建MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的MCP服务，可以是存量API转换的MCP服务，也可以是MCP市场中的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                     | 参数类型         | 是否必填  | 描述                             |
+| Name                     | Type         | Required  | Description                             |
 |-------------------------|--------------|-------|--------------------------------|
-| `namespaceId`           | `string` | 否     | MCP服务的命名空间ID，默认为`public`       |
-| `serverSpecification`   | `string` | **是** | MCP服务的描述详情                     |
-| `toolSpecification`     | `string` | 否     | MCP服务的工具描述详情                   |
-| `endpointSpecification` | `string` | 否     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
+| `namespaceId`           | `string` | No     | MCP服务的命名空间ID，默认为`public`       |
+| `serverSpecification`   | `string` | **Yes** | MCP服务的描述详情                     |
+| `toolSpecification`     | `string` | No     | MCP服务的工具描述详情                   |
+| `endpointSpecification` | `string` | No     | MCP服务的远端服务地址详情，仅在非`stdio`协议时生效 |
 
 其中`serverSpecification`、`toolSpecification`、`endpointSpecification`参数的详细内容如下：
 
 > serverSpecification
 
-| 参数名                  | 参数类型                  | 描述                                                                                              |
+| Name                  | Type                  | Description                                                                                              |
 |----------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `id`                 | `string` | MCP服务的ID，一般为UUID，无需传入，系统自动生成。                                                                   |
 | `name`               | `string` | MCP服务名。                                                                                         |
@@ -3502,7 +3502,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
@@ -3510,7 +3510,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 > toolSpecification
 
-| 参数名               | 参数类型                       | 描述                                                                                      |
+| Name               | Type                       | Description                                                                                      |
 |-------------------|----------------------------|-----------------------------------------------------------------------------------------|
 | `tools`           | `List<McpTool>`            | 该MCP Server所提供的工具列表，参考标准MCP协议中对于MCP Tool的定义                                             |
 | `toolsMeta`       | `Map<String, McpToolMeta>` | 该MCP Server所提供的工具的额外元数据信息，可用于扩展标准MCP协议中未定义但又使用中需要的信息。key为`McpTool`的`name`, value为拓展元数据。 |
@@ -3518,15 +3518,15 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 其中`McpTool`结构如下：
 
-| 参数名           | 参数类型                  | 描述                                            |
+| Name           | Type                  | Description                                            |
 |---------------|-----------------------|-----------------------------------------------|
 | `name`        | `string` | MCP 工具的名称                                     |
 | `description` | `string` | MCP 工具的描述                                     |
-| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`类型`,`是否必须`,`描述` 等。 |
+| `inputSchema` | `Map<String, Object>` | MCP工具的入参描述，参考标准MCP协议，主要包含，`Type`,`是否必须`,`Description` 等。 |
 
 其中`McpToolMeta` 结构如下：
 
-| 参数名             | 参数类型                  | 描述                             |
+| Name             | Type                  | Description                             |
 |-----------------|-----------------------|--------------------------------|
 | `invokeContext` | `map<string, string>` | MCP 工具调用时的上下文信息，如后端服务的`Path`等。 |
 | `enabled`       | `boolean` | MCP工具是否启用。                     |
@@ -3534,7 +3534,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 其中`SecurityScheme` 结构如下：
 
-| 参数名                 | 参数类型     | 描述                                                                                |
+| Name                 | Type     | Description                                                                                |
 |---------------------|----------|-----------------------------------------------------------------------------------|
 | `id`                | `string` | 安全方案的ID，将被MCP工具使用和引用。。                                                            |
 | `type`              | `string` | 安全方案的类型。可能的值包括：`http`、`apiKey`、`localEnv`或其他自定义扩展。                                |
@@ -3545,22 +3545,22 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 > endpointSpecification
 
-| 参数名    | 参数类型                  | 描述                                                                                                                               |
+| Name    | Type                  | Description                                                                                                                               |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `type` | `string` | MCP endpoint的后端服务类型，可选值`REF`和`DIRECT`.                                                                                           |
 | `data` | `map<string, string>` | MCP endpoint的后端服务的实际数据， 根据`type`的不同，传入的参数不同，如`REF`传入的为`namespaceId`, `groupName` 和 `serviceName`；`DIRECT`传入的为`address` 和 `port`。 |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | 新建MCP服务的id。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp' \
@@ -3568,7 +3568,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 -d 'mcpName=test' \
 -d 'serverSpecification={"protocol":"stdio","frontProtocol":"stdio","name":"test","id":"","description":"ceshi","versionDetail":{"version":"1.0.0"},"enabled":true,"localServerConfig":{"test":{}}}'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3580,52 +3580,52 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp' \
 
 ### 4.4. 删除MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的MCP服务。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                       |
+| Name           | Type     | Required  | Description                                       |
 |---------------|----------|-------|------------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                 |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                 |
 | `mcpId`       | `string` | One of two required | MCP service ID (usually UUID). One of `mcpId` and `mcpName` must be provided (OpenAPI cannot express this constraint; at least one is required in practice). Prefer `mcpId`. |
 | `mcpName`     | `string` | One of two required | MCP service name template. One of `mcpId` and `mcpName` must be provided; prefer `mcpId`.    |
-| `version`     | `string` | 否     | MCP服务的版本，未传入是为最新版本                       |
+| `version`     | `string` | No     | MCP服务的版本，未传入是为最新版本                       |
 
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述         |
+| Name    | Type     | Description         |
 |--------|----------|------------|
 | `data` | `string` | MCP服务删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpName=test&mcpId=d7a64724-a556-4fe4-82fa-e806d43e00dc'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3637,41 +3637,41 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpNa
 
 ### 4.5. 查询MCP服务的服务列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的MCP服务的服务列表。
 
-#### 起始版本
+#### Since
 
 `3.0.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                                     |
+| Name           | Type     | Required  | Description                                                     |
 |---------------|----------|-------|--------------------------------------------------------|
-| `pageNo`      | `integer` | **是** | 当前页，默认为`1`                                             |
-| `pageSize`    | `integer` | **是** | 页条目数，默认为`20`，最大为`500`                                  |
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID，默认为`public`                               |
-| `mcpName`     | `string`   | 否     | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
-| `search`      | `string` | 否     | blur or accurate                  |
+| `pageNo`      | `integer` | **Yes** | 当前页，默认为`1`                                             |
+| `pageSize`    | `integer` | **Yes** | 页条目数，默认为`20`，最大为`500`                                  |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID，默认为`public`                               |
+| `mcpName`     | `string`   | No     | MCP服务的名字模版，为空时查询所有MCP服务，当`search`为`blur`时，可使用`*`进行模糊搜索 |
+| `search`      | `string` | No     | blur or accurate                  |
 
-#### 返回数据
+#### Response Data
 
-返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-统一返回体格式)，下表只阐述`data`字段中的返回参数。
+返回体遵循[Nacos open API 统一返回体格式](../user/overview/api-overview.md#32-http-api-response-format)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                           | 参数类型                  | 描述                                                                                              |
+| Name                                           | Type                  | Description                                                                                              |
 |-----------------------------------------------|-----------------------|-------------------------------------------------------------------------------------------------|
 | `totalCount`                                  | `integer` | 符合条件的服务的总数。                                                                                     |
 | `pageNumber`                                  | `integer` | 当前页码，起始为`1`。                                                                                    |
@@ -3692,20 +3692,20 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/mcp?namespaceId=public&mcpNa
 
 其中`VersionDetail`结构如下：
 
-| 参数名            | 参数类型      | 描述               |
+| Name            | Type      | Description               |
 |----------------|-----------|------------------|
 | `version`      | `string` | MCP服务的版本号。       |
 | `release_date` | `string` | MCP服务的版本发布时间。    |
 | `is_latest`    | `boolean` | MCP服务的版本是否为最新版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3748,51 +3748,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/list?pageNo=1&pageSize=100&
 
 ### 4.6. 导入MCP工具
 
-#### 接口描述
+#### Description
 
 通过该接口，可以通过指定MCP`URL`的方式直接获取MCP工具并导入，避免逐个填写。
 
-#### 起始版本
+#### Since
 
 `3.0.3`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/importToolsFromMcp`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名             | 参数类型     | 是否必填  | 描述                                      |
+| Name             | Type     | Required  | Description                                      |
 |-----------------|----------|-------|-----------------------------------------|
-| `transportType` | `string` | **是** | MCP服务的传输协议类型，`mcp-sse`或`mcp-streamable` |
-| `baseUrl`       | `string` | **是** | MCP服务的baseURL                           |
-| `endpoint`      | `string` | **是** | MCP服务的可访问端点                             |
-| `authToken`     | `string` | 否     | MCP服务访问的身份Token                         |
+| `transportType` | `string` | **Yes** | MCP服务的传输协议类型，`mcp-sse`或`mcp-streamable` |
+| `baseUrl`       | `string` | **Yes** | MCP服务的baseURL                           |
+| `endpoint`      | `string` | **Yes** | MCP服务的可访问端点                             |
+| `authToken`     | `string` | No     | MCP服务访问的身份Token                         |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型                   | 描述                                                                                                       |
+| Name    | Type                   | Description                                                                                                       |
 |--------|------------------------|----------------------------------------------------------------------------------------------------------|
 | `data` | `List<McpSchema.Tool>` | MCP工具元数据信息,符合[MCP工具元数据标准定义](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool)。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transportType=mcp-sse&baseUrl=%2Fsse&endpoint=http%3A%2F%2Flocalhost'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3818,42 +3818,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transpor
 
 ### 4.7. 验证待导入的MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以验证当前待导入的MCP服务内容是否符合规则，返回的内容中包含有效个数和无效个数，无效的服务在对应字段中有错误信息。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/import/validate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                      |
+| Name           | Type     | Required  | Description                                      |
 |---------------|----------|-------|-----------------------------------------|
-| `namespaceId` | `string` | 否     | MCP服务的命名空间ID                            |
-| `importType`  | `string` | **是** | enum of `file`, `json`, `url`           |
-| `data`        | `string` | **是** | 导入数据的内容                                 |
-| `cursor`      | `string` | 否     | Optional start cursor for URL-based import pagination. |
-| `limit`       | `integer` | 否     | 分页的页大小                                  |
-| `search`      | `string`   | 否     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
+| `namespaceId` | `string` | No     | MCP服务的命名空间ID                            |
+| `importType`  | `string` | **Yes** | enum of `file`, `json`, `url`           |
+| `data`        | `string` | **Yes** | 导入数据的内容                                 |
+| `cursor`      | `string` | No     | Optional start cursor for URL-based import pagination. |
+| `limit`       | `integer` | No     | 分页的页大小                                  |
+| `search`      | `string`   | No     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名              | 参数类型                            | 描述        |
+| Name              | Type                            | Description        |
 |------------------|---------------------------------|-----------|
 | `valid`          | `boolean` | 导入服务是否合法。 |
 | `totalCount`     | `integer` | 导入服务总数。   |
@@ -3863,9 +3863,9 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transpor
 | `servers`        | `List<McpServerValidationItem>` | 导入服务列表。   |
 | `errors`         | `List<String>`                  | 导入服务错误列表。 |
 
-其中`McpServerValidationItem`描述如下:
+其中 `McpServerValidationItem` 描述如下:
 
-| 参数名          | 参数类型      | 描述       |
+| Name          | Type      | Description       |
 |--------------|-----------|----------|
 | `serverName` | `string` | 服务名称。    |
 | `serverId`   | `string` | 服务ID。    |
@@ -3873,9 +3873,9 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/mcp/importToolsFromMcp?transpor
 | `selected`   | `boolean` | 服务是否被选中。 |
 | `exists`     | `boolean` | 服务是否已存在。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
@@ -3884,7 +3884,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 -d 'data=' \
 -d 'limit=10'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -3916,46 +3916,46 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 
 ### 4.8. 导入的MCP服务
 
-#### 接口描述
+#### Description
 
 通过该接口，可以通过`文件`,`JSON`和指定MCP`URL`的方式直接导入MCP服务，避免逐个填写。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/mcp/import/execute`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型      | 是否必填  | 描述                                      |
+| Name                | Type      | Required  | Description                                      |
 |--------------------|-----------|-------|-----------------------------------------|
-| `namespaceId`      | `string` | 否     | MCP服务的命名空间ID                            |
-| `importType`       | `string` | **是** | enum of `file`, `json`, `url`           |
-| `data`             | `string` | **是** | 导入数据的内容                                 |
-| `cursor`           | `string` | 否     | Optional start cursor for URL-based import pagination. |
-| `limit`            | `integer` | 否     | 分页的页大小                                  |
-| `search`           | `string`    | 否     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
-| `overrideExisting` | `boolean` | 否     | 导入时若服务已存在时是否覆盖。默认为`false`。              |                                    |
-| `skipInvalid`      | `boolean` | 否     | 导入时是否忽略错误无效的服务。默认为`false`。              |
-| `selectedServers`  | `array` | 否     | Selected services to import. Empty means importing all services. |
+| `namespaceId`      | `string` | No     | MCP服务的命名空间ID                            |
+| `importType`       | `string` | **Yes** | enum of `file`, `json`, `url`           |
+| `data`             | `string` | **Yes** | 导入数据的内容                                 |
+| `cursor`           | `string` | No     | Optional start cursor for URL-based import pagination. |
+| `limit`            | `integer` | No     | 分页的页大小                                  |
+| `search`           | `string`    | No     | Optional fuzzy search keyword for registry import listing. Only used when importType is 'url'. |
+| `overrideExisting` | `boolean` | No     | 导入时若服务已存在时是否覆盖。默认为`false`。              |                                    |
+| `skipInvalid`      | `boolean` | No     | 导入时是否忽略错误无效的服务。默认为`false`。              |
+| `selectedServers`  | `array` | No     | Selected services to import. Empty means importing all services. |
 
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名            | 参数类型                          | 描述        |
+| Name            | Type                          | Description        |
 |----------------|-------------------------------|-----------|
 | `success`      | `boolean` | 导入服务是否成功。 |
 | `totalCount`   | `integer` | 导入服务总数。   |
@@ -3964,9 +3964,9 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 | `skippedCount` | `integer` | 导入服务跳过个数。 |
 | `results`      | `List<McpServerImportResult>` | 导入服务列表。   |
 
-其中`McpServerImportResult`描述如下:
+其中 `McpServerImportResult` 描述如下:
 
-| 参数名            | 参数类型      | 描述                     |
+| Name            | Type      | Description                     |
 |----------------|-----------|------------------------|
 | `serverName`   | `string` | 服务名称。                  |
 | `serverId`     | `string` | 服务ID。                  |
@@ -3974,9 +3974,9 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/validate' \
 | `errorMessage` | `boolean` | 服务导入失败的错误信息，仅在导入失败时存在。 |
 
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
@@ -3988,7 +3988,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
 -d 'selectedServers=[]' \
 -d 'limit=10'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4017,41 +4017,41 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
 
 ### 5.1. 查询AgentCard的列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上的AgentCard的列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                                              |
+| Name           | Type     | Required  | Description                                              |
 |---------------|----------|-------|-------------------------------------------------|
-| `pageNo`      | `integer` | **是** | 当前页，默认为`1`                                      |
-| `pageSize`    | `integer` | **是** | 页条目数，默认为`100`                                   |
-| `namespaceId` | `string` | 否     | AgentCard的命名空间ID，默认为`public`                    |
-| `agentName`   | `string` | 否     | AgentCard的名称，为空是查询所有AgentCard                   |
-| `search`      | `string` | **是** | blur or accurate |
+| `pageNo`      | `integer` | **Yes** | 当前页，默认为`1`                                      |
+| `pageSize`    | `integer` | **Yes** | 页条目数，默认为`100`                                   |
+| `namespaceId` | `string` | No     | AgentCard的命名空间ID，默认为`public`                    |
+| `agentName`   | `string` | No     | AgentCard的名称，为空是查询所有AgentCard                   |
+| `search`      | `string` | **Yes** | blur or accurate |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                     | 参数类型                       | 描述                                                                                                     |
+| Name                                     | Type                       | Description                                                                                                     |
 |-----------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------|
 | `totalCount`                            | `integer` | 符合条件的服务的总数。                                                                                            |
 | `pageNumber`                            | `integer` | 当前页码，起始为`1`。                                                                                           |
@@ -4070,21 +4070,21 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/mcp/import/execute' \
 
 其中`AgentVersionDetail`包含内容如下：
 
-| 参数名         | 参数类型      | 描述              |
+| Name         | Type      | Description              |
 |-------------|-----------|-----------------|
 | `version`   | `string` | AgentCard的版本号。  |
 | `createdAt` | `string` | 该版本的创建时间。       |
 | `updatedAt` | `string` | 该版本的最后更新时间。     |
 | `latest`    | `boolean` | 该版本是否标记为最新发布版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/list?pageNo=1&pageSize=100&namespaceId=public&search=blur'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4138,52 +4138,52 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/list?pageNo=1&pageSize=100&
 
 ### 5.2. 查询指定AgentCard的版本列表
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询指定托管在Nacos上的AgentCard的版本列表。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a/version/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                   | 参数类型      | 描述              |
+| Name                   | Type      | Description              |
 |-----------------------|-----------|-----------------|
 | `data`[i].`version`   | `string` | AgentCard的版本号。  |
 | `data`[i].`createdAt` | `string` | 该版本的创建时间。       |
 | `data`[i].`updatedAt` | `string` | 该版本的最后更新时间。     |
 | `data`[i].`latest`    | `boolean` | 该版本是否标记为最新发布版本。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/version/list?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4200,40 +4200,40 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/version/list?namespaceId=pu
 
 ### 5.3. 查询AgentCard的详情
 
-#### 接口描述
+#### Description
 
 通过该接口，可以查询托管在Nacos上指定AgentCard的详细信息。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型     | 是否必填  | 描述                                                                                 |
+| Name                | Type     | Required  | Description                                                                                 |
 |--------------------|----------|-------|------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                        |
-| `agentName`        | `string` | **是** | AgentCard的名称                                                                       |
-| `version`          | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情                                                          |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                        |
+| `agentName`        | `string` | **Yes** | AgentCard的名称                                                                       |
+| `version`          | `string` | No     | AgentCard的版本号，为空时返回最新版本详情                                                          |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成 |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名                                 | 参数类型                              | 描述                                                                                                       |
+| Name                                 | Type                              | Description                                                                                                       |
 |-------------------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------|
 | `protocolVersion`                   | `string` | AgentCard的A2A协议版本。                                                                                       |
 | `name`                              | `string` | AgentCard的名称。                                                                                            |
@@ -4256,14 +4256,14 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a/version/list?namespaceId=pu
 | `latestVersion`                     | `string` | AgentCard当前版本时否为最新版本。                                                                                    |
 
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0&registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4335,47 +4335,47 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agentNam
 
 ### 5.4. 更新AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以更新托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                                                     |
-| `agentCard`        | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成                              |
-| `setAsLatest`      | `boolean` | 否     | 是否设置此版本为最新发布版本，默认为false                                                                                         |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                                                     |
+| `agentCard`        | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成                              |
+| `setAsLatest`      | `boolean` | No     | 是否设置此版本为最新发布版本，默认为false                                                                                         |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述               |
+| Name    | Type     | Description               |
 |--------|----------|------------------|
 | `data` | `string` | AgentCard服务更新结果。 |
 
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/a2a' \
@@ -4384,7 +4384,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 -d 'registrationType=SERVICE' \
 -d 'setAsLatest=true'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4396,45 +4396,45 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 
 ### 5.5. 创建AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以创建托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 参数类型        | 是否必填  | 描述                                                                                                              |
+| Name                | Type        | Required  | Description                                                                                                              |
 |--------------------|-------------|-------|-----------------------------------------------------------------------------------------------------------------|
-| `namespaceId`      | `string` | 否     | AgentCard所属的命名空间，默认`public`                                                                                     |
-| `agentCard`        | `string` | **是** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
-| `registrationType` | `string` | 否     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认值为`URL`                   |
+| `namespaceId`      | `string` | No     | AgentCard所属的命名空间，默认`public`                                                                                     |
+| `agentCard`        | `string` | **Yes** | AgentCard的完整对象，详情请参考[标准AgentCard](https://a2a-protocol.org/latest/specification/#55-agentcard-object-structure) |
+| `registrationType` | `string` | No     | AgentCard的默认注册类型，可选`URL`和`SERVICE`。未填写时根据此AgentCard的默认`registrationType`进行`url`的生成, 默认为`URL`                   |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard发布结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/a2a' \
@@ -4442,7 +4442,7 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 -d 'agentCard={"protocolVersion":"0.2.9","name":"GeoSpatial Route Planner Agent","description":"Provides advanced route planning, traffic analysis, and custom map generation services. This agent can calculate optimal routes, estimate travel times considering real-time traffic, and create personalized maps with points of interest.","url":"https://georoute-agent.example.com/a2a/v1","preferredTransport":"JSONRPC","additionalInterfaces":[{"url":"https://georoute-agent.example.com/a2a/v1","transport":"JSONRPC"},{"url":"https://georoute-agent.example.com/a2a/grpc","transport":"GRPC"},{"url":"https://georoute-agent.example.com/a2a/json","transport":"HTTP+JSON"}],"provider":{"organization":"Example Geo Services Inc.","url":"https://www.examplegeoservices.com"},"iconUrl":"https://georoute-agent.example.com/icon.png","version":"1.2.0","documentationUrl":"https://docs.examplegeoservices.com/georoute-agent/api","capabilities":{"streaming":true,"pushNotifications":true,"stateTransitionHistory":false},"securitySchemes":{"google":{"type":"openIdConnect","openIdConnectUrl":"https://accounts.google.com/.well-known/openid-configuration"}},"security":[{"google":["openid","profile","email"]}],"defaultInputModes":["application/json","text/plain"],"defaultOutputModes":["application/json","image/png"],"skills":[{"id":"route-optimizer-traffic","name":"Traffic-Aware Route Optimizer","description":"Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).","tags":["maps","routing","navigation","directions","traffic"],"examples":["Plan a route from '1600 Amphitheatre Parkway, Mountain View, CA' to 'San Francisco International Airport' avoiding tolls.","{\"origin\": {\"lat\": 37.422, \"lng\": -122.084}, \"destination\": {\"lat\": 37.7749, \"lng\": -122.4194}, \"preferences\": [\"avoid_ferries\"]}"],"inputModes":["application/json","text/plain"],"outputModes":["application/json","application/vnd.geo+json","text/html"]},{"id":"custom-map-generator","name":"Personalized Map Generator","description":"Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.","tags":["maps","customization","visualization","cartography"],"examples":["Generate a map of my upcoming road trip with all planned stops highlighted.","Show me a map visualizing all coffee shops within a 1-mile radius of my current location."],"inputModes":["application/json"],"outputModes":["image/png","image/jpeg","application/json","text/html"]}],"supportsAuthenticatedExtendedCard":true,"signatures":[{"protected":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0","signature":"QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ"}]}' \
 -d 'registrationType=SERVICE'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4454,50 +4454,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/a2a' \
 
 ### 5.6. 删除AgentCard
 
-#### 接口描述
+#### Description
 
 通过该接口，可以删除托管在Nacos上的AgentCard。
 
-#### 起始版本
+#### Since
 
 `3.1.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/a2a`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名           | 参数类型     | 是否必填  | 描述                          |
+| Name           | Type     | Required  | Description                          |
 |---------------|----------|-------|-----------------------------|
-| `namespaceId` | `string` | 否     | AgentCard所属的命名空间，默认`public` |
-| `agentName`   | `string` | **是** | AgentCard的名称                |
-| `version`     | `string` | 否     | AgentCard的版本号，为空时返回最新版本详情   |
+| `namespaceId` | `string` | No     | AgentCard所属的命名空间，默认`public` |
+| `agentName`   | `string` | **Yes** | AgentCard的名称                |
+| `version`     | `string` | No     | AgentCard的版本号，为空时返回最新版本详情   |
 
-#### 返回数据
+#### Response Data
 
 返回体遵循[Nacos open API 统一返回体格式](#01-统一返回体格式)，下表只阐述`data`字段中的返回参数。
 
-| 参数名    | 参数类型     | 描述             |
+| Name    | Type     | Description             |
 |--------|----------|----------------|
 | `data` | `string` | AgentCard删除结果。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent&version=1.0.0'
 ```
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4512,49 +4512,49 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/a2a?namespaceId=public&agent
 Prompt 管理 API 提供 Prompt 的草稿、发布、上下线、治理查询、版本查询与下载能力。
 
 ### 6.1. Delete Prompt
-#### 接口描述
+#### Description
 This interface allows deleting a specific Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `boolean` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4566,50 +4566,50 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt?namespaceId=public&pr
 
 
 ### 6.2. Update Prompt Biz Tags
-#### 接口描述
+#### Description
 This interface updates Prompt biz tags.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `bizTags` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `bizTags` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/biz-tags' -d "namespaceId=namespaceId&promptKey=promptKey&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4621,50 +4621,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/biz-tags' -d "namespaceI
 
 
 ### 6.3. Update Prompt Description
-#### 接口描述
+#### Description
 This interface updates the Prompt description.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/description`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `description` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `description` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/description' -d "namespaceId=namespaceId&promptKey=promptKey&description=description"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4676,56 +4676,56 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/description' -d "namespa
 
 
 ### 6.4. Create Prompt Draft
-#### 接口描述
+#### Description
 This interface creates a Prompt draft version or forks a draft from an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `basedOnVersion` | `string` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `template` | `string` | 否 | - |
-| `variables` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
-| `description` | `string` | 否 | - |
-| `bizTags` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `basedOnVersion` | `string` | No | - |
+| `targetVersion` | `string` | No | - |
+| `template` | `string` | No | - |
+| `variables` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
+| `description` | `string` | No | - |
+| `bizTags` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=namespaceId&promptKey=promptKey&basedOnVersion=basedOnVersion&targetVersion=targetVersion&template=template&variables=variables&commitMsg=commitMsg&description=description&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4737,52 +4737,52 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=
 
 
 ### 6.5. Update Prompt Draft
-#### 接口描述
+#### Description
 This interface updates the current Prompt draft content.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `template` | `string` | **是** | - |
-| `variables` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `template` | `string` | **Yes** | - |
+| `variables` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=namespaceId&promptKey=promptKey&template=template&variables=variables&commitMsg=commitMsg"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4794,49 +4794,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/draft' -d "namespaceId=n
 
 
 ### 6.6. Delete Prompt Draft
-#### 接口描述
+#### Description
 This interface deletes the current Prompt draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt/draft?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4848,51 +4848,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/prompt/draft?namespaceId=pub
 
 
 ### 6.7. Force Publish Prompt Version
-#### 接口描述
+#### Description
 This interface force-publishes a Prompt version by bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/force-publish' -d "namespaceId=namespaceId&promptKey=promptKey&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4904,35 +4904,35 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/force-publish' -d "name
 
 
 ### 6.8. Get Prompt Governance Detail
-#### 接口描述
+#### Description
 This interface retrieves Prompt metadata, version governance information, and version summaries.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/governance`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -4951,15 +4951,15 @@ This interface retrieves Prompt metadata, version governance information, and ve
 | data.data.versions | `array` | - |
 | data.data.versionDetails | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/governance?namespaceId=public&promptKey=my-prompt'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -4971,50 +4971,50 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/governance?namespaceId=p
 
 
 ### 6.9. Update Prompt Labels
-#### 接口描述
+#### Description
 This interface updates runtime routing labels of a Prompt.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `labels` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `labels` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/labels' -d "namespaceId=namespaceId&promptKey=promptKey&labels=labels"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5026,53 +5026,53 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/prompt/labels' -d "namespaceId=
 
 
 ### 6.10. List Prompts
-#### 接口描述
+#### Description
 This interface allows listing Prompts with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | 否 | - |
-| `search` | `string` | 否 | blur or accurate |
-| `bizTags` | `string` | 否 | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | No | - |
+| `search` | `string` | No | blur or accurate |
+| `bizTags` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/list?pageNo=1&pageSize=10&namespaceId=public&promptKey=my-prompt&search=blur&bizTags=tag-a'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5084,50 +5084,50 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/list?pageNo=1&pageSize=1
 
 
 ### 6.11. Offline Prompt Version
-#### 接口描述
+#### Description
 This interface takes a specified Prompt version offline.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/offline' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5139,50 +5139,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/offline' -d "namespaceI
 
 
 ### 6.12. Online Prompt Version
-#### 接口描述
+#### Description
 This interface brings a specified Prompt version online.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/online' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5194,51 +5194,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/online' -d "namespaceId
 
 
 ### 6.13. Publish Prompt Version
-#### 接口描述
+#### Description
 This interface publishes an approved Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/publish' -d "namespaceId=namespaceId&promptKey=promptKey&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5250,50 +5250,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/publish' -d "namespaceI
 
 
 ### 6.14. Redraft Prompt Version
-#### 接口描述
+#### Description
 This interface transitions a reviewed Prompt version back to draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/redraft' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5305,50 +5305,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/redraft' -d "namespaceI
 
 
 ### 6.15. Submit Prompt Version
-#### 接口描述
+#### Description
 This interface submits a Prompt version for pipeline review.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/submit' -d "namespaceId=namespaceId&promptKey=promptKey&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5360,36 +5360,36 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/prompt/submit' -d "namespaceId
 
 
 ### 6.16. Get Prompt Version Detail
-#### 接口描述
+#### Description
 This interface retrieves details of a specified Prompt version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -5405,15 +5405,15 @@ This interface retrieves details of a specified Prompt version.
 | data.data.md5 | `string` | - |
 | data.data.variables | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version?namespaceId=public&promptKey=my-prompt&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5425,42 +5425,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version?namespaceId=publ
 
 
 ### 6.17. Download Prompt Version
-#### 接口描述
+#### Description
 This interface downloads a specified Prompt version as a Markdown file.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version/download?namespaceId=public&promptKey=my-prompt&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5472,51 +5472,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/version/download?namespa
 
 
 ### 6.18. List Prompt Versions
-#### 接口描述
+#### Description
 This interface allows listing versions of a specific Prompt with pagination.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/prompt/versions`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `promptKey` | `string` | **是** | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `promptKey` | `string` | **Yes** | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/versions?namespaceId=public&promptKey=my-prompt&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5531,36 +5531,36 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/prompt/versions?namespaceId=pub
 Skills 管理 API 提供 Skill 的查询、草稿、发布、上下线、版本管理与 ZIP 上传能力。
 
 ### 7.1. Get Skill Details
-#### 接口描述
+#### Description
 This interface allows retrieving detailed information of a specific Skill hosted on Nacos.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -5580,15 +5580,15 @@ This interface allows retrieving detailed information of a specific Skill hosted
 | data.data.downloadCount | `integer` | - |
 | data.data.versions | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5600,50 +5600,50 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&skill
 
 
 ### 7.2. Delete Skill
-#### 接口描述
+#### Description
 This interface allows deleting a Skill hosted on Nacos.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5655,50 +5655,50 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills?namespaceId=public&sk
 
 
 ### 7.3. Update Skill Business Tags
-#### 接口描述
+#### Description
 This interface allows updating the business tag list of a skill without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `bizTags` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `bizTags` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/biz-tags' -d "namespaceId=public&skillName=my-skill&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5710,52 +5710,52 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/biz-tags' -d "namespaceI
 
 
 ### 7.4. Create Skill Draft Version
-#### 接口描述
+#### Description
 This interface allows creating a draft version based on an existing version or a brand-new SkillCard.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | 否 | - |
-| `basedOnVersion` | `string` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `skillCard` | `string` | 否 | Skill card JSON; required if basedOnVersion is not set |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | No | - |
+| `basedOnVersion` | `string` | No | - |
+| `targetVersion` | `string` | No | - |
+| `skillCard` | `string` | No | Skill card JSON; required if basedOnVersion is not set |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=public&skillName=my-skill&basedOnVersion=basedOnVersion&targetVersion=targetVersion&skillCard=skillCard"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5767,50 +5767,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=
 
 
 ### 7.5. Update Skill Draft Content
-#### 接口描述
+#### Description
 This interface allows updating the SkillCard content of the current draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `skillCard` | `string` | **是** | Skill card JSON string containing complete Skill information |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `skillCard` | `string` | **Yes** | Skill card JSON string containing complete Skill information |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=public&skillName=my-skill&skillCard=skillCard"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5822,49 +5822,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/draft' -d "namespaceId=p
 
 
 ### 7.6. Delete Skill Draft Version
-#### 接口描述
+#### Description
 This interface allows deleting the current draft version of a specified skill.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills/draft?namespaceId=public&skillName=my-skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5876,51 +5876,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/skills/draft?namespaceId=pub
 
 
 ### 7.7. Force Publish Skill Version
-#### 接口描述
+#### Description
 This interface force-publishes a Skill version by bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/force-publish' -d "namespaceId=public&skillName=my-skill&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5932,50 +5932,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/force-publish' -d "name
 
 
 ### 7.8. Update Skill Version Labels
-#### 接口描述
+#### Description
 This interface allows updating skill version routing labels (e.g. latest label) without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `labels` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `labels` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/labels' -d "namespaceId=public&skillName=my-skill&labels=labels"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -5987,53 +5987,53 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/labels' -d "namespaceId=
 
 
 ### 7.9. List Skills
-#### 接口描述
+#### Description
 This interface allows querying the list of Skills hosted on Nacos.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `filterableForm` | `string` | **是** | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | 否 | - |
-| `search` | `string` | 否 | blur or accurate |
+| `filterableForm` | `string` | **Yes** | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | No | - |
+| `search` | `string` | No | blur or accurate |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?filterableForm=true&pageNo=1&pageSize=10&namespaceId=public&skillName=my-skill&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6045,51 +6045,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/list?filterableForm=true
 
 
 ### 7.10. Offline Skill
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire skill, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'skill' for skill-level offline; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'skill' for skill-level offline; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/offline' -d "namespaceId=public&skillName=my-skill&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6101,51 +6101,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/offline' -d "namespaceI
 
 
 ### 7.11. Online Skill
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire skill, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'skill' for skill-level online; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'skill' for skill-level online; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/online' -d "namespaceId=public&skillName=my-skill&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6157,51 +6157,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/online' -d "namespaceId
 
 
 ### 7.12. Publish Skill Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved skill version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/publish' -d "namespaceId=public&skillName=my-skill&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6213,50 +6213,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/publish' -d "namespaceI
 
 
 ### 7.13. Redraft Skill Version
-#### 接口描述
+#### Description
 This interface transitions a reviewed Skill version back to draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/redraft' -d "namespaceId=public&skillName=my-skill&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6268,50 +6268,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/redraft' -d "namespaceI
 
 
 ### 7.14. Update Skill Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of a skill to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/scope' -d "namespaceId=public&skillName=my-skill&scope=scope"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6323,50 +6323,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/skills/scope' -d "namespaceId=p
 
 
 ### 7.15. Submit Skill Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting a skill draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/submit' -d "namespaceId=public&skillName=my-skill&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6378,61 +6378,61 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/submit' -d "namespaceId
 
 
 ### 7.16. Upload Skill (ZIP)
-#### 接口描述
+#### Description
 This interface allows uploading a Skill from a ZIP file.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`（如文件上传），请求示例中需使用 `-F` 或 `-H 'Content-Type: multipart/form-data'`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
+| `targetVersion` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `file` | `file` | 否 | ZIP file containing skill |
-| `overwrite` | `boolean` | 否 | - |
-| `namespaceId` | `string` | 否 | - |
-| `targetVersion` | `string` | 否 | - |
-| `commitMsg` | `string` | 否 | - |
+| `file` | `file` | No | ZIP file containing skill |
+| `overwrite` | `boolean` | No | - |
+| `namespaceId` | `string` | No | - |
+| `targetVersion` | `string` | No | - |
+| `commitMsg` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload?namespaceId=public&overwrite=false&targetVersion=1.0.0&commitMsg=init' -F "file=@/path/to/skill.zip" -F "overwrite=false" -F "namespaceId=public" -F "targetVersion=1.0.0" -F "commitMsg=init"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6444,58 +6444,58 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload?namespaceId=publ
 
 
 ### 7.17. Batch Upload Skills
-#### 接口描述
+#### Description
 This interface uploads multiple Skills from a ZIP file that contains one-level Skill subdirectories.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`（如文件上传），请求示例中需使用 `-F` 或 `-H 'Content-Type: multipart/form-data'`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/upload/batch`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
-| `file` | `file` | 否 | ZIP file containing skill directories |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
+| `file` | `file` | No | ZIP file containing skill directories |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data.succeeded | `array` | - |
 | data.data.failed | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload/batch?namespaceId=public&overwrite=false' -F "namespaceId=public" -F "overwrite=false" -F "file=@/path/to/skills.zip"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6507,36 +6507,36 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/skills/upload/batch?namespaceI
 
 
 ### 7.18. Get Skill Version Detail
-#### 接口描述
+#### Description
 This interface allows querying the detail of a specific Skill version by namespace, skill name, and version number.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -6546,15 +6546,15 @@ This interface allows querying the detail of a specific Skill version by namespa
 | data.data.skillMd | `string` | - |
 | data.data.resource | `object` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6566,42 +6566,42 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version?namespaceId=publ
 
 
 ### 7.19. Download Skill Version ZIP
-#### 接口描述
+#### Description
 This interface allows downloading the ZIP package of a specific Skill version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/skills/version/download`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `skillName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `skillName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version/download?namespaceId=public&skillName=my-skill&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6616,36 +6616,36 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/skills/version/download?namespa
 AgentSpec 管理 API 提供 AgentSpec 的查询、草稿、发布、上下线、版本管理与 ZIP 上传能力。
 
 ### 8.1. Get AgentSpec
-#### 接口描述
+#### Description
 This interface allows getting the latest published version of an AgentSpec by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -6664,15 +6664,15 @@ This interface allows getting the latest published version of an AgentSpec by na
 | data.data.downloadCount | `integer` | - |
 | data.data.versions | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=public&agentSpecName=my-agent&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6684,49 +6684,49 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=public&a
 
 
 ### 8.2. Delete AgentSpec
-#### 接口描述
+#### Description
 This interface allows deleting an AgentSpec and all its versions by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=public&agentSpecName=my-agent'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6738,50 +6738,50 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs?namespaceId=publi
 
 
 ### 8.3. Update AgentSpec Business Tags
-#### 接口描述
+#### Description
 This interface allows updating the business tag list of an AgentSpec without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/biz-tags`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `bizTags` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `bizTags` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/biz-tags' -d "namespaceId=public&agentSpecName=my-agent&bizTags=bizTags"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6793,50 +6793,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/biz-tags' -d "namesp
 
 
 ### 8.4. Create AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows creating an AgentSpec draft version based on an existing version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `basedOnVersion` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `basedOnVersion` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agent&basedOnVersion=basedOnVersion"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6848,50 +6848,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespac
 
 
 ### 8.5. Update AgentSpec Draft Content
-#### 接口描述
+#### Description
 This interface allows updating the card content of the current AgentSpec draft version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | 否 | - |
-| `agentSpecCard` | `string` | **是** | AgentSpec card JSON string containing complete AgentSpec information |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | No | - |
+| `agentSpecCard` | `string` | **Yes** | AgentSpec card JSON string containing complete AgentSpec information |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespaceId=public&agentSpecName=my-agent&agentSpecCard=agentSpecCard"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6903,49 +6903,49 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft' -d "namespace
 
 
 ### 8.6. Delete AgentSpec Draft Version
-#### 接口描述
+#### Description
 This interface allows deleting the current draft version of a specified AgentSpec.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `DELETE`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/draft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft?namespaceId=public&agentSpecName=my-agent'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -6957,51 +6957,51 @@ curl -X DELETE 'http://127.0.0.1:8080/v3/console/ai/agentspecs/draft?namespaceId
 
 
 ### 8.7. Force Publish AgentSpec Version
-#### 接口描述
+#### Description
 This interface force-publishes an AgentSpec version by bypassing pipeline validation.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/force-publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/force-publish' -d "namespaceId=public&agentSpecName=my-agent&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7013,50 +7013,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/force-publish' -d "
 
 
 ### 8.8. Update AgentSpec Version Labels
-#### 接口描述
+#### Description
 This interface allows updating AgentSpec version routing labels (e.g. latest label) without changing version status.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/labels`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `labels` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `labels` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/labels' -d "namespaceId=public&agentSpecName=my-agent&labels=labels"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7068,53 +7068,53 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/labels' -d "namespac
 
 
 ### 8.9. List AgentSpecs
-#### 接口描述
+#### Description
 This interface allows paginated listing of AgentSpecs by namespace and name.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `filterableForm` | `string` | **是** | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | 否 | - |
-| `search` | `string` | 否 | Search mode: accurate or blur |
+| `filterableForm` | `string` | **Yes** | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | No | - |
+| `search` | `string` | No | Search mode: accurate or blur |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/list?filterableForm=true&pageNo=1&pageSize=10&namespaceId=public&agentSpecName=my-agent&search=blur'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7126,51 +7126,51 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/list?filterableForm=
 
 
 ### 8.10. Offline AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an offline operation on a specific version or the entire AgentSpec, making it not callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/offline`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level offline; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level offline; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/offline' -d "namespaceId=public&agentSpecName=my-agent&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7182,51 +7182,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/offline' -d "namesp
 
 
 ### 8.11. Online AgentSpec
-#### 接口描述
+#### Description
 This interface allows executing an online operation on a specific version or the entire AgentSpec, making it callable.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/online`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `scope` | `string` | 否 | Use 'agentspec' for agentspec-level online; otherwise version-level |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `scope` | `string` | No | Use 'agentspec' for agentspec-level online; otherwise version-level |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/online' -d "namespaceId=public&agentSpecName=my-agent&scope=scope&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7238,51 +7238,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/online' -d "namespa
 
 
 ### 8.12. Publish AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows publishing an approved AgentSpec version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/publish`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
-| `updateLatestLabel` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
+| `updateLatestLabel` | `boolean` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/publish' -d "namespaceId=public&agentSpecName=my-agent&version=version&updateLatestLabel=updateLatestLabel"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7294,50 +7294,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/publish' -d "namesp
 
 
 ### 8.13. Redraft AgentSpec Version
-#### 接口描述
+#### Description
 This interface transitions a reviewed AgentSpec version back to draft.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/redraft`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | **是** | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/redraft' -d "namespaceId=public&agentSpecName=my-agent&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7349,50 +7349,50 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/redraft' -d "namesp
 
 
 ### 8.14. Update AgentSpec Visibility Scope
-#### 接口描述
+#### Description
 This interface allows setting the visibility scope of an AgentSpec to PUBLIC or PRIVATE.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `PUT`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/scope`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `scope` | `string` | **是** | PUBLIC or PRIVATE |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `scope` | `string` | **Yes** | PUBLIC or PRIVATE |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/scope' -d "namespaceId=public&agentSpecName=my-agent&scope=scope"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7404,50 +7404,50 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/ai/agentspecs/scope' -d "namespace
 
 
 ### 8.15. Submit AgentSpec Version for Review
-#### 接口描述
+#### Description
 This interface allows submitting an AgentSpec draft version to the pipeline for review.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/submit`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/submit' -d "namespaceId=public&agentSpecName=my-agent&version=version"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7459,57 +7459,57 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/submit' -d "namespa
 
 
 ### 8.16. Upload AgentSpec
-#### 接口描述
+#### Description
 This interface allows uploading a ZIP-packaged AgentSpec; the package is parsed and the AgentSpec is created or updated.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`multipart/form-data`（如文件上传），请求示例中需使用 `-F` 或 `-H 'Content-Type: multipart/form-data'`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/upload`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `overwrite` | `boolean` | 否 | - |
-| `file` | `file` | 否 | ZIP file containing agentspec package |
+| `namespaceId` | `string` | No | - |
+| `overwrite` | `boolean` | No | - |
+| `file` | `file` | No | ZIP file containing agentspec package |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/upload?namespaceId=public&overwrite=false' -F "namespaceId=public" -F "overwrite=false" -F "file=@/path/to/skills.zip"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7521,36 +7521,36 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/agentspecs/upload?namespaceId=
 
 
 ### 8.17. Get AgentSpec Version
-#### 接口描述
+#### Description
 This interface allows getting a specific version of an AgentSpec by namespace, name, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/agentspecs/version`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `agentSpecName` | `string` | **是** | - |
-| `version` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `agentSpecName` | `string` | **Yes** | - |
+| `version` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7561,15 +7561,15 @@ This interface allows getting a specific version of an AgentSpec by namespace, n
 | data.data.content | `string` | - |
 | data.data.resource | `object` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/version?namespaceId=public&agentSpecName=my-agent&version=1.0.0'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7584,53 +7584,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/agentspecs/version?namespaceId=
 Pipeline 管理 API 提供 Pipeline 执行记录列表、详情与实例查询能力。
 
 ### 9.1. List Pipeline Executions
-#### 接口描述
+#### Description
 This interface allows paginated listing of Pipeline execution records by resource type, name, namespace, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | - |
-| `resourceName` | `string` | 否 | - |
-| `namespaceId` | `string` | 否 | - |
-| `version` | `string` | 否 | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
+| `resourceType` | `string` | **Yes** | - |
+| `resourceName` | `string` | No | - |
+| `namespaceId` | `string` | No | - |
+| `version` | `string` | No | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines?resourceType=skill&resourceName=my-skill&namespaceId=public&version=1.0.0&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7642,34 +7642,34 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines?resourceType=skill&re
 
 
 ### 9.2. Get Pipeline Execution
-#### 接口描述
+#### Description
 This interface allows retrieving a Pipeline execution record by pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.1`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines/detail`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | - |
+| `pipelineId` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7683,15 +7683,15 @@ This interface allows retrieving a Pipeline execution record by pipeline ID.
 | data.data.createTime | `integer` | - |
 | data.data.updateTime | `integer` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/detail?pipelineId=pipeline-001'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7703,53 +7703,53 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/detail?pipelineId=pip
 
 
 ### 9.3. List Pipeline Executions
-#### 接口描述
+#### Description
 This interface allows paginated listing of Pipeline execution records by resource type, name, namespace, and version.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines/list`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | **是** | - |
-| `resourceName` | `string` | 否 | - |
-| `namespaceId` | `string` | 否 | - |
-| `version` | `string` | 否 | - |
-| `pageNo` | `integer` | **是** | - |
-| `pageSize` | `integer` | **是** | - |
+| `resourceType` | `string` | **Yes** | - |
+| `resourceName` | `string` | No | - |
+| `namespaceId` | `string` | No | - |
+| `version` | `string` | No | - |
+| `pageNo` | `integer` | **Yes** | - |
+| `pageSize` | `integer` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `string` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/list?resourceType=skill&resourceName=my-skill&namespaceId=public&version=1.0.0&pageNo=1&pageSize=10'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7761,34 +7761,34 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/list?resourceType=ski
 
 
 ### 9.4. Get Pipeline Execution
-#### 接口描述
+#### Description
 This interface allows retrieving a Pipeline execution record by pipeline ID.
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/pipelines/{pipelineId}`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pipelineId` | `string` | **是** | - |
+| `pipelineId` | `string` | **Yes** | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7802,15 +7802,15 @@ This interface allows retrieving a Pipeline execution record by pipeline ID.
 | data.data.createTime | `integer` | - |
 | data.data.updateTime | `integer` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/{pipelineId}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7825,41 +7825,41 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/{pipelineId}'
 AI 资源导入 API 提供外部 AI 资源导入源查询、搜索、校验与执行能力。
 
 ### 10.1. Execute AI Resource Import
-#### 接口描述
+#### Description
 This interface imports selected external AI resources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/execute`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `resourceType` | `string` | **是** | - |
-| `sourceId` | `string` | **是** | - |
-| `selectedItems` | `string` | **是** | - |
-| `overwriteExisting` | `boolean` | 否 | - |
-| `skipInvalid` | `boolean` | 否 | - |
-| `validationToken` | `string` | 否 | - |
-| `options` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `resourceType` | `string` | **Yes** | - |
+| `sourceId` | `string` | **Yes** | - |
+| `selectedItems` | `string` | **Yes** | - |
+| `overwriteExisting` | `boolean` | No | - |
+| `skipInvalid` | `boolean` | No | - |
+| `validationToken` | `string` | No | - |
+| `options` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7870,15 +7870,15 @@ This interface imports selected external AI resources.
 | data.data.skippedCount | `integer` | - |
 | data.data.results | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/execute' -d "namespaceId=namespaceId&resourceType=resourceType&sourceId=sourceId&selectedItems=selectedItems&overwriteExisting=overwriteExisting&skipInvalid=skipInvalid&validationToken=validationToken&options=options"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7890,40 +7890,40 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/execute' -d "namespaceI
 
 
 ### 10.2. Search External AI Resources
-#### 接口描述
+#### Description
 This interface searches importable external AI resources from a specified source.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/search`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `resourceType` | `string` | **是** | - |
-| `sourceId` | `string` | **是** | - |
-| `query` | `string` | 否 | - |
-| `cursor` | `string` | 否 | - |
-| `limit` | `integer` | 否 | - |
-| `options` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `resourceType` | `string` | **Yes** | - |
+| `sourceId` | `string` | **Yes** | - |
+| `query` | `string` | No | - |
+| `cursor` | `string` | No | - |
+| `limit` | `integer` | No | - |
+| `options` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -7933,15 +7933,15 @@ This interface searches importable external AI resources from a specified source
 | data.data.hasMore | `boolean` | - |
 | data.data.items | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/search' -d "namespaceId=namespaceId&resourceType=resourceType&sourceId=sourceId&query=query&cursor=cursor&limit=limit&options=options"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -7953,48 +7953,48 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/search' -d "namespaceId
 
 
 ### 10.3. List AI Resource Import Sources
-#### 接口描述
+#### Description
 This interface lists configured AI resource import sources.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/sources`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `resourceType` | `string` | 否 | - |
+| `resourceType` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
 | data.data | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/ai/import/sources?resourceType=skill'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8006,39 +8006,39 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/import/sources?resourceType=ski
 
 
 ### 10.4. Validate AI Resource Import Items
-#### 接口描述
+#### Description
 This interface validates selected external AI resources before import.
 
-#### 起始版本
+#### Since
 
 `3.2.2`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/ai/import/validate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名 | 类型 | 必填 | 参数描述 |
+| Name | Type | Required | Description |
 |--------|------|------|----------|
-| `namespaceId` | `string` | 否 | - |
-| `resourceType` | `string` | **是** | - |
-| `sourceId` | `string` | **是** | - |
-| `selectedItems` | `string` | **是** | - |
-| `overwriteExisting` | `boolean` | 否 | - |
-| `options` | `string` | 否 | - |
+| `namespaceId` | `string` | No | - |
+| `resourceType` | `string` | **Yes** | - |
+| `sourceId` | `string` | **Yes** | - |
+| `selectedItems` | `string` | **Yes** | - |
+| `overwriteExisting` | `boolean` | No | - |
+| `options` | `string` | No | - |
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.code | `integer` | - |
 | data.message | `string` | - |
@@ -8047,15 +8047,15 @@ This interface validates selected external AI resources before import.
 | data.data.validationToken | `string` | - |
 | data.data.items | `array` | - |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/ai/import/validate' -d "namespaceId=namespaceId&resourceType=resourceType&sourceId=sourceId&selectedItems=selectedItems&overwriteExisting=overwriteExisting&options=options"
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8071,33 +8071,33 @@ Copilot 相关 API 提供配置获取/保存、Prompt 调试与优化、Skill �
 
 ### 11.1. 获取Copilot配置
 
-#### 接口描述
+#### Description
 
 获取当前Copilot配置，仅返回apiKey、model、studioUrl、studioProject。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `GET`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间读取`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/config`
 
-#### 请求参数
+#### Request Parameters
 
 无
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data.enabled | `boolean` | Copilot 功能是否启用。 |
 | data.defaultNamespace | `string` | 默认使用的命名空间 ID。 |
@@ -8106,15 +8106,15 @@ Copilot 相关 API 提供配置获取/保存、Prompt 调试与优化、Skill �
 | data.studioUrl | `string` | 关联的 Studio 服务地址。 |
 | data.studioProject | `string` | 关联的 Studio 项目标识。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X GET 'http://127.0.0.1:8080/v3/console/copilot/config'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8131,45 +8131,45 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/copilot/config'
 
 ### 11.2. 保存Copilot配置
 
-#### 接口描述
+#### Description
 
-创建或更新Copilot配置，仅接受apiKey、model、studioUrl、studioProject，其他字段使用默认值。
+创建或更新Copilot配置，仅接受apiKey、model、studioUrl、studioProject，其他字段使用Default。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/config`
 
-#### 请求参数
+#### Request Parameters
 
 无（请求体可传 apiKey、model、studioUrl、studioProject 等字段，具体以实际接口为准）。
 
-#### 返回数据
+#### Response Data
 
-| 参数名 | 参数类型 | 描述 |
+| Name | Type | Description |
 |--------|----------|------|
 | data | `boolean` | 是否保存成功。 |
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/config'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {
@@ -8181,48 +8181,48 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/config'
 
 ### 11.3. 流式调试Prompt
 
-#### 接口描述
+#### Description
 
 通过该接口，可使用用户输入流式调试Prompt并返回模型响应，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/prompt/debug`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名       | 类型     | 必填 | 参数描述     |
+| Name       | Type     | Required | Description     |
 |-----------|--------|----|----------|
-| `userInput` | `string` | 否 | 用户输入内容。 |
-| `prompt`    | `string` | 否 | 待调试的 Prompt。 |
+| `userInput` | `string` | No | 用户输入内容。 |
+| `prompt`    | `string` | No | 待调试的 Prompt。 |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/debug' -H 'Content-Type: application/json' -d '{"userInput":"","prompt":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}
@@ -8230,48 +8230,48 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/debug' -H 'Content
 
 ### 11.4. 流式优化Prompt
 
-#### 接口描述
+#### Description
 
 通过该接口，可流式优化Prompt，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/prompt/optimize`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名              | 类型     | 必填 | 参数描述        |
+| Name              | Type     | Required | Description        |
 |------------------|--------|----|-------------|
-| `optimizationGoal` | `string` | 否 | 优化目标。       |
-| `prompt`           | `string` | 否 | 待优化的 Prompt。 |
+| `optimizationGoal` | `string` | No | 优化目标。       |
+| `prompt`           | `string` | No | 待优化的 Prompt。 |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/optimize' -H 'Content-Type: application/json' -d '{"optimizationGoal":"","prompt":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}
@@ -8279,49 +8279,49 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/prompt/optimize' -H 'Cont
 
 ### 11.5. 流式生成Skill
 
-#### 接口描述
+#### Description
 
 通过该接口，可基于背景信息流式生成Skill，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/skill/generate`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型     | 必填 | 参数描述           |
+| Name                | Type     | Required | Description           |
 |--------------------|--------|----|----------------|
-| `backgroundInfo`     | `string` | 否 | 背景信息。           |
-| `selectedMcpTools`   | `array` | 否 | 选中的 MCP 工具。      |
-| `conversationHistory` | `object` | 否 | 对话历史。           |
+| `backgroundInfo`     | `string` | No | 背景信息。           |
+| `selectedMcpTools`   | `array` | No | 选中的 MCP 工具。      |
+| `conversationHistory` | `object` | No | 对话历史。           |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/skill/generate' -H 'Content-Type: application/json' -d '{"backgroundInfo":"","selectedMcpTools":"","conversationHistory":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}
@@ -8329,51 +8329,51 @@ curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/skill/generate' -H 'Conte
 
 ### 11.6. 流式优化Skill
 
-#### 接口描述
+#### Description
 
 通过该接口，可基于目标与对话历史流式优化Skill，返回SSE流。
 
-#### 起始版本
+#### Since
 
 `3.2.0`
 
-#### 请求方式
+#### Request Method
 
 `POST`
 
 请求体类型：`application/json`。
 
-#### 鉴权状态
+#### Authorization
 
 需要具有对应`命名空间写入`权限的用户身份。
 
-#### 请求URL
+#### Request URL
 
 `/v3/console/copilot/skill/optimize`
 
-#### 请求参数
+#### Request Parameters
 
-| 参数名                | 类型     | 必填 | 参数描述           |
+| Name                | Type     | Required | Description           |
 |--------------------|--------|----|----------------|
-| `conversationHistory` | `object` | 否 | 对话历史。           |
-| `targetFileName`      | `string` | 否 | 目标文件名。          |
-| `optimizationGoal`    | `string` | 否 | 优化目标。           |
-| `skill`               | `string` | 否 | 待优化的 Skill 内容。   |
-| `selectedMcpTools`   | `array` | 否 | 选中的 MCP 工具。      |
+| `conversationHistory` | `object` | No | 对话历史。           |
+| `targetFileName`      | `string` | No | 目标文件名。          |
+| `optimizationGoal`    | `string` | No | 优化目标。           |
+| `skill`               | `string` | No | 待优化的 Skill 内容。   |
+| `selectedMcpTools`   | `array` | No | 选中的 MCP 工具。      |
 
-#### 返回数据
+#### Response Data
 
 无（SSE 流式返回）
 
-#### 示例
+#### Examples
 
-* 请求示例
+* Request example
 
 ```shell
 curl -X POST 'http://127.0.0.1:8080/v3/console/copilot/skill/optimize' -H 'Content-Type: application/json' -d '{"conversationHistory":"","targetFileName":"","optimizationGoal":"","skill":"","selectedMcpTools":""}'
 ```
 
-* 返回示例
+* Response example
 
 ```json
 {}


### PR DESCRIPTION
## Summary
- Continue #1099 with a larger manual/admin batch.
- Align repeated English-page template labels for Admin API and Console API in both latest and next docs.
- Keep the work split into local commits so reviewers can inspect Admin API and Console API changes separately.

## Commits
- docs: align English admin API template
- docs: clean mixed admin API terminology
- docs: align English console API template

## Scope
- This PR focuses on repeated API document templates: section labels, table headers, required markers, authorization labels, example labels, common-response anchors, and small mixed-term cleanup from mechanical replacement.
- It does not fully translate every business description or API title in Admin API / Console API; those can be handled in follow-up commits or batches.

## Validation
- Public template Chinese-residual scan over latest/next English Admin API and Console API pages: no matches for the targeted labels.
- git diff --check: passed.
- npm run build: blocked locally by the existing Rollup optional native dependency loading failure (@rollup/rollup-darwin-arm64 code signature / optional dependency issue) before Astro build.