### PR TITLE
docs: align English Go SDK and addressing docs

### DIFF
--- a/src/content/docs/latest/en/manual/user/addressing.mdx
+++ b/src/content/docs/latest/en/manual/user/addressing.mdx
@@ -1,43 +1,43 @@
 ---
-title: Nacos 客户端寻址
-keywords: [寻地, 客户端, server-addr, endpoint, 地址服务器, 服务端地址配置]
-description: 本文介绍了各语言SDK如何配置寻找Nacos服务器的地址逻辑，以及多种不同的寻址方式的优先级。
+title: Nacos Client Addressing
+keywords: [addressing, client, server-addr, endpoint, address server, server address configuration]
+description: This document describes how SDKs in different languages configure the logic for finding Nacos Server addresses, and the priority of different addressing methods.
 sidebar:
   order: 10
 ---
 
 import {Tabs, TabItem} from '@astrojs/starlight/components';
 
-# Nacos 客户端寻址
+# Nacos Client Addressing
 
-在使用Nacos时， Nacos客户端需要配置Nacos服务器的地址，以确保客户端能连接到Nacos服务器，从而实现服务发现和注册等功能。
+When using Nacos, the Nacos client must configure the Nacos Server address so that the client can connect to Nacos Server and implement features such as service discovery and registration.
 
-本文档将介绍Nacos客户端的各种寻址逻辑，以及多种不同的寻址方式的优先级；对于部分支持拓展寻址的编程语言的客户端，本文档还会介绍如何实现自定义的寻址逻辑。
+This document describes the addressing logic of Nacos clients and the priority of different addressing methods. For clients in some programming languages that support extended addressing, this document also describes how to implement custom addressing logic.
 
-## 1. 客户端寻址基本逻辑
+## 1. Basic Client Addressing Logic
 
-Nacos的所有客户端在寻址Nacos服务端时，虽然具体的实现有所差异，但基本都遵循如下逻辑：
+When Nacos clients locate Nacos Server, the specific implementation may vary, but the basic logic is as follows:
 
-![寻址基本逻辑](/img/doc/manual/user/client-addressing.svg)
+![Basic addressing logic](/img/doc/manual/user/client-addressing.svg)
 
-1. 首先，Nacos客户端会根据初始化时，接受来自应用的配置，如`Properties`等信息；
-2. 在Nacos客户端初始化过程中，会创建一个`ServerListManager（服务列表管理器）`，用于管理服务端的地址列表；
-3. 根据传入的`Properties`配置信息，`ServerListManager`会选择一个对应的`ServerListProvider（服务列表提供者）`来实际获取服务端地址列表，默认情况下，Nacos客户端会提供基于`server-addr配置`的`PropertiesServerListProvider`，和`Endpoint 地址服务器`的`EndpointServerListProvider`；
-4. 在`ServerListManager`完成`ServerListProvider`的选取、初始化以及从其中获取到服务端地址列表后，Nacos客户端才会创建用于通信的`GrpcClient`，并使用`ServerListManager`管理的服务端地址列表来创建连接，并请求对应的Nacos Server。
+1. First, the Nacos client receives configuration from the application during initialization, such as `Properties`.
+2. During Nacos client initialization, a `ServerListManager` is created to manage the server address list.
+3. Based on the passed `Properties` configuration, `ServerListManager` selects the corresponding `ServerListProvider` to actually obtain the server address list. By default, the Nacos client provides `PropertiesServerListProvider` based on `server-addr` configuration and `EndpointServerListProvider` based on an endpoint address server.
+4. After `ServerListManager` selects and initializes the `ServerListProvider` and obtains the server address list from it, the Nacos client creates the `GrpcClient` used for communication, uses the server address list managed by `ServerListManager` to create connections, and sends requests to the corresponding Nacos Server.
 
-不同的`ServerListProvider`会导致客户端在寻找服务端地址列表时的行为有所不同，下文对不同`ServerListProvider`的使用条件、行为结果、优先级等特性进行说明：
+Different `ServerListProvider` implementations lead to different client behavior when finding the server address list. The following sections describe the usage conditions, behavior, results, priorities, and other characteristics of different `ServerListProvider` implementations.
 
-### 1.1. 基于配置的寻址逻辑
+### 1.1. Configuration-based Addressing Logic
 
-Nacos客户端默认提供了基于配置的`ServerListProvider`，即`PropertiesServerListProvider`，该`ServerListProvider`会根据`server-addr`配置，从配置中获取服务端地址列表，若配置中存在多个服务端地址，Nacos客户端将会使用`,`和`;`字符进行分割、并最终随机选择一个作为服务端地址。
+The Nacos client provides a configuration-based `ServerListProvider` by default: `PropertiesServerListProvider`. This `ServerListProvider` obtains the server address list from configuration based on the `server-addr` setting. If multiple server addresses exist in the configuration, the Nacos client splits them by `,` and `;`, and finally randomly selects one as the server address.
 
-若当前选择的服务端地址不可用，则Nacos客户端会按照轮询的方式，依次尝试使用其他服务端地址，当尝试所有的地址之后，会回到第一个服务端地址，继续轮询，直至找到可用的服务端地址或客户端中止。
+If the currently selected server address is unavailable, the Nacos client tries other server addresses one by one in round-robin mode. After trying all addresses, it returns to the first server address and continues polling until an available server address is found or the client stops.
 
-这种寻址方式的最大优点是，Nacos客户端的配置非常简单，只需要配置`server-addr`即可，无需配置额外的服务端地址列表配置；同时也无需部署额外的组件；但是，这种寻址方式相对不灵活，无法动态的修改服务端地址列表，需要修改时只能重新创建一个新的Nacos客户端使用。
+The biggest advantage of this addressing method is its simple Nacos client configuration. You only need to configure `server-addr`; no additional server address list configuration or extra component deployment is required. However, this addressing method is less flexible because the server address list cannot be dynamically modified. To change it, you must create a new Nacos client.
 
-使用示例：
+Example:
 
-> 注意：不同编程语言的配置方式可能存在差异，请根据实际情况修改。
+> Note: Configuration methods may differ across programming languages. Adjust them according to your actual situation.
 
 <Tabs>
   <TabItem label="Java">
@@ -90,36 +90,36 @@ Nacos客户端默认提供了基于配置的`ServerListProvider`，即`Propertie
     )
     ```
   </TabItem>
-  <TabItem label="其他语言">
-    待补充
+  <TabItem label="Other Languages">
+    To be added.
   </TabItem>
 </Tabs>
 
-### 1.2. 基于Endpoint地址服务器的寻址逻辑
+### 1.2. Endpoint Address Server-based Addressing Logic
 
-Nacos客户端还提供了基于地址服务器的寻址方式，即`EndpointServerListProvider`，该`ServerListProvider`会根据`endpoint`配置，从`endpoint`所指向的地址服务器中获取服务端地址列表；
+The Nacos client also provides an address server-based addressing method: `EndpointServerListProvider`. This `ServerListProvider` obtains the server address list from the address server pointed to by the `endpoint` configuration.
 
-地址服务器可以是任意一个提供对应HTTP接口的服务端，例如一个`nginx`,`tomcat服务端`,`Nacos的address模块等`等等；对应接口需要按照格式返回Nacos服务端的地址列表，格式为每行一个地址，例如：
+The address server can be any server that provides the corresponding HTTP interface, such as `nginx`, a `Tomcat server`, or the `Nacos address module`. The corresponding interface must return the Nacos Server address list in the required format, with one address per line, for example:
 
 ```
 127.0.0.1:8848
 1.1.1.1
 ```
 
-若返回的地址没有端口，则默认端口为8848。
+If a returned address does not contain a port, the default port is 8848.
 
-同样地，Nacos客户端会随机选择列表中的一个地址作为服务端地址，并使用该地址访问Nacos服务端；若该地址不可用，则Nacos客户端会按照轮询的方式，依次尝试使用其他服务端地址，当尝试所有的地址之后，会回到第一个服务端地址，继续轮询，直至找到可用的服务端地址或客户端中止。
+Similarly, the Nacos client randomly selects one address from the list as the server address and uses it to access Nacos Server. If the address is unavailable, the Nacos client tries other server addresses one by one in round-robin mode. After trying all addresses, it returns to the first server address and continues polling until an available server address is found or the client stops.
 
-该寻址方式的最大优点是可以动态的更新客户端所连接的服务端地址列表，无需重启客户端；但是，这种寻址方式需要额外部署一个地址服务器以提供对应的更新和获取地址列表的接口、同时可能需要配置的内容较多，适合Nacos部署规模较大的场景。
+The biggest advantage of this addressing method is that the server address list connected by the client can be dynamically updated without restarting the client. However, this method requires deploying an additional address server to provide interfaces for updating and obtaining the address list, and it may require more configuration. It is suitable for scenarios where the Nacos deployment is large.
 
-使用示例：
+Example:
 
-> 注意：不同编程语言的配置方式可能存在差异，请根据实际情况修改。
+> Note: Configuration methods may differ across programming languages. Adjust them according to your actual situation.
 
 <Tabs>
   <TabItem label="Java">
 
-    更多地址服务器相关配置，请参考[Java SDK 配置参数-通用参数](./java-sdk/properties/#21-通用参数)。
+    For more address server-related configuration, see [Java SDK Properties - Common Parameters](./java-sdk/properties/#21-common-parameters).
 
     ```java
     try {
@@ -151,37 +151,37 @@ Nacos客户端还提供了基于地址服务器的寻址方式，即`EndpointSer
     )
     ```
   </TabItem>
-  <TabItem label="其他语言">
-    待补充
+  <TabItem label="Other Languages">
+    To be added.
   </TabItem>
 </Tabs>
 
-### 1.3. 不同寻址逻辑的触发优先级
+### 1.3. Trigger Priority of Different Addressing Logic
 
-当Nacos客户端启动时， 同时配置了不同的寻址逻辑，Nacos客户端会按照以下优先级进行服务端地址的获取：
+When the Nacos client starts and multiple addressing methods are configured at the same time, the Nacos client obtains server addresses in the following priority order:
 
-1. 优先使用`EndpointServerListProvider`，尝试读取`endpoint`相关配置，若存在，则使用`EndpointServerListProvider`获取服务端地址列表，`endpoint`相关配置默认又遵循如下优先级；
-- 1.1. 其中环境变量`ALIBABA_ALIWARE_ENDPOINT_URL`的优先级最高，如果存在，则使用`ALIBABA_ALIWARE_ENDPOINT_URL`作为地址服务器地址；
-- 1.2. 其次是初始化时传入的Properties中`endpoint`配置优先，如果存在，则使用`endpoint`所配置的地址作为地址服务器地址；
-- 1.3. 再优先是JVM参数中配置的`endpoint`配置优先，如果存在，则使用JVM中的`endpoint`所配置的地址作为地址服务器地址；
-- 1.4. 最后是环境变量中的`endpoint`，如果存在，使用环境变量中`endpoint`中配置的地址作为地址服务器地址；
-2. 若以上关于`EndpointServerListProvider`的配置均不存在，则使用`PropertiesServerListProvider`
-- 1.1. 优先使用初始化时传入的Properties中`serverAddr`配置，如果存在，则使用`serverAddr`配置的地址作为Nacos服务端地址列表；
-- 1.2. 其次是JVM参数中配置的`serverAddr`配置，如果存在，则使用JVM中的`serverAddr`配置的地址作为Nacos服务端地址列表；
-- 1.3. 最后是环境变量中的`serverAddr`，如果存在，使用环境变量中`serverAddr`中配置的地址作为Nacos服务端地址列表；
+1. `EndpointServerListProvider` is used first. The client attempts to read `endpoint`-related configuration. If it exists, `EndpointServerListProvider` is used to obtain the server address list. By default, `endpoint`-related configuration follows this priority:
+   - 1.1. The environment variable `ALIBABA_ALIWARE_ENDPOINT_URL` has the highest priority. If it exists, `ALIBABA_ALIWARE_ENDPOINT_URL` is used as the address server address.
+   - 1.2. Next, the `endpoint` configuration in the `Properties` passed during initialization takes priority. If it exists, the address configured by `endpoint` is used as the address server address.
+   - 1.3. Then, the `endpoint` configuration in JVM parameters takes priority. If it exists, the address configured by `endpoint` in the JVM is used as the address server address.
+   - 1.4. Finally, the `endpoint` in environment variables is used if it exists.
+2. If none of the preceding `EndpointServerListProvider` configurations exist, `PropertiesServerListProvider` is used:
+   - 2.1. The `serverAddr` configuration in the `Properties` passed during initialization is used first. If it exists, the address configured by `serverAddr` is used as the Nacos Server address list.
+   - 2.2. Next, the `serverAddr` configuration in JVM parameters is used if it exists.
+   - 2.3. Finally, the `serverAddr` in environment variables is used if it exists.
 
-> 以上配置中的配置优先级顺序为默认情况下的优先级顺序， 不同的编程语言客户端的优先级可能存在差异，请根据实际情况修改；另外，如果设置了[Java SDK 读取配置的优先级顺序](./java-sdk/properties/#13-如何使用)，除了`ALIBABA_ALIWARE_ENDPOINT_URL`以外，其余的配置优先级顺序将会按照设置的优先级顺序进行读取。
+> The preceding priority order is the default priority order. Clients in different programming languages may have different priority orders. Adjust them according to your actual situation. In addition, if [the Java SDK configuration lookup priority](./java-sdk/properties/#13-usage) is set, all configuration items except `ALIBABA_ALIWARE_ENDPOINT_URL` are read according to the configured priority order.
 
-## 2. 自定义的寻址方式
+## 2. Custom Addressing Method
 
-> 目前仅Java SDK支持自定义的寻址方式，其他语言的SDK暂不支持。
+> Currently, only the Java SDK supports custom addressing methods. SDKs in other languages do not support this yet.
 
-Nacos的Java SDK通过SPI，可以自定义ServerListProvider，实现自定义的寻址方式：
+The Nacos Java SDK can customize `ServerListProvider` through SPI to implement custom addressing methods.
 
-### 2.1. 引入依赖
+### 2.1. Add Dependencies
 
 ```xml
-<!-- 2.5.0以上的nacos-client版本支持自定义ServerListProvider -->
+<!-- nacos-client versions later than 2.5.0 support custom ServerListProvider. -->
 <dependency>
   <groupId>com.alibaba.nacos</groupId>
   <artifactId>nacos-client</artifactId>
@@ -189,36 +189,36 @@ Nacos的Java SDK通过SPI，可以自定义ServerListProvider，实现自定义�
 </dependency>
 ```
 
-### 2.2. 实现自定义ServerListProvider
+### 2.2. Implement a Custom ServerListProvider
 
-实现接口`com.alibaba.nacos.client.address.ServerListProvider`
+Implement the `com.alibaba.nacos.client.address.ServerListProvider` interface.
 
-ServerListProvider的相应接口如果：
+The corresponding `ServerListProvider` interfaces are as follows:
 
-|方法名|入参内容|返回内容|描述|
+| Method | Input | Return | Description |
 |-----|-----|-----|---|
-|init|NacosClientProperties, NacosRestTemplate|void|初始化时会调用此接口注入Nacos的配置，HTTP客户端等，以便于您读取初始化时传入的参数，以及通过HTTP接口访问获取其他信息等|
-|getServerList|无|List&lt;String>|`ServerListManager`会调用此接口，获取服务端地址列表|
-|getServerName|无|String|获取`ServerListProvider`所对应的服务端名称，用于标记地址列表所对应的服务端名称|
-|getNamespace|无|String|获取`ServerListProvider`所归属的命名空间，也即此Nacos客户端所归属的命名空间|
-|getContextPath|无|String|获取`ServerListProvider`所对应的服务端上下文路径，当Nacos服务端配置了上下文路径时，需要此上下文路径，以便于Nacos客户端访问服务端|
-|getOrder|无|int|获取`ServerListProvider`的优先级，数字越大优先级越高，`EndpointServerListProvider`的优先级为`500`,`PropertiesServerListProvider`的优先级为499|
-|match|NacosClientProperties|boolean|判断当前`ServerListProvider`是否匹配当前Nacos客户端的配置，如果匹配，则Nacos客户端会调用`init`对此`ServerListProvider`进行初始化|
-|isFixed|无|boolean|判断当前`ServerListProvider`是否所提供的地址列表是否为固定的，比如`EndpointServerListProvider`是可变的，`PropertiesServerListProvider`是固定的|
-|getAddressSource|无|String|获取`ServerListProvider`的地址列表来源地址，比如`EndpointServerListProvider`返回是`Endpoint`的地址，`PropertiesServerListProvider`是``（空字符串）|
-|shutdown|无|void|关闭`ServerListProvider`，关闭时会调用此接口，以便于您关闭相关资源，比如关闭HTTP客户端等|
+| init | NacosClientProperties, NacosRestTemplate | void | Called during initialization to inject Nacos configuration, the HTTP client, and other objects, so that you can read parameters passed during initialization and obtain other information through HTTP APIs. |
+| getServerList | None | List&lt;String> | Called by `ServerListManager` to obtain the server address list. |
+| getServerName | None | String | Gets the server name corresponding to this `ServerListProvider`, used to mark the server name corresponding to the address list. |
+| getNamespace | None | String | Gets the namespace to which this `ServerListProvider` belongs, namely the namespace to which this Nacos client belongs. |
+| getContextPath | None | String | Gets the server context path corresponding to this `ServerListProvider`. When Nacos Server is configured with a context path, this context path is required so the Nacos client can access the server. |
+| getOrder | None | int | Gets the priority of `ServerListProvider`. A larger number indicates a higher priority. The priority of `EndpointServerListProvider` is `500`, and the priority of `PropertiesServerListProvider` is `499`. |
+| match | NacosClientProperties | boolean | Determines whether the current `ServerListProvider` matches the current Nacos client configuration. If it matches, the Nacos client calls `init` to initialize this `ServerListProvider`. |
+| isFixed | None | boolean | Determines whether the address list provided by the current `ServerListProvider` is fixed. For example, `EndpointServerListProvider` is variable, while `PropertiesServerListProvider` is fixed. |
+| getAddressSource | None | String | Gets the source address of the address list for this `ServerListProvider`. For example, `EndpointServerListProvider` returns the `Endpoint` address, and `PropertiesServerListProvider` returns `` (empty string). |
+| shutdown | None | void | Shuts down the `ServerListProvider`. This interface is called during shutdown so that you can close related resources, such as the HTTP client. |
 
-### 2.3. 使用自定义ServerListProvider
+### 2.3. Use a Custom ServerListProvider
 
-添加对应的SPI配置文件`META-INF/services/com.alibaba.nacos.client.address.ServerListProvider`到您的`resources`目录中。
+Add the corresponding SPI configuration file `META-INF/services/com.alibaba.nacos.client.address.ServerListProvider` to your `resources` directory.
 
-比如内容为：
+Example content:
 
 ```
 org.example.MyServerListProvider
 ```
 
-随后在初始化时传入的Properties中配置能让自定义ServerListProvider匹配到的对应参数，比如代码为：
+Then, in the `Properties` passed during initialization, configure the corresponding parameters that allow the custom `ServerListProvider` to match. For example:
 
 ```java
 public class MyServerListProvider implements ServerListProvider {
@@ -233,7 +233,7 @@ public class MyServerListProvider implements ServerListProvider {
 }
 ```
 
-配置内容应该为：
+The configuration should be:
 
 ```properties
 example.server.list.provider=true

--- a/src/content/docs/latest/en/manual/user/go-sdk/usage.md
+++ b/src/content/docs/latest/en/manual/user/go-sdk/usage.md
@@ -9,37 +9,37 @@ sidebar:
 # Go SDK Usage
 
 
-## 使用限制
+## Usage Limits
 Go>=v1.15
 
 Nacos>2.x
 
-## 安装
-使用`go get`安装SDK：
+## Installation
+Install the SDK with `go get`:
 ```sh
 $ go get -u github.com/nacos-group/nacos-sdk-go/v2
 ```
-## 快速使用
-* 初始化客户端配置ClientConfig
+## Quick Start
+* Initialize the client configuration `ClientConfig`
 
 ```go
 constant.ClientConfig{
-  TimeoutMs            uint64 // 请求Nacos服务端的超时时间，默认是10000ms
-  NamespaceId          string // Nacos的命名空间Id
-  Endpoint             string // 当使用地址服务器时，需要该配置. https://help.aliyun.com/document_detail/130146.html
-  RegionId             string // Nacos&KMS的regionId，用于配置中心的鉴权
-  AccessKey            string // Nacos&KMS的AccessKey，用于配置中心的鉴权
-  SecretKey            string // Nacos&KMS的SecretKey，用于配置中心的鉴权
-  OpenKMS              bool   // 是否开启kms，默认不开启，kms可以参考文档 https://help.aliyun.com/product/28933.html
-                              // 同时DataId必须以"cipher-"作为前缀才会启动加解密逻辑
-  CacheDir             string // 缓存service信息的目录，默认是当前运行目录
-  UpdateThreadNum      int    // 监听service变化的并发数，默认20
-  NotLoadCacheAtStart  bool   // 在启动的时候不读取缓存在CacheDir的service信息
-  UpdateCacheWhenEmpty bool   // 当service返回的实例列表为空时，不更新缓存，用于推空保护
-  Username             string // Nacos服务端的API鉴权Username
-  Password             string // Nacos服务端的API鉴权Password
-  LogDir               string // 日志存储路径
-  LogLevel             string // 日志默认级别，值必须是：debug,info,warn,error，默认值是info
+  TimeoutMs            uint64 // Timeout for requests to Nacos Server. The default value is 10000 ms.
+  NamespaceId          string // Nacos namespace ID.
+  Endpoint             string // Required when using an address server. https://help.aliyun.com/document_detail/130146.html
+  RegionId             string // Nacos and KMS region ID, used for config center authentication.
+  AccessKey            string // Nacos and KMS AccessKey, used for config center authentication.
+  SecretKey            string // Nacos and KMS SecretKey, used for config center authentication.
+  OpenKMS              bool   // Whether to enable KMS. It is disabled by default. See https://help.aliyun.com/product/28933.html
+                              // DataId must also use the "cipher-" prefix to enable encryption and decryption logic.
+  CacheDir             string // Directory for caching service information. The default value is the current working directory.
+  UpdateThreadNum      int    // Concurrency for listening to service changes. The default value is 20.
+  NotLoadCacheAtStart  bool   // Whether not to load service information cached in CacheDir during startup.
+  UpdateCacheWhenEmpty bool   // Whether not to update the cache when the service returns an empty instance list, used for empty-push protection.
+  Username             string // Username for Nacos Server API authentication.
+  Password             string // Password for Nacos Server API authentication.
+  LogDir               string // Log storage path.
+  LogLevel             string // Default log level. Valid values: debug, info, warn, error. The default value is info.
   LogSampling          *ClientLogSamplingConfig // the sampling config of log
   LogRollingConfig     *ClientLogRollingConfig  // the log rolling config
 }
@@ -49,22 +49,22 @@ constant.ClientConfig{
 
 ```go
 constant.ServerConfig{
-  ContextPath string // Nacos的ContextPath，默认/nacos，在2.0中不需要设置
-  IpAddr      string // Nacos的服务地址
-  Port        uint64 // Nacos的服务端口
-  Scheme      string // Nacos的服务地址前缀，默认http，在2.0中不需要设置
-  GrpcPort    uint64 // Nacos的 grpc 服务端口, 默认为 服务端口+1000, 不是必填
+  ContextPath string // Nacos ContextPath. The default value is /nacos. It is not required in 2.0.
+  IpAddr      string // Nacos service address.
+  Port        uint64 // Nacos service port.
+  Scheme      string // Nacos service address scheme. The default value is http. It is not required in 2.0.
+  GrpcPort    uint64 // Nacos gRPC service port. The default value is service port + 1000. It is optional.
 }
 ```
 
-<b>Note：我们可以配置多个ServerConfig，客户端会对这些服务端做轮询请求</b>
+<b>Note: You can configure multiple ServerConfig entries. The client sends polling requests to these servers.</b>
 
 ### Create client
 
 ```go
-// 创建clientConfig
+// Create clientConfig.
 clientConfig := constant.ClientConfig{
-  NamespaceId:         "e525eafa-f7d7-4029-83d9-008937f9d468", // 如果需要支持多namespace，我们可以创建多个client,它们有不同的NamespaceId。当namespace是public时，此处填空字符串。
+  NamespaceId:         "e525eafa-f7d7-4029-83d9-008937f9d468", // To support multiple namespaces, create multiple clients with different NamespaceId values. When the namespace is public, set this value to an empty string.
   TimeoutMs:           5000,
   NotLoadCacheAtStart: true,
   LogDir:              "/tmp/nacos/log",
@@ -72,9 +72,9 @@ clientConfig := constant.ClientConfig{
   LogLevel:            "debug",
 }
 
-// 创建clientConfig的另一种方式
+// Another way to create clientConfig.
 clientConfig := *constant.NewClientConfig(
-    constant.WithNamespaceId("e525eafa-f7d7-4029-83d9-008937f9d468"), //当namespace是public时，此处填空字符串。
+    constant.WithNamespaceId("e525eafa-f7d7-4029-83d9-008937f9d468"), // When the namespace is public, set this value to an empty string.
     constant.WithTimeoutMs(5000),
     constant.WithNotLoadCacheAtStart(true),
     constant.WithLogDir("/tmp/nacos/log"),
@@ -82,7 +82,7 @@ clientConfig := *constant.NewClientConfig(
     constant.WithLogLevel("debug"),
 )
 
-// 至少一个ServerConfig
+// At least one ServerConfig is required.
 serverConfigs := []constant.ServerConfig{
     {
         IpAddr:      "console1.nacos.io",
@@ -98,7 +98,7 @@ serverConfigs := []constant.ServerConfig{
     },
 }
 
-// 创建serverConfig的另一种方式
+// Another way to create serverConfig.
 serverConfigs := []constant.ServerConfig{
     *constant.NewServerConfig(
         "console1.nacos.io",
@@ -114,19 +114,19 @@ serverConfigs := []constant.ServerConfig{
     ),
 }
 
-// 创建服务发现客户端
+// Create a service discovery client.
 _, _ := clients.CreateNamingClient(map[string]interface{}{
   "serverConfigs": serverConfigs,
   "clientConfig":  clientConfig,
 })
 
-// 创建动态配置客户端
+// Create a dynamic configuration client.
 _, _ := clients.CreateConfigClient(map[string]interface{}{
   "serverConfigs": serverConfigs,
   "clientConfig":  clientConfig,
 })
 
-// 创建服务发现客户端的另一种方式 (推荐)
+// Another way to create a service discovery client (recommended).
 namingClient, err := clients.NewNamingClient(
     vo.NacosClientParam{
         ClientConfig:  &clientConfig,
@@ -134,7 +134,7 @@ namingClient, err := clients.NewNamingClient(
     },
 )
 
-// 创建动态配置客户端的另一种方式 (推荐)
+// Another way to create a dynamic configuration client (recommended).
 configClient, err := clients.NewConfigClient(
     vo.NacosClientParam{
         ClientConfig:  &clientConfig,
@@ -167,9 +167,9 @@ client, err := clients.NewConfigClient(
 ```
 
 
-### 服务发现
+### Service Discovery
 
-* 注册实例：RegisterInstance
+* Register instance: RegisterInstance
 
 ```go
 
@@ -182,13 +182,13 @@ success, err := namingClient.RegisterInstance(vo.RegisterInstanceParam{
     Healthy:     true,
     Ephemeral:   true,
     Metadata:    map[string]string{"idc":"shanghai"},
-    ClusterName: "cluster-a", // 默认值DEFAULT
-    GroupName:   "group-a",   // 默认值DEFAULT_GROUP
+    ClusterName: "cluster-a", // Default value: DEFAULT
+    GroupName:   "group-a",   // Default value: DEFAULT_GROUP
 })
 
 ```
 
-* 注销实例：DeregisterInstance
+* Deregister instance: DeregisterInstance
 
 ```go
 
@@ -197,72 +197,72 @@ success, err := namingClient.DeregisterInstance(vo.DeregisterInstanceParam{
     Port:        8848,
     ServiceName: "demo.go",
     Ephemeral:   true,
-    Cluster:     "cluster-a", // 默认值DEFAULT
-    GroupName:   "group-a",   // 默认值DEFAULT_GROUP
+    Cluster:     "cluster-a", // Default value: DEFAULT
+    GroupName:   "group-a",   // Default value: DEFAULT_GROUP
 })
 
 ```
 
-* 获取服务信息：GetService
+* Get service information: GetService
 
 ```go
 
 services, err := namingClient.GetService(vo.GetServiceParam{
     ServiceName: "demo.go",
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
 })
 
 ```
 
-* 获取所有的实例列表：SelectAllInstances
+* Get all instances: SelectAllInstances
 
 ```go
-// SelectAllInstance可以返回全部实例列表,包括healthy=false,enable=false,weight<=0
+// SelectAllInstance can return all instances, including instances with healthy=false, enable=false, or weight<=0.
 instances, err := namingClient.SelectAllInstances(vo.SelectAllInstancesParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
 })
 
 ```
 
-* 获取实例列表 ：SelectInstances
+* Get instances: SelectInstances
 
 ```go
-// SelectInstances 只返回满足这些条件的实例列表：healthy=${HealthyOnly},enable=true 和weight>0
+// SelectInstances returns only instances that meet these conditions: healthy=${HealthyOnly}, enable=true, and weight>0.
 instances, err := namingClient.SelectInstances(vo.SelectInstancesParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
     HealthyOnly: true,
 })
 
 ```
 
-* 获取一个健康的实例（加权随机轮询）：SelectOneHealthyInstance
+* Get one healthy instance (weighted random polling): SelectOneHealthyInstance
 
 ```go
-// SelectOneHealthyInstance将会按加权随机轮询的负载均衡策略返回一个健康的实例
-// 实例必须满足的条件：health=true,enable=true and weight>0
+// SelectOneHealthyInstance returns one healthy instance based on the weighted random polling load-balancing policy.
+// The instance must meet these conditions: health=true, enable=true, and weight>0.
 instance, err := namingClient.SelectOneHealthyInstance(vo.SelectOneHealthInstanceParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
 })
 
 ```
 
-* 监听服务变化：Subscribe
+* Listen to service changes: Subscribe
 
 ```go
 
 // Subscribe key=serviceName+groupName+cluster
-// 注意:我们可以在相同的key添加多个SubscribeCallback.
+// Note: Multiple SubscribeCallbacks can be added for the same key.
 err := namingClient.Subscribe(vo.SubscribeParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
     SubscribeCallback: func(services []model.Instance, err error) {
         log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
     },
@@ -270,14 +270,14 @@ err := namingClient.Subscribe(vo.SubscribeParam{
 
 ```
 
-* 取消服务监听：Unsubscribe
+* Unsubscribe from service changes: Unsubscribe
 
 ```go
 
 err := namingClient.Unsubscribe(vo.SubscribeParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
     SubscribeCallback: func(services []model.Instance, err error) {
         log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
     },
@@ -285,7 +285,7 @@ err := namingClient.Unsubscribe(vo.SubscribeParam{
 
 ```
 
-* 获取服务名列表:GetAllServicesInfo
+* Get service name list: GetAllServicesInfo
 ```go
 
 serviceInfos, err := namingClient.GetAllServicesInfo(vo.GetAllServiceInfoParam{
@@ -296,9 +296,9 @@ serviceInfos, err := namingClient.GetAllServicesInfo(vo.GetAllServiceInfoParam{
 
 ```
 
-### 动态配置
+### Dynamic Configuration
 
-* 发布配置：PublishConfig
+* Publish configuration: PublishConfig
 
 ```go
 
@@ -309,7 +309,7 @@ success, err := configClient.PublishConfig(vo.ConfigParam{
 
 ```
 
-* 删除配置：DeleteConfig
+* Delete configuration: DeleteConfig
 
 ```go
 
@@ -319,7 +319,7 @@ success, err = configClient.DeleteConfig(vo.ConfigParam{
 
 ```
 
-* 获取配置：GetConfig
+* Get configuration: GetConfig
 
 ```go
 
@@ -329,7 +329,7 @@ content, err := configClient.GetConfig(vo.ConfigParam{
 
 ```
 
-* 监听配置变化：ListenConfig
+* Listen to configuration changes: ListenConfig
 
 ```go
 
@@ -342,7 +342,7 @@ err := configClient.ListenConfig(vo.ConfigParam{
 })
 
 ```
-* 取消配置监听：CancelListenConfig
+* Cancel configuration listener: CancelListenConfig
 
 ```go
 
@@ -353,7 +353,7 @@ err := configClient.CancelListenConfig(vo.ConfigParam{
 
 ```
 
-* 搜索配置: SearchConfig
+* Search configuration: SearchConfig
 ```go
 configPage,err := configClient.SearchConfig(vo.SearchConfigParam{
     Search:   "blur",
@@ -363,26 +363,26 @@ configPage,err := configClient.SearchConfig(vo.SearchConfigParam{
     PageSize: 10,
 })
 ```
-## 例子
-我们能从示例中学习如何使用Nacos go客户端
-* [动态配置示例](./example/config)
-* [服务发现示例](./example/service)
+## Examples
+You can learn how to use the Nacos Go client from the examples.
+* [Dynamic configuration example](./example/config)
+* [Service discovery example](./example/service)
 
-## 文档
-Nacos open-api相关信息可以查看文档 [Nacos open-api wepsite](https://nacos.io/en-us/docs/open-api.html).
+## Documentation
+For Nacos OpenAPI information, see [Nacos OpenAPI website](https://nacos.io/en-us/docs/open-api.html).
 
-Nacos产品了解可以查看 [Nacos website](https://nacos.io/en-us/docs/what-is-nacos.html).
+To learn more about Nacos, see [Nacos website](https://nacos.io/en-us/docs/what-is-nacos.html).
 
-## 贡献代码
-我们非常欢迎大家为Nacos-sdk-go贡献代码. 贡献前请查看[CONTRIBUTING.md](./CONTRIBUTING.md)
+## Contributing
+We welcome contributions to `nacos-sdk-go`. Before contributing, read [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-## 联系我们
-* 加入Nacos-sdk-go钉钉群(23191211).
-* [Gitter](https://gitter.im/alibaba/nacos): Nacos即时聊天工具.
-* [Twitter](https://twitter.com/nacos2): 在Twitter上关注Nacos的最新动态.
-* [Weibo](https://weibo.com/u/6574374908): 在微博上关注Nacos的最新动态.
-* [Nacos SegmentFault](https://segmentfault.com/t/nacos): SegmentFault可以获得最新的推送和帮助.
+## Contact Us
+* Join the `nacos-sdk-go` DingTalk group (23191211).
+* [Gitter](https://gitter.im/alibaba/nacos): Nacos instant messaging tool.
+* [Twitter](https://twitter.com/nacos2): Follow the latest Nacos updates on Twitter.
+* [Weibo](https://weibo.com/u/6574374908): Follow the latest Nacos updates on Weibo.
+* [Nacos SegmentFault](https://segmentfault.com/t/nacos): Get the latest updates and help on SegmentFault.
 * Email Group:
-     * users-nacos@googlegroups.com: Nacos用户讨论组.
-     * dev-nacos@googlegroups.com: Nacos开发者讨论组 (APIs, feature design, etc).
-     * commits-nacos@googlegroups.com: Nacos commit提醒.
+     * users-nacos@googlegroups.com: Nacos user discussion group.
+     * dev-nacos@googlegroups.com: Nacos developer discussion group (APIs, feature design, etc).
+     * commits-nacos@googlegroups.com: Nacos commit notifications.

--- a/src/content/docs/next/en/manual/user/addressing.mdx
+++ b/src/content/docs/next/en/manual/user/addressing.mdx
@@ -1,43 +1,43 @@
 ---
-title: Nacos 客户端寻址
-keywords: [寻地, 客户端, server-addr, endpoint, 地址服务器, 服务端地址配置]
-description: 本文介绍了各语言SDK如何配置寻找Nacos服务器的地址逻辑，以及多种不同的寻址方式的优先级。
+title: Nacos Client Addressing
+keywords: [addressing, client, server-addr, endpoint, address server, server address configuration]
+description: This document describes how SDKs in different languages configure the logic for finding Nacos Server addresses, and the priority of different addressing methods.
 sidebar:
   order: 10
 ---
 
 import {Tabs, TabItem} from '@astrojs/starlight/components';
 
-# Nacos 客户端寻址
+# Nacos Client Addressing
 
-在使用Nacos时， Nacos客户端需要配置Nacos服务器的地址，以确保客户端能连接到Nacos服务器，从而实现服务发现和注册等功能。
+When using Nacos, the Nacos client must configure the Nacos Server address so that the client can connect to Nacos Server and implement features such as service discovery and registration.
 
-本文档将介绍Nacos客户端的各种寻址逻辑，以及多种不同的寻址方式的优先级；对于部分支持拓展寻址的编程语言的客户端，本文档还会介绍如何实现自定义的寻址逻辑。
+This document describes the addressing logic of Nacos clients and the priority of different addressing methods. For clients in some programming languages that support extended addressing, this document also describes how to implement custom addressing logic.
 
-## 1. 客户端寻址基本逻辑
+## 1. Basic Client Addressing Logic
 
-Nacos的所有客户端在寻址Nacos服务端时，虽然具体的实现有所差异，但基本都遵循如下逻辑：
+When Nacos clients locate Nacos Server, the specific implementation may vary, but the basic logic is as follows:
 
-![寻址基本逻辑](/img/doc/manual/user/client-addressing.svg)
+![Basic addressing logic](/img/doc/manual/user/client-addressing.svg)
 
-1. 首先，Nacos客户端会根据初始化时，接受来自应用的配置，如`Properties`等信息；
-2. 在Nacos客户端初始化过程中，会创建一个`ServerListManager（服务列表管理器）`，用于管理服务端的地址列表；
-3. 根据传入的`Properties`配置信息，`ServerListManager`会选择一个对应的`ServerListProvider（服务列表提供者）`来实际获取服务端地址列表，默认情况下，Nacos客户端会提供基于`server-addr配置`的`PropertiesServerListProvider`，和`Endpoint 地址服务器`的`EndpointServerListProvider`；
-4. 在`ServerListManager`完成`ServerListProvider`的选取、初始化以及从其中获取到服务端地址列表后，Nacos客户端才会创建用于通信的`GrpcClient`，并使用`ServerListManager`管理的服务端地址列表来创建连接，并请求对应的Nacos Server。
+1. First, the Nacos client receives configuration from the application during initialization, such as `Properties`.
+2. During Nacos client initialization, a `ServerListManager` is created to manage the server address list.
+3. Based on the passed `Properties` configuration, `ServerListManager` selects the corresponding `ServerListProvider` to actually obtain the server address list. By default, the Nacos client provides `PropertiesServerListProvider` based on `server-addr` configuration and `EndpointServerListProvider` based on an endpoint address server.
+4. After `ServerListManager` selects and initializes the `ServerListProvider` and obtains the server address list from it, the Nacos client creates the `GrpcClient` used for communication, uses the server address list managed by `ServerListManager` to create connections, and sends requests to the corresponding Nacos Server.
 
-不同的`ServerListProvider`会导致客户端在寻找服务端地址列表时的行为有所不同，下文对不同`ServerListProvider`的使用条件、行为结果、优先级等特性进行说明：
+Different `ServerListProvider` implementations lead to different client behavior when finding the server address list. The following sections describe the usage conditions, behavior, results, priorities, and other characteristics of different `ServerListProvider` implementations.
 
-### 1.1. 基于配置的寻址逻辑
+### 1.1. Configuration-based Addressing Logic
 
-Nacos客户端默认提供了基于配置的`ServerListProvider`，即`PropertiesServerListProvider`，该`ServerListProvider`会根据`server-addr`配置，从配置中获取服务端地址列表，若配置中存在多个服务端地址，Nacos客户端将会使用`,`和`;`字符进行分割、并最终随机选择一个作为服务端地址。
+The Nacos client provides a configuration-based `ServerListProvider` by default: `PropertiesServerListProvider`. This `ServerListProvider` obtains the server address list from configuration based on the `server-addr` setting. If multiple server addresses exist in the configuration, the Nacos client splits them by `,` and `;`, and finally randomly selects one as the server address.
 
-若当前选择的服务端地址不可用，则Nacos客户端会按照轮询的方式，依次尝试使用其他服务端地址，当尝试所有的地址之后，会回到第一个服务端地址，继续轮询，直至找到可用的服务端地址或客户端中止。
+If the currently selected server address is unavailable, the Nacos client tries other server addresses one by one in round-robin mode. After trying all addresses, it returns to the first server address and continues polling until an available server address is found or the client stops.
 
-这种寻址方式的最大优点是，Nacos客户端的配置非常简单，只需要配置`server-addr`即可，无需配置额外的服务端地址列表配置；同时也无需部署额外的组件；但是，这种寻址方式相对不灵活，无法动态的修改服务端地址列表，需要修改时只能重新创建一个新的Nacos客户端使用。
+The biggest advantage of this addressing method is its simple Nacos client configuration. You only need to configure `server-addr`; no additional server address list configuration or extra component deployment is required. However, this addressing method is less flexible because the server address list cannot be dynamically modified. To change it, you must create a new Nacos client.
 
-使用示例：
+Example:
 
-> 注意：不同编程语言的配置方式可能存在差异，请根据实际情况修改。
+> Note: Configuration methods may differ across programming languages. Adjust them according to your actual situation.
 
 <Tabs>
   <TabItem label="Java">
@@ -90,36 +90,36 @@ Nacos客户端默认提供了基于配置的`ServerListProvider`，即`Propertie
     )
     ```
   </TabItem>
-  <TabItem label="其他语言">
-    待补充
+  <TabItem label="Other Languages">
+    To be added.
   </TabItem>
 </Tabs>
 
-### 1.2. 基于Endpoint地址服务器的寻址逻辑
+### 1.2. Endpoint Address Server-based Addressing Logic
 
-Nacos客户端还提供了基于地址服务器的寻址方式，即`EndpointServerListProvider`，该`ServerListProvider`会根据`endpoint`配置，从`endpoint`所指向的地址服务器中获取服务端地址列表；
+The Nacos client also provides an address server-based addressing method: `EndpointServerListProvider`. This `ServerListProvider` obtains the server address list from the address server pointed to by the `endpoint` configuration.
 
-地址服务器可以是任意一个提供对应HTTP接口的服务端，例如一个`nginx`,`tomcat服务端`,`Nacos的address模块等`等等；对应接口需要按照格式返回Nacos服务端的地址列表，格式为每行一个地址，例如：
+The address server can be any server that provides the corresponding HTTP interface, such as `nginx`, a `Tomcat server`, or the `Nacos address module`. The corresponding interface must return the Nacos Server address list in the required format, with one address per line, for example:
 
 ```
 127.0.0.1:8848
 1.1.1.1
 ```
 
-若返回的地址没有端口，则默认端口为8848。
+If a returned address does not contain a port, the default port is 8848.
 
-同样地，Nacos客户端会随机选择列表中的一个地址作为服务端地址，并使用该地址访问Nacos服务端；若该地址不可用，则Nacos客户端会按照轮询的方式，依次尝试使用其他服务端地址，当尝试所有的地址之后，会回到第一个服务端地址，继续轮询，直至找到可用的服务端地址或客户端中止。
+Similarly, the Nacos client randomly selects one address from the list as the server address and uses it to access Nacos Server. If the address is unavailable, the Nacos client tries other server addresses one by one in round-robin mode. After trying all addresses, it returns to the first server address and continues polling until an available server address is found or the client stops.
 
-该寻址方式的最大优点是可以动态的更新客户端所连接的服务端地址列表，无需重启客户端；但是，这种寻址方式需要额外部署一个地址服务器以提供对应的更新和获取地址列表的接口、同时可能需要配置的内容较多，适合Nacos部署规模较大的场景。
+The biggest advantage of this addressing method is that the server address list connected by the client can be dynamically updated without restarting the client. However, this method requires deploying an additional address server to provide interfaces for updating and obtaining the address list, and it may require more configuration. It is suitable for scenarios where the Nacos deployment is large.
 
-使用示例：
+Example:
 
-> 注意：不同编程语言的配置方式可能存在差异，请根据实际情况修改。
+> Note: Configuration methods may differ across programming languages. Adjust them according to your actual situation.
 
 <Tabs>
   <TabItem label="Java">
 
-    更多地址服务器相关配置，请参考[Java SDK 配置参数-通用参数](./java-sdk/properties/#21-通用参数)。
+    For more address server-related configuration, see [Java SDK Properties - Common Parameters](./java-sdk/properties/#21-common-parameters).
 
     ```java
     try {
@@ -151,37 +151,37 @@ Nacos客户端还提供了基于地址服务器的寻址方式，即`EndpointSer
     )
     ```
   </TabItem>
-  <TabItem label="其他语言">
-    待补充
+  <TabItem label="Other Languages">
+    To be added.
   </TabItem>
 </Tabs>
 
-### 1.3. 不同寻址逻辑的触发优先级
+### 1.3. Trigger Priority of Different Addressing Logic
 
-当Nacos客户端启动时， 同时配置了不同的寻址逻辑，Nacos客户端会按照以下优先级进行服务端地址的获取：
+When the Nacos client starts and multiple addressing methods are configured at the same time, the Nacos client obtains server addresses in the following priority order:
 
-1. 优先使用`EndpointServerListProvider`，尝试读取`endpoint`相关配置，若存在，则使用`EndpointServerListProvider`获取服务端地址列表，`endpoint`相关配置默认又遵循如下优先级；
-- 1.1. 其中环境变量`ALIBABA_ALIWARE_ENDPOINT_URL`的优先级最高，如果存在，则使用`ALIBABA_ALIWARE_ENDPOINT_URL`作为地址服务器地址；
-- 1.2. 其次是初始化时传入的Properties中`endpoint`配置优先，如果存在，则使用`endpoint`所配置的地址作为地址服务器地址；
-- 1.3. 再优先是JVM参数中配置的`endpoint`配置优先，如果存在，则使用JVM中的`endpoint`所配置的地址作为地址服务器地址；
-- 1.4. 最后是环境变量中的`endpoint`，如果存在，使用环境变量中`endpoint`中配置的地址作为地址服务器地址；
-2. 若以上关于`EndpointServerListProvider`的配置均不存在，则使用`PropertiesServerListProvider`
-- 1.1. 优先使用初始化时传入的Properties中`serverAddr`配置，如果存在，则使用`serverAddr`配置的地址作为Nacos服务端地址列表；
-- 1.2. 其次是JVM参数中配置的`serverAddr`配置，如果存在，则使用JVM中的`serverAddr`配置的地址作为Nacos服务端地址列表；
-- 1.3. 最后是环境变量中的`serverAddr`，如果存在，使用环境变量中`serverAddr`中配置的地址作为Nacos服务端地址列表；
+1. `EndpointServerListProvider` is used first. The client attempts to read `endpoint`-related configuration. If it exists, `EndpointServerListProvider` is used to obtain the server address list. By default, `endpoint`-related configuration follows this priority:
+   - 1.1. The environment variable `ALIBABA_ALIWARE_ENDPOINT_URL` has the highest priority. If it exists, `ALIBABA_ALIWARE_ENDPOINT_URL` is used as the address server address.
+   - 1.2. Next, the `endpoint` configuration in the `Properties` passed during initialization takes priority. If it exists, the address configured by `endpoint` is used as the address server address.
+   - 1.3. Then, the `endpoint` configuration in JVM parameters takes priority. If it exists, the address configured by `endpoint` in the JVM is used as the address server address.
+   - 1.4. Finally, the `endpoint` in environment variables is used if it exists.
+2. If none of the preceding `EndpointServerListProvider` configurations exist, `PropertiesServerListProvider` is used:
+   - 2.1. The `serverAddr` configuration in the `Properties` passed during initialization is used first. If it exists, the address configured by `serverAddr` is used as the Nacos Server address list.
+   - 2.2. Next, the `serverAddr` configuration in JVM parameters is used if it exists.
+   - 2.3. Finally, the `serverAddr` in environment variables is used if it exists.
 
-> 以上配置中的配置优先级顺序为默认情况下的优先级顺序， 不同的编程语言客户端的优先级可能存在差异，请根据实际情况修改；另外，如果设置了[Java SDK 读取配置的优先级顺序](./java-sdk/properties/#13-如何使用)，除了`ALIBABA_ALIWARE_ENDPOINT_URL`以外，其余的配置优先级顺序将会按照设置的优先级顺序进行读取。
+> The preceding priority order is the default priority order. Clients in different programming languages may have different priority orders. Adjust them according to your actual situation. In addition, if [the Java SDK configuration lookup priority](./java-sdk/properties/#13-usage) is set, all configuration items except `ALIBABA_ALIWARE_ENDPOINT_URL` are read according to the configured priority order.
 
-## 2. 自定义的寻址方式
+## 2. Custom Addressing Method
 
-> 目前仅Java SDK支持自定义的寻址方式，其他语言的SDK暂不支持。
+> Currently, only the Java SDK supports custom addressing methods. SDKs in other languages do not support this yet.
 
-Nacos的Java SDK通过SPI，可以自定义ServerListProvider，实现自定义的寻址方式：
+The Nacos Java SDK can customize `ServerListProvider` through SPI to implement custom addressing methods.
 
-### 2.1. 引入依赖
+### 2.1. Add Dependencies
 
 ```xml
-<!-- 2.5.0以上的nacos-client版本支持自定义ServerListProvider -->
+<!-- nacos-client versions later than 2.5.0 support custom ServerListProvider. -->
 <dependency>
   <groupId>com.alibaba.nacos</groupId>
   <artifactId>nacos-client</artifactId>
@@ -189,36 +189,36 @@ Nacos的Java SDK通过SPI，可以自定义ServerListProvider，实现自定义�
 </dependency>
 ```
 
-### 2.2. 实现自定义ServerListProvider
+### 2.2. Implement a Custom ServerListProvider
 
-实现接口`com.alibaba.nacos.client.address.ServerListProvider`
+Implement the `com.alibaba.nacos.client.address.ServerListProvider` interface.
 
-ServerListProvider的相应接口如果：
+The corresponding `ServerListProvider` interfaces are as follows:
 
-|方法名|入参内容|返回内容|描述|
+| Method | Input | Return | Description |
 |-----|-----|-----|---|
-|init|NacosClientProperties, NacosRestTemplate|void|初始化时会调用此接口注入Nacos的配置，HTTP客户端等，以便于您读取初始化时传入的参数，以及通过HTTP接口访问获取其他信息等|
-|getServerList|无|List&lt;String>|`ServerListManager`会调用此接口，获取服务端地址列表|
-|getServerName|无|String|获取`ServerListProvider`所对应的服务端名称，用于标记地址列表所对应的服务端名称|
-|getNamespace|无|String|获取`ServerListProvider`所归属的命名空间，也即此Nacos客户端所归属的命名空间|
-|getContextPath|无|String|获取`ServerListProvider`所对应的服务端上下文路径，当Nacos服务端配置了上下文路径时，需要此上下文路径，以便于Nacos客户端访问服务端|
-|getOrder|无|int|获取`ServerListProvider`的优先级，数字越大优先级越高，`EndpointServerListProvider`的优先级为`500`,`PropertiesServerListProvider`的优先级为499|
-|match|NacosClientProperties|boolean|判断当前`ServerListProvider`是否匹配当前Nacos客户端的配置，如果匹配，则Nacos客户端会调用`init`对此`ServerListProvider`进行初始化|
-|isFixed|无|boolean|判断当前`ServerListProvider`是否所提供的地址列表是否为固定的，比如`EndpointServerListProvider`是可变的，`PropertiesServerListProvider`是固定的|
-|getAddressSource|无|String|获取`ServerListProvider`的地址列表来源地址，比如`EndpointServerListProvider`返回是`Endpoint`的地址，`PropertiesServerListProvider`是``（空字符串）|
-|shutdown|无|void|关闭`ServerListProvider`，关闭时会调用此接口，以便于您关闭相关资源，比如关闭HTTP客户端等|
+| init | NacosClientProperties, NacosRestTemplate | void | Called during initialization to inject Nacos configuration, the HTTP client, and other objects, so that you can read parameters passed during initialization and obtain other information through HTTP APIs. |
+| getServerList | None | List&lt;String> | Called by `ServerListManager` to obtain the server address list. |
+| getServerName | None | String | Gets the server name corresponding to this `ServerListProvider`, used to mark the server name corresponding to the address list. |
+| getNamespace | None | String | Gets the namespace to which this `ServerListProvider` belongs, namely the namespace to which this Nacos client belongs. |
+| getContextPath | None | String | Gets the server context path corresponding to this `ServerListProvider`. When Nacos Server is configured with a context path, this context path is required so the Nacos client can access the server. |
+| getOrder | None | int | Gets the priority of `ServerListProvider`. A larger number indicates a higher priority. The priority of `EndpointServerListProvider` is `500`, and the priority of `PropertiesServerListProvider` is `499`. |
+| match | NacosClientProperties | boolean | Determines whether the current `ServerListProvider` matches the current Nacos client configuration. If it matches, the Nacos client calls `init` to initialize this `ServerListProvider`. |
+| isFixed | None | boolean | Determines whether the address list provided by the current `ServerListProvider` is fixed. For example, `EndpointServerListProvider` is variable, while `PropertiesServerListProvider` is fixed. |
+| getAddressSource | None | String | Gets the source address of the address list for this `ServerListProvider`. For example, `EndpointServerListProvider` returns the `Endpoint` address, and `PropertiesServerListProvider` returns `` (empty string). |
+| shutdown | None | void | Shuts down the `ServerListProvider`. This interface is called during shutdown so that you can close related resources, such as the HTTP client. |
 
-### 2.3. 使用自定义ServerListProvider
+### 2.3. Use a Custom ServerListProvider
 
-添加对应的SPI配置文件`META-INF/services/com.alibaba.nacos.client.address.ServerListProvider`到您的`resources`目录中。
+Add the corresponding SPI configuration file `META-INF/services/com.alibaba.nacos.client.address.ServerListProvider` to your `resources` directory.
 
-比如内容为：
+Example content:
 
 ```
 org.example.MyServerListProvider
 ```
 
-随后在初始化时传入的Properties中配置能让自定义ServerListProvider匹配到的对应参数，比如代码为：
+Then, in the `Properties` passed during initialization, configure the corresponding parameters that allow the custom `ServerListProvider` to match. For example:
 
 ```java
 public class MyServerListProvider implements ServerListProvider {
@@ -233,7 +233,7 @@ public class MyServerListProvider implements ServerListProvider {
 }
 ```
 
-配置内容应该为：
+The configuration should be:
 
 ```properties
 example.server.list.provider=true

--- a/src/content/docs/next/en/manual/user/go-sdk/usage.md
+++ b/src/content/docs/next/en/manual/user/go-sdk/usage.md
@@ -9,37 +9,37 @@ sidebar:
 # Go SDK Usage
 
 
-## 使用限制
+## Usage Limits
 Go>=v1.15
 
 Nacos>2.x
 
-## 安装
-使用`go get`安装SDK：
+## Installation
+Install the SDK with `go get`:
 ```sh
 $ go get -u github.com/nacos-group/nacos-sdk-go/v2
 ```
-## 快速使用
-* 初始化客户端配置ClientConfig
+## Quick Start
+* Initialize the client configuration `ClientConfig`
 
 ```go
 constant.ClientConfig{
-  TimeoutMs            uint64 // 请求Nacos服务端的超时时间，默认是10000ms
-  NamespaceId          string // Nacos的命名空间Id
-  Endpoint             string // 当使用地址服务器时，需要该配置. https://help.aliyun.com/document_detail/130146.html
-  RegionId             string // Nacos&KMS的regionId，用于配置中心的鉴权
-  AccessKey            string // Nacos&KMS的AccessKey，用于配置中心的鉴权
-  SecretKey            string // Nacos&KMS的SecretKey，用于配置中心的鉴权
-  OpenKMS              bool   // 是否开启kms，默认不开启，kms可以参考文档 https://help.aliyun.com/product/28933.html
-                              // 同时DataId必须以"cipher-"作为前缀才会启动加解密逻辑
-  CacheDir             string // 缓存service信息的目录，默认是当前运行目录
-  UpdateThreadNum      int    // 监听service变化的并发数，默认20
-  NotLoadCacheAtStart  bool   // 在启动的时候不读取缓存在CacheDir的service信息
-  UpdateCacheWhenEmpty bool   // 当service返回的实例列表为空时，不更新缓存，用于推空保护
-  Username             string // Nacos服务端的API鉴权Username
-  Password             string // Nacos服务端的API鉴权Password
-  LogDir               string // 日志存储路径
-  LogLevel             string // 日志默认级别，值必须是：debug,info,warn,error，默认值是info
+  TimeoutMs            uint64 // Timeout for requests to Nacos Server. The default value is 10000 ms.
+  NamespaceId          string // Nacos namespace ID.
+  Endpoint             string // Required when using an address server. https://help.aliyun.com/document_detail/130146.html
+  RegionId             string // Nacos and KMS region ID, used for config center authentication.
+  AccessKey            string // Nacos and KMS AccessKey, used for config center authentication.
+  SecretKey            string // Nacos and KMS SecretKey, used for config center authentication.
+  OpenKMS              bool   // Whether to enable KMS. It is disabled by default. See https://help.aliyun.com/product/28933.html
+                              // DataId must also use the "cipher-" prefix to enable encryption and decryption logic.
+  CacheDir             string // Directory for caching service information. The default value is the current working directory.
+  UpdateThreadNum      int    // Concurrency for listening to service changes. The default value is 20.
+  NotLoadCacheAtStart  bool   // Whether not to load service information cached in CacheDir during startup.
+  UpdateCacheWhenEmpty bool   // Whether not to update the cache when the service returns an empty instance list, used for empty-push protection.
+  Username             string // Username for Nacos Server API authentication.
+  Password             string // Password for Nacos Server API authentication.
+  LogDir               string // Log storage path.
+  LogLevel             string // Default log level. Valid values: debug, info, warn, error. The default value is info.
   LogSampling          *ClientLogSamplingConfig // the sampling config of log
   LogRollingConfig     *ClientLogRollingConfig  // the log rolling config
 }
@@ -49,22 +49,22 @@ constant.ClientConfig{
 
 ```go
 constant.ServerConfig{
-  ContextPath string // Nacos的ContextPath，默认/nacos，在2.0中不需要设置
-  IpAddr      string // Nacos的服务地址
-  Port        uint64 // Nacos的服务端口
-  Scheme      string // Nacos的服务地址前缀，默认http，在2.0中不需要设置
-  GrpcPort    uint64 // Nacos的 grpc 服务端口, 默认为 服务端口+1000, 不是必填
+  ContextPath string // Nacos ContextPath. The default value is /nacos. It is not required in 2.0.
+  IpAddr      string // Nacos service address.
+  Port        uint64 // Nacos service port.
+  Scheme      string // Nacos service address scheme. The default value is http. It is not required in 2.0.
+  GrpcPort    uint64 // Nacos gRPC service port. The default value is service port + 1000. It is optional.
 }
 ```
 
-<b>Note：我们可以配置多个ServerConfig，客户端会对这些服务端做轮询请求</b>
+<b>Note: You can configure multiple ServerConfig entries. The client sends polling requests to these servers.</b>
 
 ### Create client
 
 ```go
-// 创建clientConfig
+// Create clientConfig.
 clientConfig := constant.ClientConfig{
-  NamespaceId:         "e525eafa-f7d7-4029-83d9-008937f9d468", // 如果需要支持多namespace，我们可以创建多个client,它们有不同的NamespaceId。当namespace是public时，此处填空字符串。
+  NamespaceId:         "e525eafa-f7d7-4029-83d9-008937f9d468", // To support multiple namespaces, create multiple clients with different NamespaceId values. When the namespace is public, set this value to an empty string.
   TimeoutMs:           5000,
   NotLoadCacheAtStart: true,
   LogDir:              "/tmp/nacos/log",
@@ -72,9 +72,9 @@ clientConfig := constant.ClientConfig{
   LogLevel:            "debug",
 }
 
-// 创建clientConfig的另一种方式
+// Another way to create clientConfig.
 clientConfig := *constant.NewClientConfig(
-    constant.WithNamespaceId("e525eafa-f7d7-4029-83d9-008937f9d468"), //当namespace是public时，此处填空字符串。
+    constant.WithNamespaceId("e525eafa-f7d7-4029-83d9-008937f9d468"), // When the namespace is public, set this value to an empty string.
     constant.WithTimeoutMs(5000),
     constant.WithNotLoadCacheAtStart(true),
     constant.WithLogDir("/tmp/nacos/log"),
@@ -82,7 +82,7 @@ clientConfig := *constant.NewClientConfig(
     constant.WithLogLevel("debug"),
 )
 
-// 至少一个ServerConfig
+// At least one ServerConfig is required.
 serverConfigs := []constant.ServerConfig{
     {
         IpAddr:      "console1.nacos.io",
@@ -98,7 +98,7 @@ serverConfigs := []constant.ServerConfig{
     },
 }
 
-// 创建serverConfig的另一种方式
+// Another way to create serverConfig.
 serverConfigs := []constant.ServerConfig{
     *constant.NewServerConfig(
         "console1.nacos.io",
@@ -114,19 +114,19 @@ serverConfigs := []constant.ServerConfig{
     ),
 }
 
-// 创建服务发现客户端
+// Create a service discovery client.
 _, _ := clients.CreateNamingClient(map[string]interface{}{
   "serverConfigs": serverConfigs,
   "clientConfig":  clientConfig,
 })
 
-// 创建动态配置客户端
+// Create a dynamic configuration client.
 _, _ := clients.CreateConfigClient(map[string]interface{}{
   "serverConfigs": serverConfigs,
   "clientConfig":  clientConfig,
 })
 
-// 创建服务发现客户端的另一种方式 (推荐)
+// Another way to create a service discovery client (recommended).
 namingClient, err := clients.NewNamingClient(
     vo.NacosClientParam{
         ClientConfig:  &clientConfig,
@@ -134,7 +134,7 @@ namingClient, err := clients.NewNamingClient(
     },
 )
 
-// 创建动态配置客户端的另一种方式 (推荐)
+// Another way to create a dynamic configuration client (recommended).
 configClient, err := clients.NewConfigClient(
     vo.NacosClientParam{
         ClientConfig:  &clientConfig,
@@ -167,9 +167,9 @@ client, err := clients.NewConfigClient(
 ```
 
 
-### 服务发现
+### Service Discovery
 
-* 注册实例：RegisterInstance
+* Register instance: RegisterInstance
 
 ```go
 
@@ -182,13 +182,13 @@ success, err := namingClient.RegisterInstance(vo.RegisterInstanceParam{
     Healthy:     true,
     Ephemeral:   true,
     Metadata:    map[string]string{"idc":"shanghai"},
-    ClusterName: "cluster-a", // 默认值DEFAULT
-    GroupName:   "group-a",   // 默认值DEFAULT_GROUP
+    ClusterName: "cluster-a", // Default value: DEFAULT
+    GroupName:   "group-a",   // Default value: DEFAULT_GROUP
 })
 
 ```
 
-* 注销实例：DeregisterInstance
+* Deregister instance: DeregisterInstance
 
 ```go
 
@@ -197,72 +197,72 @@ success, err := namingClient.DeregisterInstance(vo.DeregisterInstanceParam{
     Port:        8848,
     ServiceName: "demo.go",
     Ephemeral:   true,
-    Cluster:     "cluster-a", // 默认值DEFAULT
-    GroupName:   "group-a",   // 默认值DEFAULT_GROUP
+    Cluster:     "cluster-a", // Default value: DEFAULT
+    GroupName:   "group-a",   // Default value: DEFAULT_GROUP
 })
 
 ```
 
-* 获取服务信息：GetService
+* Get service information: GetService
 
 ```go
 
 services, err := namingClient.GetService(vo.GetServiceParam{
     ServiceName: "demo.go",
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
 })
 
 ```
 
-* 获取所有的实例列表：SelectAllInstances
+* Get all instances: SelectAllInstances
 
 ```go
-// SelectAllInstance可以返回全部实例列表,包括healthy=false,enable=false,weight<=0
+// SelectAllInstance can return all instances, including instances with healthy=false, enable=false, or weight<=0.
 instances, err := namingClient.SelectAllInstances(vo.SelectAllInstancesParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
 })
 
 ```
 
-* 获取实例列表 ：SelectInstances
+* Get instances: SelectInstances
 
 ```go
-// SelectInstances 只返回满足这些条件的实例列表：healthy=${HealthyOnly},enable=true 和weight>0
+// SelectInstances returns only instances that meet these conditions: healthy=${HealthyOnly}, enable=true, and weight>0.
 instances, err := namingClient.SelectInstances(vo.SelectInstancesParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
     HealthyOnly: true,
 })
 
 ```
 
-* 获取一个健康的实例（加权随机轮询）：SelectOneHealthyInstance
+* Get one healthy instance (weighted random polling): SelectOneHealthyInstance
 
 ```go
-// SelectOneHealthyInstance将会按加权随机轮询的负载均衡策略返回一个健康的实例
-// 实例必须满足的条件：health=true,enable=true and weight>0
+// SelectOneHealthyInstance returns one healthy instance based on the weighted random polling load-balancing policy.
+// The instance must meet these conditions: health=true, enable=true, and weight>0.
 instance, err := namingClient.SelectOneHealthyInstance(vo.SelectOneHealthInstanceParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
 })
 
 ```
 
-* 监听服务变化：Subscribe
+* Listen to service changes: Subscribe
 
 ```go
 
 // Subscribe key=serviceName+groupName+cluster
-// 注意:我们可以在相同的key添加多个SubscribeCallback.
+// Note: Multiple SubscribeCallbacks can be added for the same key.
 err := namingClient.Subscribe(vo.SubscribeParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
     SubscribeCallback: func(services []model.Instance, err error) {
         log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
     },
@@ -270,14 +270,14 @@ err := namingClient.Subscribe(vo.SubscribeParam{
 
 ```
 
-* 取消服务监听：Unsubscribe
+* Unsubscribe from service changes: Unsubscribe
 
 ```go
 
 err := namingClient.Unsubscribe(vo.SubscribeParam{
     ServiceName: "demo.go",
-    GroupName:   "group-a",             // 默认值DEFAULT_GROUP
-    Clusters:    []string{"cluster-a"}, // 默认值DEFAULT
+    GroupName:   "group-a",             // Default value: DEFAULT_GROUP
+    Clusters:    []string{"cluster-a"}, // Default value: DEFAULT
     SubscribeCallback: func(services []model.Instance, err error) {
         log.Printf("\n\n callback return services:%s \n\n", utils.ToJsonString(services))
     },
@@ -285,7 +285,7 @@ err := namingClient.Unsubscribe(vo.SubscribeParam{
 
 ```
 
-* 获取服务名列表:GetAllServicesInfo
+* Get service name list: GetAllServicesInfo
 ```go
 
 serviceInfos, err := namingClient.GetAllServicesInfo(vo.GetAllServiceInfoParam{
@@ -296,9 +296,9 @@ serviceInfos, err := namingClient.GetAllServicesInfo(vo.GetAllServiceInfoParam{
 
 ```
 
-### 动态配置
+### Dynamic Configuration
 
-* 发布配置：PublishConfig
+* Publish configuration: PublishConfig
 
 ```go
 
@@ -309,7 +309,7 @@ success, err := configClient.PublishConfig(vo.ConfigParam{
 
 ```
 
-* 删除配置：DeleteConfig
+* Delete configuration: DeleteConfig
 
 ```go
 
@@ -319,7 +319,7 @@ success, err = configClient.DeleteConfig(vo.ConfigParam{
 
 ```
 
-* 获取配置：GetConfig
+* Get configuration: GetConfig
 
 ```go
 
@@ -329,7 +329,7 @@ content, err := configClient.GetConfig(vo.ConfigParam{
 
 ```
 
-* 监听配置变化：ListenConfig
+* Listen to configuration changes: ListenConfig
 
 ```go
 
@@ -342,7 +342,7 @@ err := configClient.ListenConfig(vo.ConfigParam{
 })
 
 ```
-* 取消配置监听：CancelListenConfig
+* Cancel configuration listener: CancelListenConfig
 
 ```go
 
@@ -353,7 +353,7 @@ err := configClient.CancelListenConfig(vo.ConfigParam{
 
 ```
 
-* 搜索配置: SearchConfig
+* Search configuration: SearchConfig
 ```go
 configPage,err := configClient.SearchConfig(vo.SearchConfigParam{
     Search:   "blur",
@@ -363,26 +363,26 @@ configPage,err := configClient.SearchConfig(vo.SearchConfigParam{
     PageSize: 10,
 })
 ```
-## 例子
-我们能从示例中学习如何使用Nacos go客户端
-* [动态配置示例](./example/config)
-* [服务发现示例](./example/service)
+## Examples
+You can learn how to use the Nacos Go client from the examples.
+* [Dynamic configuration example](./example/config)
+* [Service discovery example](./example/service)
 
-## 文档
-Nacos open-api相关信息可以查看文档 [Nacos open-api wepsite](https://nacos.io/en-us/docs/open-api.html).
+## Documentation
+For Nacos OpenAPI information, see [Nacos OpenAPI website](https://nacos.io/en-us/docs/open-api.html).
 
-Nacos产品了解可以查看 [Nacos website](https://nacos.io/en-us/docs/what-is-nacos.html).
+To learn more about Nacos, see [Nacos website](https://nacos.io/en-us/docs/what-is-nacos.html).
 
-## 贡献代码
-我们非常欢迎大家为Nacos-sdk-go贡献代码. 贡献前请查看[CONTRIBUTING.md](./CONTRIBUTING.md)
+## Contributing
+We welcome contributions to `nacos-sdk-go`. Before contributing, read [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-## 联系我们
-* 加入Nacos-sdk-go钉钉群(23191211).
-* [Gitter](https://gitter.im/alibaba/nacos): Nacos即时聊天工具.
-* [Twitter](https://twitter.com/nacos2): 在Twitter上关注Nacos的最新动态.
-* [Weibo](https://weibo.com/u/6574374908): 在微博上关注Nacos的最新动态.
-* [Nacos SegmentFault](https://segmentfault.com/t/nacos): SegmentFault可以获得最新的推送和帮助.
+## Contact Us
+* Join the `nacos-sdk-go` DingTalk group (23191211).
+* [Gitter](https://gitter.im/alibaba/nacos): Nacos instant messaging tool.
+* [Twitter](https://twitter.com/nacos2): Follow the latest Nacos updates on Twitter.
+* [Weibo](https://weibo.com/u/6574374908): Follow the latest Nacos updates on Weibo.
+* [Nacos SegmentFault](https://segmentfault.com/t/nacos): Get the latest updates and help on SegmentFault.
 * Email Group:
-     * users-nacos@googlegroups.com: Nacos用户讨论组.
-     * dev-nacos@googlegroups.com: Nacos开发者讨论组 (APIs, feature design, etc).
-     * commits-nacos@googlegroups.com: Nacos commit提醒.
+     * users-nacos@googlegroups.com: Nacos user discussion group.
+     * dev-nacos@googlegroups.com: Nacos developer discussion group (APIs, feature design, etc).
+     * commits-nacos@googlegroups.com: Nacos commit notifications.


### PR DESCRIPTION
## Summary
- Translate the Go SDK usage guide for latest and next English docs.
- Translate the Nacos client addressing guide for latest and next English docs.
- Keep API names, code examples, image paths, and MDX tab structure unchanged.

## Validation
- rg -n "[\p{Han}]" src/content/docs/latest/en/manual/user/go-sdk src/content/docs/next/en/manual/user/go-sdk src/content/docs/latest/en/manual/user/addressing.mdx src/content/docs/next/en/manual/user/addressing.mdx
- git diff --check develop-astro-nacos..HEAD
- npm run build (blocked locally by Rollup optional native dependency @rollup/rollup-darwin-arm64 failing to load with ERR_DLOPEN_FAILED / code signature Team ID mismatch)