### PR TITLE
docs: align English AI user docs

### DIFF
--- a/src/content/docs/latest/en/manual/user/ai/agent-registry.md
+++ b/src/content/docs/latest/en/manual/user/ai/agent-registry.md
@@ -62,8 +62,8 @@ number.
 
 Nacos, serving as Agent Registry (A2A Registry), offers:
 
-- [HTTP-based API](../../admin/admin-api.md#5-a2a注册中心)
-- [gRPC-based SDK](../java-sdk/usage.md#7-a2a-注册中心)
+- [HTTP-based API](../../admin/admin-api.md)
+- [gRPC-based SDK](../java-sdk/usage.md)
 
 to assist A2A servers and agent providers in publishing Agents (AgentCards).
 
@@ -235,7 +235,7 @@ Certain Agents (AgentCards) provided by external providers should be published v
 
 ### 2.3.2. Publishing External Provider Agents via Nacos HTTP API
 
-For scenarios where the console is unavailable, use the [Nacos Create Agent HTTP API](../../admin/admin-api.md#55-创建agentcard).
+For scenarios where the console is unavailable, use the [Nacos Create Agent HTTP API](../../admin/admin-api.md).
 
 Example: Importing the [A2A official sample AgentCard](https://a2a-protocol.org/latest/specification/#57-sample-agent-card):
 
@@ -249,8 +249,8 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 
 Nacos, serving as Agent Registry (A2A Registry), offers:
 
-- [HTTP-based API](../../admin/admin-api.md#5-a2a注册中心)
-- [gRPC-based SDK](../java-sdk/usage.md#7-a2a-注册中心)
+- [HTTP-based API](../../admin/admin-api.md)
+- [gRPC-based SDK](../java-sdk/usage.md)
 
 to assist A2A clients and agent consumers in query Agents (AgentCards).
 
@@ -411,13 +411,13 @@ try {
 
 ### 3.3. Query Agent
 
-Nacos also supports retrieving AgentCard information exactly by Agent name via [HTTP APIs](../../admin/admin-api.md#5-a2a注册中心), and performing fuzzy searches for AgentCard information by Agent name.
+Nacos also supports retrieving AgentCard information exactly by Agent name via [HTTP APIs](../../admin/admin-api.md), and performing fuzzy searches for AgentCard information by Agent name.
 
 > The capability for fuzzy searches based on skills, tags, and descriptions is currently under development.
 
 #### 3.3.1. Query Agent detail information by Name
 
-Through [Query HTTP的API](../../admin/admin-api.md#53-查询agentcard的详情), Query the detail information of an Agent by Agent name. Such as：
+Use the [Query Agent HTTP API](../../admin/admin-api.md) to query the detail information of an Agent by Agent name. Such as:
 
 ```bash
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent'
@@ -425,7 +425,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 
 #### 3.3.2. Search Agent list by Name
 
-Through[Search HTTP的API](../../admin/admin-api.md#52-查询agentcard的列表)，Search the list of AgentCards by Agent name. Such as：
+Use the [Search Agent HTTP API](../../admin/admin-api.md) to search the list of AgentCards by Agent name. Such as:
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&agentName=Planner&namespaceId=public&search=blur'

--- a/src/content/docs/latest/en/manual/user/ai/api-to-mcp.md
+++ b/src/content/docs/latest/en/manual/user/ai/api-to-mcp.md
@@ -1,111 +1,98 @@
 ---
 title: Existing API Migration to MCP Manual
-keywords: [ MCP Server Register,MCP,Existing API,Migration to MCP]
-description: 如何通过Nacos，将已经注册在Nacos上的存量微服务API，转化成为MCP服务
+keywords: [MCP Server Register, MCP, Existing API, Migration to MCP]
+description: Learn how to use Nacos to convert existing microservice APIs registered in Nacos into MCP services.
 sidebar:
   order: 5
 ---
 
-# 存量API转换MCP手册
+# Existing API Migration to MCP
 
-Nacos 能够通过和 [Higress](https://higress.ai) 等AI网关的结合，**0代码改动**地实现将存量API转换成MCP
-服务的能力。本文档将说明如何在Nacos上对已经注册在Nacos中的存量API声明为MCP服务，并通过[Higress](https://higress.ai)
-的协议转换能力进行MCP Tools的调用。
+Nacos can work with AI gateways such as [Higress](https://higress.ai) to convert existing APIs into MCP services with **zero code changes**. This guide explains how to declare APIs that are already registered in Nacos as MCP services, and how to call MCP tools through the protocol conversion capability of [Higress](https://higress.ai).
 
-![API转换MCP原理](/img/doc/manual/user/ai/ai-api-to-mcp.svg)
+![API to MCP architecture](/img/doc/manual/user/ai/ai-api-to-mcp.svg)
 
-## 0. 准备工作
+## 0. Prerequisites
 
-将存量API转换成MCP服务的准备工作主要有：
+Prepare the following components before converting existing APIs into MCP services:
 
-- **部署Nacos引擎** : 在运行环境中部署版本`3.0.0`
-  及以上的Nacos引擎，可参考[Nacos快速开始](../../../quickstart/quick-start.mdx), [Nacos Docker 快速开始](../../../quickstart/quick-start-docker.mdx)
-  或 [Nacos Kubernetes 快速开始](../../../quickstart/quick-start-kubernetes.mdx)。
-- **部署Higress-AI** : 在运行环境中部署版本`2.1.2`
-  及以上的Higress，可参考[Higress Docker 快速开始](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG)
-  或 [Higress Kubernetes 快速开始](https://higress.cn/ai/mcp-quick-start/?spm=36971b57.31888769.0.0.646150f85M2PAG)。
-- **将存量API注册到Nacos引擎中** : 将存量API通过[Nacos SDK](../overview/other-language.md)
-  或 [Spring Cloud](https://sca.aliyun.com/docs/2023/user-guide/nacos/quick-start/?spm=5176.29160081.0.0.74805c72y6j24s)
-  等框架进行注册或自动注册。
+- **Deploy the Nacos engine**: Deploy Nacos `3.0.0` or later in your runtime environment. For details, see [Nacos Quick Start](../../../quickstart/quick-start.mdx), [Nacos Docker Quick Start](../../../quickstart/quick-start-docker.mdx), or [Nacos Kubernetes Quick Start](../../../quickstart/quick-start-kubernetes.mdx).
+- **Deploy Higress AI**: Deploy Higress `2.1.2` or later in your runtime environment. For details, see [Higress Docker Quick Start](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG) or [Higress Kubernetes Quick Start](https://higress.cn/ai/mcp-quick-start/?spm=36971b57.31888769.0.0.646150f85M2PAG).
+- **Register existing APIs in Nacos**: Register existing APIs manually or automatically through [Nacos SDKs](../overview/other-language.md), [Spring Cloud](https://sca.aliyun.com/docs/2023/user-guide/nacos/quick-start/?spm=5176.29160081.0.0.74805c72y6j24s), or another integration framework.
 
-## 1. 将存量服务声明成MCP服务
+## 1. Declare an Existing Service as an MCP Service
 
-打开Nacos控制台`http://${nacos_console_host}:${nacos_console_port}` 如 `http://127.0.0.1:8080`.
+Open the Nacos console at `http://${nacos_console_host}:${nacos_console_port}`, for example `http://127.0.0.1:8080`.
 
-> 首次打开可能需要进行管理员密码的初始化工作，请参考[Nacos控制台手册](../../admin/console.md#3-登录管理)。
+> When you open the console for the first time, you may need to initialize the administrator password. For details, see the [Nacos Console Guide](../../admin/console.md#3-login-management).
 
-点击左侧 `MCP Registry` -> `MCP List` 进入 MCP Registry 页面
+In the left navigation, click `MCP Registry` -> `MCP List` to open the MCP Registry page.
 
-在页面左上角点击`创建MCP Server`，在创建MCP Server页面中填写必要信息，如：
+Click `Create MCP Server` in the upper-left corner, and fill in the required information on the Create MCP Server page:
 
-| 信息            | 描述                                                                     |
-|---------------|------------------------------------------------------------------------|
-| MCP 服务名       | MCP Server 名称，用于区分不同MCP Server                                         |
-| 协议类型          | 请选择`sse`或`streamable`                                                  |
-| HTTP 转 MCP 服务 | 在`协议类型`选择为`sse`或`streamable`之后出现此选项，可选择`http`或`https`，根据存量服务提供的协议类型选择。 |
-| 后端服务          | 在`协议类型`选择为`sse`或`streamable`之后出现此选项，选择`使用已有服务`                         |
-| 服务引用          | 在单选框中选择需要转换的存量服务的服务名                                                   |
-| 描述            | MCP服务的描述，自定义描述此存量服务转化成MCP服务后的描述信息                                      |
-| 服务版本          | MCP服务的版本号，自定义版本号，一般使用如`1.0.0`样式的多级版本号                                  |
+| Field | Description |
+| --- | --- |
+| MCP service name | MCP Server name, used to distinguish different MCP Servers. |
+| Protocol type | Select `sse` or `streamable`. |
+| HTTP to MCP service | Appears after you select `sse` or `streamable` as the protocol type. Select `http` or `https` according to the protocol used by the existing service. |
+| Backend service | Appears after you select `sse` or `streamable` as the protocol type. Select `Use existing service`. |
+| Service reference | Select the existing service that you want to convert. |
+| Description | Description of the MCP service after the existing service is converted. |
+| Service version | Version of the MCP service. Use a semantic-style version such as `1.0.0`. |
 
-填写完成后，点击页面右上角的`发布`即可完成。
+After completing the form, click `Publish` in the upper-right corner.
 
-## 2. 将存量服务的API声明为MCP服务的Tools
+## 2. Declare Existing Service APIs as MCP Tools
 
-打开Nacos控制台`http://${nacos_console_host}:${nacos_console_port}` 如 `http://127.0.0.1:8080`.
+Open the Nacos console at `http://${nacos_console_host}:${nacos_console_port}`, for example `http://127.0.0.1:8080`.
 
-点击左侧 `MCP Registry` -> `MCP List` 进入 MCP Registry 页面
+In the left navigation, click `MCP Registry` -> `MCP List` to open the MCP Registry page.
 
-在列表中找到[上一步骤](#1-将存量服务声明成mcp服务)中创建的MCP服务，在列表的`操作`列中点击`编辑`。
+Find the MCP service created in [the previous step](#1-declare-an-existing-service-as-an-mcp-service), and click `Edit` in the `Actions` column.
 
-在`编辑 MCP Server`页面中，修改`服务版本`为新的版本号
+On the `Edit MCP Server` page, change `Service Version` to a new version.
 
-> 考虑到不同MCP Server的版本兼容性问题，编辑时对于已发布的版本，只能修改Tool以及参数的描述信息以及开关；避免新增，删除，修改参数类型导致的MCP服务不兼容问题。
+> For compatibility between different MCP Server versions, published versions can only update tool descriptions, parameter descriptions, and switches. Avoid adding, deleting, or changing parameter types for a published version because those changes can make the MCP service incompatible.
 
-修改为新版本号后，在页面下方的`Tools`区域中会出现`添加`按钮，点击`添加`按钮，在`添加 MCP Tools`页面中填写必要信息，如：
+After changing the version, an `Add` button appears in the `Tools` section. Click `Add`, and fill in the required information on the Add MCP Tools page:
 
-| 信息        | 描述                                         |
-|-----------|--------------------------------------------|
-| Tool 名称   | MCP Tools的名称，用于区分不同MCP Tools               |
-| Tool 描述   | MCP Tools的描述，自定义描述此存量服务API成MCP服务Tool后的描述信息 |
-| 是否启用      | 是否启用此Tool，默认为启用                            |
-| Tool 入参描述 | 对Mcp Tools的输入参数列表进行描述。                     |
+| Field | Description |
+| --- | --- |
+| Tool name | MCP Tool name, used to distinguish different MCP Tools. |
+| Tool description | Description of the MCP Tool converted from the existing service API. |
+| Enabled | Whether this Tool is enabled. It is enabled by default. |
+| Tool input parameters | Describes the input parameter list for the MCP Tool. |
 
-其中点击`添加属性`能够新增输入参数。
+Click `Add Property` to add an input parameter.
 
-> 注意，只有当焦点处于`参数列表`时，点击`添加属性`
-> 才能新增输入参数。若焦点处于某一参数时，说明此时正在进行此参数的内容编辑，`添加属性`不允许点击。
+> You can add input parameters only when the focus is on `Parameter List`. If the focus is on an existing parameter, the page is editing that parameter and `Add Property` cannot be clicked.
 
-之后再点击需要修改的输入参数，如`NewArg1`；在`参数信息`中进行参数属性的修改，参数属性内容解释如下：
+Then click an input parameter such as `NewArg1`, and edit its attributes in `Parameter Information`:
 
-| 信息     | 描述                                                                                                                     |
-|--------|------------------------------------------------------------------------------------------------------------------------|
-| 名称     | MCP Tools的输入参数名称，用于区分不同参数                                                                                              |
-| 类型     | MCP Tools的输入参数类型，支持`string`、`number`、`integer`、`boolean`、`array`、`object`                                              |
-| 描述     | MCP Tools的输入参数描述，自定义描述此MCP服务Tool参数描述信息                                                                                 |                                                                          |
-| 协议转化配置 | 提供给AI网关或协议转换代理的协议转化配置，用于提供给给AI网关或协议转化代理，此工具实际映射的存量服务的API信息，如`url`，`参数映射关系`等，具体配置细节，请参见[MCP模版配置手册](./mcp-template.md)。 |
+| Field | Description |
+| --- | --- |
+| Name | Input parameter name of the MCP Tool, used to distinguish different parameters. |
+| Type | Input parameter type of the MCP Tool. Supported values include `string`, `number`, `integer`, `boolean`, `array`, and `object`. |
+| Description | Input parameter description for the MCP Tool. |
+| Protocol conversion configuration | Protocol conversion configuration for the AI gateway or protocol conversion proxy. It describes the existing service API that the Tool maps to, such as `url` and parameter mappings. For configuration details, see the [MCP Template Configuration Guide](./mcp-template.md). |
 
-所有Tool的输入参数编辑完成后， 点击`确定`进行保存，之后重复添加其他的Tool信息后，点击页面右上角`发布为最新版本`。
+After all Tool input parameters are edited, click `OK` to save them. Add other Tools if needed, and then click `Publish as Latest Version` in the upper-right corner.
 
-> 页面右上角的`保存`仅会将内容进行保存，不会标记成最新版本，不进行发布最新版本，可能会导致AI网关或协议转换代理无法读取到新改动的工具信息。可用于编辑过程中保存记录以及灰度使用。
+> The `Save` button in the upper-right corner only saves the content. It does not mark the version as latest or publish the latest version, so AI gateways or protocol conversion proxies may not read the updated Tool information. Use it to save drafts during editing or for gray release scenarios.
 
-## 3. 配置协议转换暴露MCP服务
+## 3. Configure Protocol Conversion to Expose the MCP Service
 
-上述步骤已经已经将存量服务及其API声明成了MCP服务及MCP
-Tool，Nacos作为控制面进行声明的存储和下发，但想要实际以MCP协议进行访问，还需要有数据面进行协议转换，目前Higress-AI网关已经提供了协议转换的能力。
+The previous steps declare the existing service and its APIs as an MCP service and MCP Tools. Nacos stores and distributes these declarations as the control plane. To access the service through the MCP protocol, you also need a data plane for protocol conversion. Higress AI Gateway already provides this capability.
 
-Higress-AI网关的部署可参考参考[Higress Docker 快速开始](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG)
-或 [Higress Kubernetes 快速开始](https://higress.cn/ai/mcp-quick-start/?spm=36971b57.31888769.0.0.646150f85M2PAG)
-进行部署，此文档主要说明如何配置：
+For Higress AI Gateway deployment, see [Higress Docker Quick Start](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG) or [Higress Kubernetes Quick Start](https://higress.cn/ai/mcp-quick-start/?spm=5176.29160081.0.0.74805c72y6j24s). This guide focuses on the configuration steps.
 
-### 3.1. 开启Higress-AI网关的MCP协议转换
+### 3.1. Enable MCP Protocol Conversion in Higress AI Gateway
 
-参考[Higress ConfigMap 全局参数配置](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE)
-文档，将`data.higress.mcpServer.enable`的值修改为`true`，同时确保`data.higress.mcpServer.redis.address`的地址配置正确.
+Refer to [Higress ConfigMap global parameter configuration](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE), set `data.higress.mcpServer.enable` to `true`, and make sure `data.higress.mcpServer.redis.address` is configured correctly.
 
-> `data.higress.mcpServer.match_list`可保持默认值，默认为`[]`，表示由Higress-AI网关自动进行会话保持管理。
+> `data.higress.mcpServer.match_list` can keep the default value `[]`, which means Higress AI Gateway automatically manages session affinity.
 
-例如：
+Example:
 
 ```yaml
 apiVersion: v1
@@ -116,24 +103,23 @@ data:
   higress: |-
     mcpServer:
       ...
-      enable: true          # 启用 MCP Server
+      enable: true          # Enable MCP Server
       redis:
-        address: ${IP}:6379 # Redis服务地址。
+        address: ${IP}:6379 # Redis service address.
         ...
-      match_list: [] 
+      match_list: []
       ...
 ```
 
-### 3.2. 配置 Nacos 作为 Higress-AI的 MCP Registry
+### 3.2. Configure Nacos as the MCP Registry for Higress AI
 
-参考[Higress 配置 Nacos MCP Registry](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE)
+Refer to [Higress Nacos MCP Registry configuration](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE).
 
-将Nacos作为MCP Registry 服务来源进行配置，配置完毕后可在`Higress的控制台-服务列表`中查看到所有通过MCP协议暴露的存量服务的服务名称。
+After configuring Nacos as the MCP Registry service source, you can view all existing services exposed through MCP in `Higress Console` -> `Service List`.
 
-同时使用`curl http://${higress_ai_host}:${higress_ai_port}/mcp/${your_mcp_server_name}/sse`
-可连接MCP服务，查看到连接MCP服务的sessionId，并定时能看到心跳响应。
+You can also connect to the MCP service with `curl http://${higress_ai_host}:${higress_ai_port}/mcp/${your_mcp_server_name}/sse`, view the session ID of the MCP connection, and receive heartbeat responses periodically.
 
-如，我的MCP服务名称为`restToMcp`：
+For example, if the MCP service name is `restToMcp`:
 
 ```shell
 curl localhost:8080/mcp/restToMcp/sse
@@ -148,7 +134,4 @@ data: {"jsonrpc":"2.0","id":"2025-06-16T03:33:09Z","method":"ping"}
 
 ```
 
-至此，您已经将一个已经注册在Nacos上的存量服务API，转化成为了MCP服务，您可以将此MCP服务配置在各类LLM
-Agent应用上，如`DeepChat`, `Cline`, `Cherry Studio`
-等；或通过[Nacos-Mcp-Router](./nacos-mcp-router.md)，[MCP-Client](https://modelcontextprotocol.io/quickstart/client)，[Spring-AI](https://java2ai.com/docs/1.0.0-M6.1/get-started/?spm=5176.29160081.0.0.6546aa5c63Vkgn)
-进行直接的访问和调用。
+At this point, you have converted an existing service API registered in Nacos into an MCP service. You can configure this MCP service in LLM Agent applications such as `DeepChat`, `Cline`, and `Cherry Studio`, or access and invoke it directly through [Nacos MCP Router](./nacos-mcp-router.md), [MCP Client](https://modelcontextprotocol.io/quickstart/client), or [Spring AI](https://java2ai.com/docs/1.0.0-M6.1/get-started/?spm=5176.29160081.0.0.6546aa5c63Vkgn).

--- a/src/content/docs/latest/en/manual/user/ai/nacos-mcp-router.md
+++ b/src/content/docs/latest/en/manual/user/ai/nacos-mcp-router.md
@@ -1,48 +1,53 @@
 ---
 title: Nacos MCP Router
-keywords: [Nacos MCP Router,MCP,使用手册]
-description: Nacos MCP Router 使用手册
+keywords: [Nacos MCP Router, MCP, User Guide]
+description: Nacos MCP Router user guide.
 sidebar:
     order: 6
 ---
 
-Nacos MCP Router是一个基于MCP官方SDK开发的标准MCP Server，为MCP Client提供MCP Server的`智能搜索`、`安装`、`代理`等功能， **极大地简化了**MCP服务的使用流程。 同时，Nacos MCP Router跟Nacos MCP Registry结合，可以实现MCP Server治理，如MCP Server及工具可见性、版本管理等。
+Nacos MCP Router is a standard MCP Server built on the official MCP SDK. It provides MCP Clients with MCP Server `intelligent search`, `installation`, and `proxy` capabilities, which **greatly simplifies** MCP service usage. When used together with Nacos MCP Registry, Nacos MCP Router can also support MCP Server governance, such as MCP Server and tool visibility and version management.
 
-![MCP Router架构图](/img/doc/overview/ai-mcp-router-struncture.svg)
+![MCP Router architecture](/img/doc/overview/ai-mcp-router-struncture.svg)
 
-## 功能介绍
-Nacos MCP Router 有两种工作模式：
-1. router模式：默认模式，通过MCP Server推荐、安装及代理其他MCP Server的功能，帮助用户更方便的使用MCP Server服务。
-2. proxy模式：使用环境变量MODE=proxy指定，通过简单配置可以把sse、stdio协议MCP Server转换为streamableHTTP协议MCP Server。
+## Features
 
-在router 模式下，Nacos MCP Router 作为一个标准MCP Server，提供MCP Server推荐、分发、安装及代理其他MCP Server的功能。其主要工具列表为
+Nacos MCP Router has two working modes:
+
+1. Router mode: The default mode. It recommends, installs, and proxies other MCP Servers to help users consume MCP Server services more easily.
+2. Proxy mode: Enabled by setting the `MODE=proxy` environment variable. With simple configuration, it can convert MCP Servers that use `sse` or `stdio` into `streamableHTTP` MCP Servers.
+
+In router mode, Nacos MCP Router works as a standard MCP Server. It recommends, distributes, installs, and proxies other MCP Servers. The main tools are:
+
 1. `search_mcp_server`
-    - 根据任务描述及关键字从MCP注册中心（Nacos）中搜索相关的MCP Server列表
-    - 输入:
-      - `task_description`(string): 任务描述，示例：今天杭州天气如何
-      - `key_words`(string): 任务关键字，示例：天气、杭州
-    - 输出: list of MCP servers and instructions to complete the task.
+   - Searches the MCP Registry (Nacos) for related MCP Servers by task description and keywords.
+   - Input:
+     - `task_description` (string): Task description, for example: "What is the weather in Hangzhou today?"
+     - `key_words` (string): Task keywords, for example: "weather, Hangzhou"
+   - Output: List of MCP servers and instructions to complete the task.
 2. `add_mcp_server`
-    - 添加并初始化一个MCP Server，根据Nacos中的配置与该MCP Server建立连接，等待调用。
-    - 输入:
-      - `mcp_server_name`(string): 需要添加的MCP Server名字
-    - 输出: MCP Server工具列表及使用方法
+   - Adds and initializes an MCP Server, connects to it according to the configuration in Nacos, and waits for calls.
+   - Input:
+     - `mcp_server_name` (string): Name of the MCP Server to add.
+   - Output: MCP Server tool list and usage instructions.
 3. `use_tool`
-   - 代理其他MCP Server的工具
-   - 输入:
-     - `mcp_server_name`(string): 被调的目标MCP Server名称.
-     - `mcp_tool_name`(string): 被调的目标MCP Server的工具名称
-     - `params`(map): 被调的目标MCP Server的工具的参数
-   - 输出: 被调的目标MCP Server的工具的输出结果
+   - Proxies tools from another MCP Server.
+   - Input:
+     - `mcp_server_name` (string): Name of the target MCP Server.
+     - `mcp_tool_name` (string): Name of the target MCP Server tool.
+     - `params` (map): Parameters of the target MCP Server tool.
+   - Output: Output result from the target MCP Server tool.
 
-在proxy 模式下，Nacos MCP Router 仅提供代理功能，无需代码改动即可实现stdio、sse协议一键转换为streamableHTTP协议。
- 
+In proxy mode, Nacos MCP Router only provides proxy capability. It can convert existing `stdio` or `sse` MCP Servers into the `streamableHTTP` protocol without code changes.
 
-## router模式
-**启动Nacos MCP Router**
+## Router Mode
 
-### stdio协议
-* 使用uvx
+**Start Nacos MCP Router**
+
+### stdio Protocol
+
+* Use uvx
+
     ```json
     {
         "mcpServers":
@@ -56,15 +61,17 @@ Nacos MCP Router 有两种工作模式：
                 ],
                 "env":
                 {
-                    "NACOS_ADDR": "<NACOS-ADDR>, 选填，默认为127.0.0.1:8848",
-                    "NACOS_USERNAME": "<NACOS-USERNAME>, 选填，默认为nacos",
-                    "NACOS_PASSWORD": "<NACOS-PASSWORD>, 必填"
+                    "NACOS_ADDR": "<NACOS-ADDR>, optional, defaults to 127.0.0.1:8848",
+                    "NACOS_USERNAME": "<NACOS-USERNAME>, optional, defaults to nacos",
+                    "NACOS_PASSWORD": "<NACOS-PASSWORD>, required"
                 }
             }
         }
-    }   
+    }
     ```
-* 使用docker
+
+* Use Docker
+
     ```json
     {
         "mcpServers": {
@@ -78,8 +85,10 @@ Nacos MCP Router 有两种工作模式：
     }
     ```
 
-### sse协议
-* uvx启动
+### sse Protocol
+
+* Start with uvx
+
     ```shell
     export NACOS_ADDR=127.0.0.1:8848
     export NACOS_USERNAME=nacos
@@ -87,13 +96,17 @@ Nacos MCP Router 有两种工作模式：
     export TRANSPORT_TYPE=sse
     uvx nacos-mcp-router@latest
     ```
-* docker启动
+
+* Start with Docker
+
     ```shell
     docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=sse nacos-mcp-router:latest
     ```
 
-### streamableHTTP 协议
-* uvx启动
+### streamableHTTP Protocol
+
+* Start with uvx
+
     ```shell
     export NACOS_ADDR=127.0.0.1:8848
     export NACOS_USERNAME=nacos
@@ -101,12 +114,19 @@ Nacos MCP Router 有两种工作模式：
     export TRANSPORT_TYPE=streamable_http
     uvx nacos-mcp-router@latest
     ```
-* docker启动
+
+* Start with Docker
+
     ```shell
     docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http nacos-mcp-router:latest
     ```
-### 使用,Nacos-MCP-Router,以CherryStudio为例，MCP配置如下
-* stdio模式配置
+
+### Use Nacos MCP Router with Cherry Studio
+
+The following examples show MCP configurations for Cherry Studio.
+
+* stdio mode configuration
+
     ```json
     {
             "mcpServers": {
@@ -120,7 +140,8 @@ Nacos MCP Router 有两种工作模式：
         }
     ```
 
-* sse模式配置
+* sse mode configuration
+
     ```json
     {
             "mcpServers": {
@@ -131,7 +152,8 @@ Nacos MCP Router 有两种工作模式：
         }
     ```
 
-* streamableHTTP模式配置
+* streamableHTTP mode configuration
+
     ```json
      {
             "mcpServers": {
@@ -142,37 +164,39 @@ Nacos MCP Router 有两种工作模式：
         }
     ```
 
+## Proxy Mode
 
-## proxy模式
-proxy模式诞生的初衷是帮助存量stdio、sse协议的MCP Server转换为streamableHTTP协议，享受streamableHTTP协议带来的好处。proxy模式下，Nacos MCP Router仅做请求透明转发，对外暴露目标MCP Server的工具列表。
+Proxy mode is designed to convert existing `stdio` and `sse` MCP Servers into the `streamableHTTP` protocol so they can benefit from streamableHTTP. In proxy mode, Nacos MCP Router only transparently forwards requests and exposes the target MCP Server tool list.
 
-proxy模式下，需设置环境变量MODE=proxy和PROXIED_MCP_NAME=<MCP Server Name>
-* 使用uvx
+In proxy mode, set the `MODE=proxy` and `PROXIED_MCP_NAME=<MCP Server Name>` environment variables.
+
+* Use uvx
+
     ```bash
-    export NACOS_ADDR=$NACOS_ADDR 
+    export NACOS_ADDR=$NACOS_ADDR
     export NACOS_USERNAME=$NACOS_USERNAME
-    export NACOS_PASSWORD=$NACOS_PASSWORD 
+    export NACOS_PASSWORD=$NACOS_PASSWORD
     export TRANSPORT_TYPE=streamable_http
     export MODE=proxy
-    export PROXIED_MCP_NAME=$PROXIED_MCP_NAME 
+    export PROXIED_MCP_NAME=$PROXIED_MCP_NAME
     uvx nacos-mcp-router@latest
     ```
-* 使用docker
+
+* Use Docker
+
     ```bash
     docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http -e MODE=proxy -e PROXIED_MCP_NAME=$PROXIED_MCP_NAME  nacos-mcp-router:latest
     ```
 
+## Environment Variables
 
-## 环境变量配置
-
-|    |               |                |      |                                           |
-|----|---------------|----------------|------|-------------------------------------------|
-|  参数 | 描述            | 默认值            | 是否必填 | 备注                                        |
-| NACOS_ADDR | Nacos 服务器地址   | 127.0.0.1:8848 | 否    | 填写 Nacos 服务器的地址，如 192.168.1.1:8848，注意要写端口 |
-| NACOS_USERNAME | Nacos 用户名     | nacos          | 否    | 填写 Nacos 用户名，如 nacos                      |
-| NACOS_PASSWORD | Nacos 密码      | 密码             | 是    | 填写 Nacos 密码，如 nacos                       |
-|NACOS_NAMESPACE| Nacos命名空间     | public         | 否    | Nacos命名空间，如 public                        |
-| TRANSPORT_TYPE | 传输协议类型        | stdio          | 否    | 填写传输协议类型，可选值：stdio、sse、streamable_http    |
-| PROXIED_MCP_NAME | 代理的 MCP 服务器名称 | -              | 否    | proxy模式下需要被转换的 MCP 服务器名称，需要先注册到Nacos      |
-| MODE | 工作模式          | router         | 否    | 可选的值：router、proxy                         |
-| PORT | 服务端口          | 8000           | 否    | 协议类型为sse或streamable时使用                    |
+| Parameter | Description | Default | Required | Notes |
+| --- | --- | --- | --- | --- |
+| NACOS_ADDR | Nacos server address | 127.0.0.1:8848 | No | Nacos server address, such as 192.168.1.1:8848. Include the port. |
+| NACOS_USERNAME | Nacos username | nacos | No | Nacos username, such as nacos. |
+| NACOS_PASSWORD | Nacos password | password | Yes | Nacos password, such as nacos. |
+| NACOS_NAMESPACE | Nacos namespace | public | No | Nacos namespace, such as public. |
+| TRANSPORT_TYPE | Transport protocol type | stdio | No | Supported values: stdio, sse, streamable_http. |
+| PROXIED_MCP_NAME | Proxied MCP Server name | - | No | Name of the MCP Server to convert in proxy mode. It must already be registered in Nacos. |
+| MODE | Working mode | router | No | Supported values: router, proxy. |
+| PORT | Server port | 8000 | No | Used when the protocol type is sse or streamable. |

--- a/src/content/docs/latest/en/manual/user/ai/skill-registry.md
+++ b/src/content/docs/latest/en/manual/user/ai/skill-registry.md
@@ -247,7 +247,7 @@ Skill Registry provides multiple access methods. Refer to the respective documen
 
 ### 4.1. nacos-cli
 
-[nacos-cli](../../admin/nacos-cli.md) is the command-line tool for Skill Registry, providing Skill search, installation, upload, and sync capabilities. For detailed installation and Skill commands, see [Nacos CLI User Guide - AI Skill commands](../../admin/nacos-cli.md#51-ai-技能管理-).
+[nacos-cli](../../admin/nacos-cli.md) is the command-line tool for Skill Registry, providing Skill search, installation, upload, and sync capabilities. For detailed installation and Skill commands, see [Nacos CLI User Guide - AI Skill commands](../../admin/nacos-cli.md).
 
 ### 4.2. REST API
 
@@ -255,9 +255,9 @@ Skill Registry provides three layers of REST APIs:
 
 | API Layer | Description | Documentation |
 |-----------|-------------|---------------|
-| **Client API** | Client runtime query/download Skills (supports anonymous access) | [Client API - Download Skill](../open-api.md#34-下载-skill) |
-| **Console API** | Console operations (requires login authentication) | [Console API - Skills](../../admin/console-api.md#7-skills-管理) |
-| **Admin API** | Cluster internal management interface | [Admin API - AI Skills](../../admin/admin-api.md#7-ai-skills-管理) |
+| **Client API** | Client runtime query/download Skills (supports anonymous access) | [Client API - Download Skill](../open-api.md) |
+| **Console API** | Console operations (requires login authentication) | [Console API - Skills](../../admin/console-api.md) |
+| **Admin API** | Cluster internal management interface | [Admin API - AI Skills](../../admin/admin-api.md) |
 
 ### 4.3. Java SDK
 
@@ -265,5 +265,5 @@ Nacos provides two Java SDKs for programmatic Skill management:
 
 | SDK | Use Case | Documentation |
 |-----|----------|---------------|
-| **nacos-client** | Client runtime Skill loading and subscription | [Java SDK - Skill](../java-sdk/usage.md#8-skill-能力) |
-| **nacos-maintainer-client** | Operations management (create, publish, online/offline, etc.), suitable for automation and CI/CD | [Maintainer SDK - Skill](../../admin/maintainer-sdk.md#9-skill-能力) |
+| **nacos-client** | Client runtime Skill loading and subscription | [Java SDK - Skill](../java-sdk/usage.md) |
+| **nacos-maintainer-client** | Operations management (create, publish, online/offline, etc.), suitable for automation and CI/CD | [Maintainer SDK - Skill](../../admin/maintainer-sdk.md) |

--- a/src/content/docs/next/en/manual/user/ai/agent-registry.md
+++ b/src/content/docs/next/en/manual/user/ai/agent-registry.md
@@ -62,8 +62,8 @@ number.
 
 Nacos, serving as Agent Registry (A2A Registry), offers:
 
-- [HTTP-based API](../../admin/admin-api.md#5-a2a注册中心)
-- [gRPC-based SDK](../java-sdk/usage.md#7-a2a-注册中心)
+- [HTTP-based API](../../admin/admin-api.md)
+- [gRPC-based SDK](../java-sdk/usage.md)
 
 to assist A2A servers and agent providers in publishing Agents (AgentCards).
 
@@ -235,7 +235,7 @@ Certain Agents (AgentCards) provided by external providers should be published v
 
 ### 2.3.2. Publishing External Provider Agents via Nacos HTTP API
 
-For scenarios where the console is unavailable, use the [Nacos Create Agent HTTP API](../../admin/admin-api.md#55-创建agentcard).
+For scenarios where the console is unavailable, use the [Nacos Create Agent HTTP API](../../admin/admin-api.md).
 
 Example: Importing the [A2A official sample AgentCard](https://a2a-protocol.org/latest/specification/#57-sample-agent-card):
 
@@ -249,8 +249,8 @@ curl -X POST '127.0.0.1:8848/nacos/v3/admin/ai/a2a' \
 
 Nacos, serving as Agent Registry (A2A Registry), offers:
 
-- [HTTP-based API](../../admin/admin-api.md#5-a2a注册中心)
-- [gRPC-based SDK](../java-sdk/usage.md#7-a2a-注册中心)
+- [HTTP-based API](../../admin/admin-api.md)
+- [gRPC-based SDK](../java-sdk/usage.md)
 
 to assist A2A clients and agent consumers in query Agents (AgentCards).
 
@@ -411,13 +411,13 @@ try {
 
 ### 3.3. Query Agent
 
-Nacos also supports retrieving AgentCard information exactly by Agent name via [HTTP APIs](../../admin/admin-api.md#5-a2a注册中心), and performing fuzzy searches for AgentCard information by Agent name.
+Nacos also supports retrieving AgentCard information exactly by Agent name via [HTTP APIs](../../admin/admin-api.md), and performing fuzzy searches for AgentCard information by Agent name.
 
 > The capability for fuzzy searches based on skills, tags, and descriptions is currently under development.
 
 #### 3.3.1. Query Agent detail information by Name
 
-Through [Query HTTP的API](../../admin/admin-api.md#53-查询agentcard的详情), Query the detail information of an Agent by Agent name. Such as：
+Use the [Query Agent HTTP API](../../admin/admin-api.md) to query the detail information of an Agent by Agent name. Such as:
 
 ```bash
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=GeoSpatial+Route+Planner+Agent'
@@ -425,7 +425,7 @@ curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a?namespaceId=public&agentName=G
 
 #### 3.3.2. Search Agent list by Name
 
-Through[Search HTTP的API](../../admin/admin-api.md#52-查询agentcard的列表)，Search the list of AgentCards by Agent name. Such as：
+Use the [Search Agent HTTP API](../../admin/admin-api.md) to search the list of AgentCards by Agent name. Such as:
 
 ```shell
 curl -X GET '127.0.0.1:8848/nacos/v3/admin/ai/a2a/list?pageNo=1&pageSize=100&agentName=Planner&namespaceId=public&search=blur'

--- a/src/content/docs/next/en/manual/user/ai/api-to-mcp.md
+++ b/src/content/docs/next/en/manual/user/ai/api-to-mcp.md
@@ -1,111 +1,98 @@
 ---
 title: Existing API Migration to MCP Manual
-keywords: [ MCP Server Register,MCP,Existing API,Migration to MCP]
-description: 如何通过Nacos，将已经注册在Nacos上的存量微服务API，转化成为MCP服务
+keywords: [MCP Server Register, MCP, Existing API, Migration to MCP]
+description: Learn how to use Nacos to convert existing microservice APIs registered in Nacos into MCP services.
 sidebar:
   order: 5
 ---
 
-# 存量API转换MCP手册
+# Existing API Migration to MCP
 
-Nacos 能够通过和 [Higress](https://higress.ai) 等AI网关的结合，**0代码改动**地实现将存量API转换成MCP
-服务的能力。本文档将说明如何在Nacos上对已经注册在Nacos中的存量API声明为MCP服务，并通过[Higress](https://higress.ai)
-的协议转换能力进行MCP Tools的调用。
+Nacos can work with AI gateways such as [Higress](https://higress.ai) to convert existing APIs into MCP services with **zero code changes**. This guide explains how to declare APIs that are already registered in Nacos as MCP services, and how to call MCP tools through the protocol conversion capability of [Higress](https://higress.ai).
 
-![API转换MCP原理](/img/doc/manual/user/ai/ai-api-to-mcp.svg)
+![API to MCP architecture](/img/doc/manual/user/ai/ai-api-to-mcp.svg)
 
-## 0. 准备工作
+## 0. Prerequisites
 
-将存量API转换成MCP服务的准备工作主要有：
+Prepare the following components before converting existing APIs into MCP services:
 
-- **部署Nacos引擎** : 在运行环境中部署版本`3.0.0`
-  及以上的Nacos引擎，可参考[Nacos快速开始](../../../quickstart/quick-start.mdx), [Nacos Docker 快速开始](../../../quickstart/quick-start-docker.mdx)
-  或 [Nacos Kubernetes 快速开始](../../../quickstart/quick-start-kubernetes.mdx)。
-- **部署Higress-AI** : 在运行环境中部署版本`2.1.2`
-  及以上的Higress，可参考[Higress Docker 快速开始](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG)
-  或 [Higress Kubernetes 快速开始](https://higress.cn/ai/mcp-quick-start/?spm=36971b57.31888769.0.0.646150f85M2PAG)。
-- **将存量API注册到Nacos引擎中** : 将存量API通过[Nacos SDK](../overview/other-language.md)
-  或 [Spring Cloud](https://sca.aliyun.com/docs/2023/user-guide/nacos/quick-start/?spm=5176.29160081.0.0.74805c72y6j24s)
-  等框架进行注册或自动注册。
+- **Deploy the Nacos engine**: Deploy Nacos `3.0.0` or later in your runtime environment. For details, see [Nacos Quick Start](../../../quickstart/quick-start.mdx), [Nacos Docker Quick Start](../../../quickstart/quick-start-docker.mdx), or [Nacos Kubernetes Quick Start](../../../quickstart/quick-start-kubernetes.mdx).
+- **Deploy Higress AI**: Deploy Higress `2.1.2` or later in your runtime environment. For details, see [Higress Docker Quick Start](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG) or [Higress Kubernetes Quick Start](https://higress.cn/ai/mcp-quick-start/?spm=36971b57.31888769.0.0.646150f85M2PAG).
+- **Register existing APIs in Nacos**: Register existing APIs manually or automatically through [Nacos SDKs](../overview/other-language.md), [Spring Cloud](https://sca.aliyun.com/docs/2023/user-guide/nacos/quick-start/?spm=5176.29160081.0.0.74805c72y6j24s), or another integration framework.
 
-## 1. 将存量服务声明成MCP服务
+## 1. Declare an Existing Service as an MCP Service
 
-打开Nacos控制台`http://${nacos_console_host}:${nacos_console_port}` 如 `http://127.0.0.1:8080`.
+Open the Nacos console at `http://${nacos_console_host}:${nacos_console_port}`, for example `http://127.0.0.1:8080`.
 
-> 首次打开可能需要进行管理员密码的初始化工作，请参考[Nacos控制台手册](../../admin/console.md#3-登录管理)。
+> When you open the console for the first time, you may need to initialize the administrator password. For details, see the [Nacos Console Guide](../../admin/console.md#3-login-management).
 
-点击左侧 `MCP Registry` -> `MCP List` 进入 MCP Registry 页面
+In the left navigation, click `MCP Registry` -> `MCP List` to open the MCP Registry page.
 
-在页面左上角点击`创建MCP Server`，在创建MCP Server页面中填写必要信息，如：
+Click `Create MCP Server` in the upper-left corner, and fill in the required information on the Create MCP Server page:
 
-| 信息            | 描述                                                                     |
-|---------------|------------------------------------------------------------------------|
-| MCP 服务名       | MCP Server 名称，用于区分不同MCP Server                                         |
-| 协议类型          | 请选择`sse`或`streamable`                                                  |
-| HTTP 转 MCP 服务 | 在`协议类型`选择为`sse`或`streamable`之后出现此选项，可选择`http`或`https`，根据存量服务提供的协议类型选择。 |
-| 后端服务          | 在`协议类型`选择为`sse`或`streamable`之后出现此选项，选择`使用已有服务`                         |
-| 服务引用          | 在单选框中选择需要转换的存量服务的服务名                                                   |
-| 描述            | MCP服务的描述，自定义描述此存量服务转化成MCP服务后的描述信息                                      |
-| 服务版本          | MCP服务的版本号，自定义版本号，一般使用如`1.0.0`样式的多级版本号                                  |
+| Field | Description |
+| --- | --- |
+| MCP service name | MCP Server name, used to distinguish different MCP Servers. |
+| Protocol type | Select `sse` or `streamable`. |
+| HTTP to MCP service | Appears after you select `sse` or `streamable` as the protocol type. Select `http` or `https` according to the protocol used by the existing service. |
+| Backend service | Appears after you select `sse` or `streamable` as the protocol type. Select `Use existing service`. |
+| Service reference | Select the existing service that you want to convert. |
+| Description | Description of the MCP service after the existing service is converted. |
+| Service version | Version of the MCP service. Use a semantic-style version such as `1.0.0`. |
 
-填写完成后，点击页面右上角的`发布`即可完成。
+After completing the form, click `Publish` in the upper-right corner.
 
-## 2. 将存量服务的API声明为MCP服务的Tools
+## 2. Declare Existing Service APIs as MCP Tools
 
-打开Nacos控制台`http://${nacos_console_host}:${nacos_console_port}` 如 `http://127.0.0.1:8080`.
+Open the Nacos console at `http://${nacos_console_host}:${nacos_console_port}`, for example `http://127.0.0.1:8080`.
 
-点击左侧 `MCP Registry` -> `MCP List` 进入 MCP Registry 页面
+In the left navigation, click `MCP Registry` -> `MCP List` to open the MCP Registry page.
 
-在列表中找到[上一步骤](#1-将存量服务声明成mcp服务)中创建的MCP服务，在列表的`操作`列中点击`编辑`。
+Find the MCP service created in [the previous step](#1-declare-an-existing-service-as-an-mcp-service), and click `Edit` in the `Actions` column.
 
-在`编辑 MCP Server`页面中，修改`服务版本`为新的版本号
+On the `Edit MCP Server` page, change `Service Version` to a new version.
 
-> 考虑到不同MCP Server的版本兼容性问题，编辑时对于已发布的版本，只能修改Tool以及参数的描述信息以及开关；避免新增，删除，修改参数类型导致的MCP服务不兼容问题。
+> For compatibility between different MCP Server versions, published versions can only update tool descriptions, parameter descriptions, and switches. Avoid adding, deleting, or changing parameter types for a published version because those changes can make the MCP service incompatible.
 
-修改为新版本号后，在页面下方的`Tools`区域中会出现`添加`按钮，点击`添加`按钮，在`添加 MCP Tools`页面中填写必要信息，如：
+After changing the version, an `Add` button appears in the `Tools` section. Click `Add`, and fill in the required information on the Add MCP Tools page:
 
-| 信息        | 描述                                         |
-|-----------|--------------------------------------------|
-| Tool 名称   | MCP Tools的名称，用于区分不同MCP Tools               |
-| Tool 描述   | MCP Tools的描述，自定义描述此存量服务API成MCP服务Tool后的描述信息 |
-| 是否启用      | 是否启用此Tool，默认为启用                            |
-| Tool 入参描述 | 对Mcp Tools的输入参数列表进行描述。                     |
+| Field | Description |
+| --- | --- |
+| Tool name | MCP Tool name, used to distinguish different MCP Tools. |
+| Tool description | Description of the MCP Tool converted from the existing service API. |
+| Enabled | Whether this Tool is enabled. It is enabled by default. |
+| Tool input parameters | Describes the input parameter list for the MCP Tool. |
 
-其中点击`添加属性`能够新增输入参数。
+Click `Add Property` to add an input parameter.
 
-> 注意，只有当焦点处于`参数列表`时，点击`添加属性`
-> 才能新增输入参数。若焦点处于某一参数时，说明此时正在进行此参数的内容编辑，`添加属性`不允许点击。
+> You can add input parameters only when the focus is on `Parameter List`. If the focus is on an existing parameter, the page is editing that parameter and `Add Property` cannot be clicked.
 
-之后再点击需要修改的输入参数，如`NewArg1`；在`参数信息`中进行参数属性的修改，参数属性内容解释如下：
+Then click an input parameter such as `NewArg1`, and edit its attributes in `Parameter Information`:
 
-| 信息     | 描述                                                                                                                     |
-|--------|------------------------------------------------------------------------------------------------------------------------|
-| 名称     | MCP Tools的输入参数名称，用于区分不同参数                                                                                              |
-| 类型     | MCP Tools的输入参数类型，支持`string`、`number`、`integer`、`boolean`、`array`、`object`                                              |
-| 描述     | MCP Tools的输入参数描述，自定义描述此MCP服务Tool参数描述信息                                                                                 |                                                                          |
-| 协议转化配置 | 提供给AI网关或协议转换代理的协议转化配置，用于提供给给AI网关或协议转化代理，此工具实际映射的存量服务的API信息，如`url`，`参数映射关系`等，具体配置细节，请参见[MCP模版配置手册](./mcp-template.md)。 |
+| Field | Description |
+| --- | --- |
+| Name | Input parameter name of the MCP Tool, used to distinguish different parameters. |
+| Type | Input parameter type of the MCP Tool. Supported values include `string`, `number`, `integer`, `boolean`, `array`, and `object`. |
+| Description | Input parameter description for the MCP Tool. |
+| Protocol conversion configuration | Protocol conversion configuration for the AI gateway or protocol conversion proxy. It describes the existing service API that the Tool maps to, such as `url` and parameter mappings. For configuration details, see the [MCP Template Configuration Guide](./mcp-template.md). |
 
-所有Tool的输入参数编辑完成后， 点击`确定`进行保存，之后重复添加其他的Tool信息后，点击页面右上角`发布为最新版本`。
+After all Tool input parameters are edited, click `OK` to save them. Add other Tools if needed, and then click `Publish as Latest Version` in the upper-right corner.
 
-> 页面右上角的`保存`仅会将内容进行保存，不会标记成最新版本，不进行发布最新版本，可能会导致AI网关或协议转换代理无法读取到新改动的工具信息。可用于编辑过程中保存记录以及灰度使用。
+> The `Save` button in the upper-right corner only saves the content. It does not mark the version as latest or publish the latest version, so AI gateways or protocol conversion proxies may not read the updated Tool information. Use it to save drafts during editing or for gray release scenarios.
 
-## 3. 配置协议转换暴露MCP服务
+## 3. Configure Protocol Conversion to Expose the MCP Service
 
-上述步骤已经已经将存量服务及其API声明成了MCP服务及MCP
-Tool，Nacos作为控制面进行声明的存储和下发，但想要实际以MCP协议进行访问，还需要有数据面进行协议转换，目前Higress-AI网关已经提供了协议转换的能力。
+The previous steps declare the existing service and its APIs as an MCP service and MCP Tools. Nacos stores and distributes these declarations as the control plane. To access the service through the MCP protocol, you also need a data plane for protocol conversion. Higress AI Gateway already provides this capability.
 
-Higress-AI网关的部署可参考参考[Higress Docker 快速开始](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG)
-或 [Higress Kubernetes 快速开始](https://higress.cn/ai/mcp-quick-start/?spm=36971b57.31888769.0.0.646150f85M2PAG)
-进行部署，此文档主要说明如何配置：
+For Higress AI Gateway deployment, see [Higress Docker Quick Start](https://higress.cn/ai/mcp-quick-start_docker/?spm=36971b57.31888769.0.0.646150f85M2PAG) or [Higress Kubernetes Quick Start](https://higress.cn/ai/mcp-quick-start/?spm=5176.29160081.0.0.74805c72y6j24s). This guide focuses on the configuration steps.
 
-### 3.1. 开启Higress-AI网关的MCP协议转换
+### 3.1. Enable MCP Protocol Conversion in Higress AI Gateway
 
-参考[Higress ConfigMap 全局参数配置](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE)
-文档，将`data.higress.mcpServer.enable`的值修改为`true`，同时确保`data.higress.mcpServer.redis.address`的地址配置正确.
+Refer to [Higress ConfigMap global parameter configuration](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE), set `data.higress.mcpServer.enable` to `true`, and make sure `data.higress.mcpServer.redis.address` is configured correctly.
 
-> `data.higress.mcpServer.match_list`可保持默认值，默认为`[]`，表示由Higress-AI网关自动进行会话保持管理。
+> `data.higress.mcpServer.match_list` can keep the default value `[]`, which means Higress AI Gateway automatically manages session affinity.
 
-例如：
+Example:
 
 ```yaml
 apiVersion: v1
@@ -116,24 +103,23 @@ data:
   higress: |-
     mcpServer:
       ...
-      enable: true          # 启用 MCP Server
+      enable: true          # Enable MCP Server
       redis:
-        address: ${IP}:6379 # Redis服务地址。
+        address: ${IP}:6379 # Redis service address.
         ...
-      match_list: [] 
+      match_list: []
       ...
 ```
 
-### 3.2. 配置 Nacos 作为 Higress-AI的 MCP Registry
+### 3.2. Configure Nacos as the MCP Registry for Higress AI
 
-参考[Higress 配置 Nacos MCP Registry](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE)
+Refer to [Higress Nacos MCP Registry configuration](https://higress.cn/ai/mcp-quick-start_docker/#configmap-%E5%85%A8%E5%B1%80%E5%8F%82%E6%95%B0%E9%85%8D%E7%BD%AE).
 
-将Nacos作为MCP Registry 服务来源进行配置，配置完毕后可在`Higress的控制台-服务列表`中查看到所有通过MCP协议暴露的存量服务的服务名称。
+After configuring Nacos as the MCP Registry service source, you can view all existing services exposed through MCP in `Higress Console` -> `Service List`.
 
-同时使用`curl http://${higress_ai_host}:${higress_ai_port}/mcp/${your_mcp_server_name}/sse`
-可连接MCP服务，查看到连接MCP服务的sessionId，并定时能看到心跳响应。
+You can also connect to the MCP service with `curl http://${higress_ai_host}:${higress_ai_port}/mcp/${your_mcp_server_name}/sse`, view the session ID of the MCP connection, and receive heartbeat responses periodically.
 
-如，我的MCP服务名称为`restToMcp`：
+For example, if the MCP service name is `restToMcp`:
 
 ```shell
 curl localhost:8080/mcp/restToMcp/sse
@@ -148,7 +134,4 @@ data: {"jsonrpc":"2.0","id":"2025-06-16T03:33:09Z","method":"ping"}
 
 ```
 
-至此，您已经将一个已经注册在Nacos上的存量服务API，转化成为了MCP服务，您可以将此MCP服务配置在各类LLM
-Agent应用上，如`DeepChat`, `Cline`, `Cherry Studio`
-等；或通过[Nacos-Mcp-Router](./nacos-mcp-router.md)，[MCP-Client](https://modelcontextprotocol.io/quickstart/client)，[Spring-AI](https://java2ai.com/docs/1.0.0-M6.1/get-started/?spm=5176.29160081.0.0.6546aa5c63Vkgn)
-进行直接的访问和调用。
+At this point, you have converted an existing service API registered in Nacos into an MCP service. You can configure this MCP service in LLM Agent applications such as `DeepChat`, `Cline`, and `Cherry Studio`, or access and invoke it directly through [Nacos MCP Router](./nacos-mcp-router.md), [MCP Client](https://modelcontextprotocol.io/quickstart/client), or [Spring AI](https://java2ai.com/docs/1.0.0-M6.1/get-started/?spm=5176.29160081.0.0.6546aa5c63Vkgn).

--- a/src/content/docs/next/en/manual/user/ai/nacos-mcp-router.md
+++ b/src/content/docs/next/en/manual/user/ai/nacos-mcp-router.md
@@ -1,48 +1,53 @@
 ---
 title: Nacos MCP Router
-keywords: [Nacos MCP Router,MCP,使用手册]
-description: Nacos MCP Router 使用手册
+keywords: [Nacos MCP Router, MCP, User Guide]
+description: Nacos MCP Router user guide.
 sidebar:
     order: 6
 ---
 
-Nacos MCP Router是一个基于MCP官方SDK开发的标准MCP Server，为MCP Client提供MCP Server的`智能搜索`、`安装`、`代理`等功能， **极大地简化了**MCP服务的使用流程。 同时，Nacos MCP Router跟Nacos MCP Registry结合，可以实现MCP Server治理，如MCP Server及工具可见性、版本管理等。
+Nacos MCP Router is a standard MCP Server built on the official MCP SDK. It provides MCP Clients with MCP Server `intelligent search`, `installation`, and `proxy` capabilities, which **greatly simplifies** MCP service usage. When used together with Nacos MCP Registry, Nacos MCP Router can also support MCP Server governance, such as MCP Server and tool visibility and version management.
 
-![MCP Router架构图](/img/doc/overview/ai-mcp-router-struncture.svg)
+![MCP Router architecture](/img/doc/overview/ai-mcp-router-struncture.svg)
 
-## 功能介绍
-Nacos MCP Router 有两种工作模式：
-1. router模式：默认模式，通过MCP Server推荐、安装及代理其他MCP Server的功能，帮助用户更方便的使用MCP Server服务。
-2. proxy模式：使用环境变量MODE=proxy指定，通过简单配置可以把sse、stdio协议MCP Server转换为streamableHTTP协议MCP Server。
+## Features
 
-在router 模式下，Nacos MCP Router 作为一个标准MCP Server，提供MCP Server推荐、分发、安装及代理其他MCP Server的功能。其主要工具列表为
+Nacos MCP Router has two working modes:
+
+1. Router mode: The default mode. It recommends, installs, and proxies other MCP Servers to help users consume MCP Server services more easily.
+2. Proxy mode: Enabled by setting the `MODE=proxy` environment variable. With simple configuration, it can convert MCP Servers that use `sse` or `stdio` into `streamableHTTP` MCP Servers.
+
+In router mode, Nacos MCP Router works as a standard MCP Server. It recommends, distributes, installs, and proxies other MCP Servers. The main tools are:
+
 1. `search_mcp_server`
-    - 根据任务描述及关键字从MCP注册中心（Nacos）中搜索相关的MCP Server列表
-    - 输入:
-      - `task_description`(string): 任务描述，示例：今天杭州天气如何
-      - `key_words`(string): 任务关键字，示例：天气、杭州
-    - 输出: list of MCP servers and instructions to complete the task.
+   - Searches the MCP Registry (Nacos) for related MCP Servers by task description and keywords.
+   - Input:
+     - `task_description` (string): Task description, for example: "What is the weather in Hangzhou today?"
+     - `key_words` (string): Task keywords, for example: "weather, Hangzhou"
+   - Output: List of MCP servers and instructions to complete the task.
 2. `add_mcp_server`
-    - 添加并初始化一个MCP Server，根据Nacos中的配置与该MCP Server建立连接，等待调用。
-    - 输入:
-      - `mcp_server_name`(string): 需要添加的MCP Server名字
-    - 输出: MCP Server工具列表及使用方法
+   - Adds and initializes an MCP Server, connects to it according to the configuration in Nacos, and waits for calls.
+   - Input:
+     - `mcp_server_name` (string): Name of the MCP Server to add.
+   - Output: MCP Server tool list and usage instructions.
 3. `use_tool`
-   - 代理其他MCP Server的工具
-   - 输入:
-     - `mcp_server_name`(string): 被调的目标MCP Server名称.
-     - `mcp_tool_name`(string): 被调的目标MCP Server的工具名称
-     - `params`(map): 被调的目标MCP Server的工具的参数
-   - 输出: 被调的目标MCP Server的工具的输出结果
+   - Proxies tools from another MCP Server.
+   - Input:
+     - `mcp_server_name` (string): Name of the target MCP Server.
+     - `mcp_tool_name` (string): Name of the target MCP Server tool.
+     - `params` (map): Parameters of the target MCP Server tool.
+   - Output: Output result from the target MCP Server tool.
 
-在proxy 模式下，Nacos MCP Router 仅提供代理功能，无需代码改动即可实现stdio、sse协议一键转换为streamableHTTP协议。
- 
+In proxy mode, Nacos MCP Router only provides proxy capability. It can convert existing `stdio` or `sse` MCP Servers into the `streamableHTTP` protocol without code changes.
 
-## router模式
-**启动Nacos MCP Router**
+## Router Mode
 
-### stdio协议
-* 使用uvx
+**Start Nacos MCP Router**
+
+### stdio Protocol
+
+* Use uvx
+
     ```json
     {
         "mcpServers":
@@ -56,15 +61,17 @@ Nacos MCP Router 有两种工作模式：
                 ],
                 "env":
                 {
-                    "NACOS_ADDR": "<NACOS-ADDR>, 选填，默认为127.0.0.1:8848",
-                    "NACOS_USERNAME": "<NACOS-USERNAME>, 选填，默认为nacos",
-                    "NACOS_PASSWORD": "<NACOS-PASSWORD>, 必填"
+                    "NACOS_ADDR": "<NACOS-ADDR>, optional, defaults to 127.0.0.1:8848",
+                    "NACOS_USERNAME": "<NACOS-USERNAME>, optional, defaults to nacos",
+                    "NACOS_PASSWORD": "<NACOS-PASSWORD>, required"
                 }
             }
         }
-    }   
+    }
     ```
-* 使用docker
+
+* Use Docker
+
     ```json
     {
         "mcpServers": {
@@ -78,8 +85,10 @@ Nacos MCP Router 有两种工作模式：
     }
     ```
 
-### sse协议
-* uvx启动
+### sse Protocol
+
+* Start with uvx
+
     ```shell
     export NACOS_ADDR=127.0.0.1:8848
     export NACOS_USERNAME=nacos
@@ -87,13 +96,17 @@ Nacos MCP Router 有两种工作模式：
     export TRANSPORT_TYPE=sse
     uvx nacos-mcp-router@latest
     ```
-* docker启动
+
+* Start with Docker
+
     ```shell
     docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=sse nacos-mcp-router:latest
     ```
 
-### streamableHTTP 协议
-* uvx启动
+### streamableHTTP Protocol
+
+* Start with uvx
+
     ```shell
     export NACOS_ADDR=127.0.0.1:8848
     export NACOS_USERNAME=nacos
@@ -101,12 +114,19 @@ Nacos MCP Router 有两种工作模式：
     export TRANSPORT_TYPE=streamable_http
     uvx nacos-mcp-router@latest
     ```
-* docker启动
+
+* Start with Docker
+
     ```shell
     docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http nacos-mcp-router:latest
     ```
-### 使用,Nacos-MCP-Router,以CherryStudio为例，MCP配置如下
-* stdio模式配置
+
+### Use Nacos MCP Router with Cherry Studio
+
+The following examples show MCP configurations for Cherry Studio.
+
+* stdio mode configuration
+
     ```json
     {
             "mcpServers": {
@@ -120,7 +140,8 @@ Nacos MCP Router 有两种工作模式：
         }
     ```
 
-* sse模式配置
+* sse mode configuration
+
     ```json
     {
             "mcpServers": {
@@ -131,7 +152,8 @@ Nacos MCP Router 有两种工作模式：
         }
     ```
 
-* streamableHTTP模式配置
+* streamableHTTP mode configuration
+
     ```json
      {
             "mcpServers": {
@@ -142,37 +164,39 @@ Nacos MCP Router 有两种工作模式：
         }
     ```
 
+## Proxy Mode
 
-## proxy模式
-proxy模式诞生的初衷是帮助存量stdio、sse协议的MCP Server转换为streamableHTTP协议，享受streamableHTTP协议带来的好处。proxy模式下，Nacos MCP Router仅做请求透明转发，对外暴露目标MCP Server的工具列表。
+Proxy mode is designed to convert existing `stdio` and `sse` MCP Servers into the `streamableHTTP` protocol so they can benefit from streamableHTTP. In proxy mode, Nacos MCP Router only transparently forwards requests and exposes the target MCP Server tool list.
 
-proxy模式下，需设置环境变量MODE=proxy和PROXIED_MCP_NAME=<MCP Server Name>
-* 使用uvx
+In proxy mode, set the `MODE=proxy` and `PROXIED_MCP_NAME=<MCP Server Name>` environment variables.
+
+* Use uvx
+
     ```bash
-    export NACOS_ADDR=$NACOS_ADDR 
+    export NACOS_ADDR=$NACOS_ADDR
     export NACOS_USERNAME=$NACOS_USERNAME
-    export NACOS_PASSWORD=$NACOS_PASSWORD 
+    export NACOS_PASSWORD=$NACOS_PASSWORD
     export TRANSPORT_TYPE=streamable_http
     export MODE=proxy
-    export PROXIED_MCP_NAME=$PROXIED_MCP_NAME 
+    export PROXIED_MCP_NAME=$PROXIED_MCP_NAME
     uvx nacos-mcp-router@latest
     ```
-* 使用docker
+
+* Use Docker
+
     ```bash
     docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http -e MODE=proxy -e PROXIED_MCP_NAME=$PROXIED_MCP_NAME  nacos-mcp-router:latest
     ```
 
+## Environment Variables
 
-## 环境变量配置
-
-|    |               |                |      |                                           |
-|----|---------------|----------------|------|-------------------------------------------|
-|  参数 | 描述            | 默认值            | 是否必填 | 备注                                        |
-| NACOS_ADDR | Nacos 服务器地址   | 127.0.0.1:8848 | 否    | 填写 Nacos 服务器的地址，如 192.168.1.1:8848，注意要写端口 |
-| NACOS_USERNAME | Nacos 用户名     | nacos          | 否    | 填写 Nacos 用户名，如 nacos                      |
-| NACOS_PASSWORD | Nacos 密码      | 密码             | 是    | 填写 Nacos 密码，如 nacos                       |
-|NACOS_NAMESPACE| Nacos命名空间     | public         | 否    | Nacos命名空间，如 public                        |
-| TRANSPORT_TYPE | 传输协议类型        | stdio          | 否    | 填写传输协议类型，可选值：stdio、sse、streamable_http    |
-| PROXIED_MCP_NAME | 代理的 MCP 服务器名称 | -              | 否    | proxy模式下需要被转换的 MCP 服务器名称，需要先注册到Nacos      |
-| MODE | 工作模式          | router         | 否    | 可选的值：router、proxy                         |
-| PORT | 服务端口          | 8000           | 否    | 协议类型为sse或streamable时使用                    |
+| Parameter | Description | Default | Required | Notes |
+| --- | --- | --- | --- | --- |
+| NACOS_ADDR | Nacos server address | 127.0.0.1:8848 | No | Nacos server address, such as 192.168.1.1:8848. Include the port. |
+| NACOS_USERNAME | Nacos username | nacos | No | Nacos username, such as nacos. |
+| NACOS_PASSWORD | Nacos password | password | Yes | Nacos password, such as nacos. |
+| NACOS_NAMESPACE | Nacos namespace | public | No | Nacos namespace, such as public. |
+| TRANSPORT_TYPE | Transport protocol type | stdio | No | Supported values: stdio, sse, streamable_http. |
+| PROXIED_MCP_NAME | Proxied MCP Server name | - | No | Name of the MCP Server to convert in proxy mode. It must already be registered in Nacos. |
+| MODE | Working mode | router | No | Supported values: router, proxy. |
+| PORT | Server port | 8000 | No | Used when the protocol type is sse or streamable. |

--- a/src/content/docs/next/en/manual/user/ai/skill-registry.md
+++ b/src/content/docs/next/en/manual/user/ai/skill-registry.md
@@ -247,7 +247,7 @@ Skill Registry provides multiple access methods. Refer to the respective documen
 
 ### 4.1. nacos-cli
 
-[nacos-cli](../../admin/nacos-cli.md) is the command-line tool for Skill Registry, providing Skill search, installation, upload, and sync capabilities. For detailed installation and Skill commands, see [Nacos CLI User Guide - AI Skill commands](../../admin/nacos-cli.md#51-ai-技能管理-).
+[nacos-cli](../../admin/nacos-cli.md) is the command-line tool for Skill Registry, providing Skill search, installation, upload, and sync capabilities. For detailed installation and Skill commands, see [Nacos CLI User Guide - AI Skill commands](../../admin/nacos-cli.md).
 
 ### 4.2. REST API
 
@@ -255,9 +255,9 @@ Skill Registry provides three layers of REST APIs:
 
 | API Layer | Description | Documentation |
 |-----------|-------------|---------------|
-| **Client API** | Client runtime query/download Skills (supports anonymous access) | [Client API - Download Skill](../open-api.md#34-下载-skill) |
-| **Console API** | Console operations (requires login authentication) | [Console API - Skills](../../admin/console-api.md#7-skills-管理) |
-| **Admin API** | Cluster internal management interface | [Admin API - AI Skills](../../admin/admin-api.md#7-ai-skills-管理) |
+| **Client API** | Client runtime query/download Skills (supports anonymous access) | [Client API - Download Skill](../open-api.md) |
+| **Console API** | Console operations (requires login authentication) | [Console API - Skills](../../admin/console-api.md) |
+| **Admin API** | Cluster internal management interface | [Admin API - AI Skills](../../admin/admin-api.md) |
 
 ### 4.3. Java SDK
 
@@ -265,5 +265,5 @@ Nacos provides two Java SDKs for programmatic Skill management:
 
 | SDK | Use Case | Documentation |
 |-----|----------|---------------|
-| **nacos-client** | Client runtime Skill loading and subscription | [Java SDK - Skill](../java-sdk/usage.md#8-skill-能力) |
-| **nacos-maintainer-client** | Operations management (create, publish, online/offline, etc.), suitable for automation and CI/CD | [Maintainer SDK - Skill](../../admin/maintainer-sdk.md#9-skill-能力) |
+| **nacos-client** | Client runtime Skill loading and subscription | [Java SDK - Skill](../java-sdk/usage.md) |
+| **nacos-maintainer-client** | Operations management (create, publish, online/offline, etc.), suitable for automation and CI/CD | [Maintainer SDK - Skill](../../admin/maintainer-sdk.md) |


### PR DESCRIPTION
## Summary
- Continue #1099 with the manual/user/ai batch.
- Remove Chinese residuals from the English AI user docs in both latest and next.
- Keep the work split into file-oriented commits for review.

## Commits
- docs: clean AI registry English links
- docs: translate API to MCP guide
- docs: translate Nacos MCP Router guide

## Scope
- Updates Skill Registry and Agent Registry links/text that contained Chinese anchors or mixed Chinese wording.
- Fully translates the API-to-MCP guide and Nacos MCP Router guide into English.
- Keeps commands, image paths, and external links intact unless the link text needed English alignment.

## Validation
- Chinese-character scan over latest/next English manual/user/ai docs: no matches.
- git diff --check: passed.
- npm run build: blocked locally by the existing Rollup optional native dependency loading failure (@rollup/rollup-darwin-arm64 code signature / optional dependency issue) before Astro build.