### PR TITLE
docs: align English test guides

### DIFF
--- a/src/content/docs/latest/en/manual/test/nacos-e2e.md
+++ b/src/content/docs/latest/en/manual/test/nacos-e2e.md
@@ -6,58 +6,58 @@ sidebar:
     order: 2
 ---
 
-# Nacos E2E 测试
+# Nacos E2E Tests
 
-[`nacos-group/nacos-e2e`](https://github.com/nacos-group/nacos-e2e) 项目是 Nacos 的端到端测试项目，用于验证 Nacos 在不同场景下的功能正确性。如果你想要向这个项目中新增测试用例，可以按照以下步骤进行：
+The [`nacos-group/nacos-e2e`](https://github.com/nacos-group/nacos-e2e) project is the end-to-end testing project for Nacos. It verifies the functional correctness of Nacos in different scenarios. To add test cases to this project, follow these steps:
 
-## 1. 准备工作
+## 1. Preparation
 
-+ **Fork 仓库**：首先你需要在 GitHub 上 Fork `nacos-group/nacos-e2e` 仓库到你自己的账号下。
-+ **克隆仓库**：将 Fork 后的仓库克隆到本地。
++ **Fork the repository**: First, fork the `nacos-group/nacos-e2e` repository to your own GitHub account.
++ **Clone the repository**: Clone the forked repository locally.
 
 ```shell
 git clone https://github.com/your-username/nacos-e2e.git
 cd nacos-e2e
 ```
 
-+**设置上游仓库**：为了能够拉取官方最新的更新，建议设置上游仓库。
++ **Set the upstream repository**: To pull the latest official updates, set the upstream repository.
 
 ```shell
 git remote add upstream https://github.com/nacos-group/nacos-e2e.git
 ```
 
-## 2. 理解现有结构
+## 2. Understand the Existing Structure
 
-查看项目的目录结构，目前主要按客户端测试语言类型和CI部署Nacos的依赖区分，其中java按客户端版本范围和鉴权用例区分
+View the project directory structure. It is mainly organized by client test language type and dependencies used by CI to deploy Nacos. The Java directory is further organized by client version range and authentication test cases.
 
-+ cicd，build目录包含docker相关文件、构建脚本和Nacos部署的配置文件；helm目录包含Kubernetes 的包管理器，它简化了在 Kubernetes 集群上部署应用程序的过程
-+ cpp，用C++语言编写的用例，测试C++客户端
-+ csharp，用csharp语言编写的用例，测试csharp客户端
-+ golang，用golang语言编写的用例，测试go客户端
-+ java，用java语言编写的用例，测试java客户端，其中4个目录分别验证：
-    - auth，部署单例模式的Nacos，验证开启鉴权后的场景
-    - nacos-1X，1.X客户端在1.3版本以上及2.0版本以下时的测试场景
-    - nacos-1X-1.3down，1.X客户端在1.3及以下版本时的测试场景
-    - nacos-2X，2.X客户在2.0及以上版本时的测试场景
-+ nodejs，用nodejs语言编写的用例，测试nodejs客户端
-+ python，用python语言编写的用例，测试python客户端
++ `cicd`: The `build` directory contains Docker-related files, build scripts, and Nacos deployment configuration files. The `helm` directory contains the Kubernetes package manager content, which simplifies application deployment on Kubernetes clusters.
++ `cpp`: Test cases written in C++ to test the C++ client.
++ `csharp`: Test cases written in C# to test the C# client.
++ `golang`: Test cases written in Go to test the Go client.
++ `java`: Test cases written in Java to test the Java client. The four directories verify the following scenarios:
+    - `auth`: Deploys Nacos in standalone mode and verifies scenarios after authentication is enabled.
+    - `nacos-1X`: Test scenarios for 1.x clients with versions later than 1.3 and earlier than 2.0.
+    - `nacos-1X-1.3down`: Test scenarios for 1.x clients with version 1.3 or earlier.
+    - `nacos-2X`: Test scenarios for 2.x clients with version 2.0 or later.
++ `nodejs`: Test cases written in Node.js to test the Node.js client.
++ `python`: Test cases written in Python to test the Python client.
 
-## 3. 新增测试用例
+## 3. Add Test Cases
 
-下面以在`java/nacos-2X`目录下新增一个配置中心相关用例举例：
+The following example shows how to add a config center-related test case under the `java/nacos-2X` directory:
 
-+ **选择合适的包**：根据你要测试的客户端语言和客户端版本，选择或创建一个合适的包（例如 `/nacos-e2e/java/nacos-2X/src/test/java/com/alibaba/nacos/config`）。
-+ **编写测试类**：在选定的包下创建一个新的测试类，例如 `YourFeatureTest.java`。
-    - 每个目录下会继承一个测试基类，如此配置继承ConfigBase基类，此基类进行配置测试用到的常量声明以及在@BeforeAll  @AfterAll 中定义在所有测试方法执行之前或之后运行的方法
-    - ConfigBase基类继承BaseOperate，定义一些通用的操作，比如配置中心和服务中心初始化连接时用到的Properties
-    - BaseOperate继承ResourceInit，定义初始化时用到的变量（从环境变量或者本地文件中获取到的变量）、所有用例启动前服务端的数据写入，初始化一些必要数据（比如命名空间），获取当前服务端客户端的数据（服务端版本、客户端版本等）
-+ **配置依赖**：如果需要引入新的依赖，请修改 `pom.xml` 或其他构建文件。
-+ **测试类规范**：
-    - @BeforeEach 注解的方法中对每个用例数据进行随机初始化和配置
-    - @AfterEach 注解的方法中对每个用例写入数据进行删除等操作清理
-    - @Test 注解的方法中进行用例逻辑编写，在@DisplayName 中描述当前用例测试的场景
++ **Choose a suitable package**: Based on the client language and client version you want to test, choose or create a suitable package, such as `/nacos-e2e/java/nacos-2X/src/test/java/com/alibaba/nacos/config`.
++ **Write a test class**: Create a new test class under the selected package, such as `YourFeatureTest.java`.
+    - Each directory inherits from a test base class. For example, config tests inherit from the `ConfigBase` base class. This base class declares constants used by config tests and defines methods annotated with `@BeforeAll` and `@AfterAll` that run before or after all test methods.
+    - The `ConfigBase` base class inherits from `BaseOperate`, which defines common operations, such as the `Properties` used to initialize config center and service center connections.
+    - `BaseOperate` inherits from `ResourceInit`, which defines variables used during initialization, obtained from environment variables or local files, writes server-side data before all cases start, initializes necessary data such as namespaces, and obtains current server and client data such as server version and client version.
++ **Configure dependencies**: If new dependencies are required, modify `pom.xml` or other build files.
++ **Test class specifications**:
+    - Methods annotated with `@BeforeEach` randomly initialize and configure data for each test case.
+    - Methods annotated with `@AfterEach` delete or otherwise clean up data written by each test case.
+    - Methods annotated with `@Test` contain the test case logic, and `@DisplayName` describes the scenario tested by the current case.
 
-示例代码：
+Example code:
 
 ```java
 package com.alibaba.nacos.config;
@@ -115,49 +115,48 @@ public class YourFeatureTest extends ConfigBase{
 
 ```
 
-## 4. 运行测试
+## 4. Run Tests
 
-java目录下的用例，修改每个module的daily.conf文件中serverList变量为指定服务端IP:Port，或者在执行命令中传入，亦或本地编译器中执行
+For cases under the `java` directory, modify the `serverList` variable in the `daily.conf` file of each module to the specified server `IP:Port`, pass it in the command, or run the tests in a local IDE.
 
-+ **用例执行命令：**
++ **Test case execution command:**
 
 ```shell
 mvn clean test -B -Dtest=YourFeatureTest -DserverList=127.0.0.1
 ```
 
-其他语言下的用例执行，可以参考每种语言的module下bin目录的run.sh文件，在语言环境具备情况下，安装必要的包和设置环境变量后执行，亦或安装相应的编译器本地执行
+For cases in other languages, refer to the `run.sh` file in the `bin` directory of each language module. After the language environment is ready, install the required packages and set environment variables before running the tests, or install the corresponding IDE and run them locally.
 
-## 5. 提交更改
+## 5. Submit Changes
 
-+ **提交代码**：将你的更改提交到本地仓库。
++ **Commit code**: Commit your changes to the local repository.
 
 ```shell
 git add .
 git commit -m "Add new e2e test for your feature"
 ```
 
-+ **推送到远程仓库**：将更改推送到你的 GitHub 仓库。
++ **Push to the remote repository**: Push the changes to your GitHub repository.
 
 ```shell
 git push origin main
 ```
 
-## 6. 创建 Pull Request
+## 6. Create a Pull Request
 
-+ **创建 PR**：回到 GitHub 页面，点击 "New pull request" 按钮，选择你的分支与 `nacos-group/nacos-e2e` 的主分支进行比较，然后创建 Pull Request。
-+ **等待审查**：项目维护者会对你的 PR 进行审查，可能会提出一些修改意见。根据反馈进行相应的调整。
++ **Create a PR**: Return to the GitHub page, click the "New pull request" button, select your branch and compare it with the main branch of `nacos-group/nacos-e2e`, and then create the pull request.
++ **Wait for review**: Project maintainers review your PR and may request changes. Adjust your changes based on the feedback.
 
-## 7. 合并 PR
+## 7. Merge the PR
 
-+ **合并**：一旦 PR 被批准，它会被合并到主分支中。
++ **Merge**: Once the PR is approved, it is merged into the main branch.
 
-通过以上步骤，你就可以成功地向 `nacos-group/nacos-e2e` 项目中新增测试用例了。
+With these steps, you can successfully add test cases to the `nacos-group/nacos-e2e` project.
 
-## 8. Nacos主仓库CI能力
+## 8. CI Capabilities in the Main Nacos Repository
 
-1. 成功地向 `nacos-group/nacos-e2e` 项目中新增测试用例后，用例最终在`alibaba/nacos` 仓库的actions中触发运行。
-2. CI通过使用阿里云ASK能力为每次PUSH和PR提供一个独立的Nacos环境进行E2E测试，部署使用nacos-group/nacos-e2e仓库中的helm chart(nacos-e2e/cicd)，镜像为当次提交的代码。
-3. 由于安全性考虑，将PR和PUSH动作的CI分离为两个流水线。PR触发E2E测试后回写评论至PR中，可以关联跳转到对应的测试报告。
-4. 测试报告可视化，每次E2E测试的报告在CI当次执行页面上可视化展示，无需查看日志，方便排查。
-5. 支持兼容性测试，并发执行多OS和JDK版本的测试。
-
+1. After test cases are successfully added to the `nacos-group/nacos-e2e` project, they are eventually triggered and run in the actions of the `alibaba/nacos` repository.
+2. CI uses Alibaba Cloud ASK capabilities to provide an independent Nacos environment for each push and PR for E2E testing. Deployment uses the Helm chart in the `nacos-group/nacos-e2e` repository (`nacos-e2e/cicd`), and the image is built from the code of the current commit.
+3. For security reasons, CI for PR and push events is separated into two pipelines. After a PR triggers E2E testing, a comment is written back to the PR and can link to the corresponding test report.
+4. Test reports are visualized. The report for each E2E test is displayed visually on the CI execution page, so you do not need to inspect logs, making troubleshooting easier.
+5. Compatibility testing is supported, with tests for multiple OS and JDK versions executed concurrently.

--- a/src/content/docs/latest/en/manual/test/nacos-unit-test.md
+++ b/src/content/docs/latest/en/manual/test/nacos-unit-test.md
@@ -6,39 +6,39 @@ sidebar:
     order: 1
 ---
 
-# Nacos 单元测试
+# Nacos Unit Tests
 
-Nacos 单元测试主要指的是Nacos 核心仓库[`alibaba/nacos`](https://github.com/alibaba/nacos)中的最基本的单元测试，用于测试各个最小测试单元（一般是Class）的逻辑正确性及改动正确性。
+Nacos unit tests mainly refer to the most basic unit tests in the Nacos core repository [`alibaba/nacos`](https://github.com/alibaba/nacos). They are used to verify the logic correctness of each smallest test unit, usually a class, and the correctness of changes.
 
-该文档将介绍Nacos 单元测试的规范，以及运行单元测试的步骤，帮助开发者快速了解在修改功能代码后如何撰写并贡献对应的单元测试代码。
+This document describes the Nacos unit test specifications and the steps to run unit tests, helping developers quickly understand how to write and contribute corresponding unit test code after modifying feature code.
 
-## 1. Nacos 单元测试准备工作
+## 1. Prepare for Nacos Unit Tests
 
-- 可参考[Nacos 贡献流程](../../contribution/contributing-flow.md)的前3个步骤，进行仓库克隆、和本地Git的设置。
-- 安装JDK1.8+ 以上版本
-- 安装Maven3.2.5 以上版本。
+- Refer to the first three steps in [Nacos Contribution Process](../../contribution/contributing-flow.md) to clone the repository and configure local Git.
+- Install JDK 1.8 or later.
+- Install Maven 3.2.5 or later.
 
-## 2. 新增Nacos 单元测试用例
+## 2. Add Nacos Unit Test Cases
 
-Nacos 的单元测试基于`junit5`,`mockito`两个测试框架，详细使用方法请参考[JUnit5](https://junit.org/junit5/docs/current/user-guide/)和[Mockito](https://site.mockito.org/#features)。
+Nacos unit tests are based on the `junit5` and `mockito` test frameworks. For detailed usage, see [JUnit5](https://junit.org/junit5/docs/current/user-guide/) and [Mockito](https://site.mockito.org/#features).
 
-新建的单元测试用例类需尽量与所测试类的模块、包名一致；若已经存在单元测试类，请尽量在原有测试类中添加测试用例，不要新建测试类，部分情况为避免用例互相干扰，可以新增单元测试类，但需要在新类名中进行说明和表达。
+The newly created unit test class should be in the same module and package as the class being tested whenever possible. If a unit test class already exists, add test cases to the existing test class instead of creating a new one. In some cases, to avoid interference between test cases, you can create a new unit test class, but the new class name should clearly explain the scenario.
 
-新增的单元测试类需要遵循如下规范：
+New unit test classes must follow these specifications:
 
-### 2.1. Nacos 单元测试规范
+### 2.1. Nacos Unit Test Specifications
 
-1. 单元测试类必须以`Test`结尾，前面的类名必须与测试类名一致；如：类名为`NacosNamingService`，则单元测试类名为`NacosNamingServiceTest`。
-2. 单元测试的用例必须以`test`开头，后接需要测试的方法名，以驼峰命名法命名测试用例，如：`testRegisterInstance`。
-3. 单元测试用例中必须存在断言。
-4. 单元测试中不允许依赖外部资源，如：数据库, 若有需要，请使用Mockito进行模拟。
-5. 单元测试的用例若遇到所测试方法存在多个分支和测试用例的情况，请创建多个用例，且通过`For`,`With`,`Without`等描述测试用例场景，如：`DefaultParamCheckerTest`的`testCheckParamInfoForNamespaceShowName`、`testCheckParamInfoForNamespaceId`等。
-6. 单元测试用例中如果存在设置 static 变量，请使用 `@AfterAll` 或 `@AfterEach` 注解在用例结束后进行回滚，避免影响其他测试用例。
-7. 单元测试用例中所需要的依赖尽量使用`@Mock`注解进行模拟，需要用到的前置设置和初始化，尽量在`@BeforeAll` 和 `@BeforeEach`注解中完成，避免大量重复初始化代码。
-8. 单元测试若需要测试异步方法，尽量使用mock的线程池进行，若无法使用mock线程池，可以尝试控制线程池的启动时间和间隔周期，避免单元测试运行时间过长。
-9. 单元测试代码同样需要遵循[Nacos代码规范](https://github.com/alibaba/nacos/blob/develop/style/codeStyle.md)。
+1. The unit test class name must end with `Test`, and the preceding class name must match the class under test. For example, if the class name is `NacosNamingService`, the unit test class name should be `NacosNamingServiceTest`.
+2. Unit test case names must start with `test`, followed by the method name to be tested, and use camel case, such as `testRegisterInstance`.
+3. Assertions must exist in unit test cases.
+4. Unit tests must not depend on external resources, such as databases. Use Mockito to mock them if needed.
+5. If the method under test has multiple branches and test scenarios, create multiple test cases and use words such as `For`, `With`, and `Without` to describe the scenario, such as `testCheckParamInfoForNamespaceShowName` and `testCheckParamInfoForNamespaceId` in `DefaultParamCheckerTest`.
+6. If a unit test case sets static variables, use `@AfterAll` or `@AfterEach` to roll them back after the case ends to avoid affecting other test cases.
+7. Use the `@Mock` annotation to mock dependencies required by unit test cases whenever possible. Complete required setup and initialization in `@BeforeAll` and `@BeforeEach` whenever possible to avoid large amounts of repeated initialization code.
+8. If a unit test needs to test asynchronous methods, use a mocked thread pool whenever possible. If a mocked thread pool cannot be used, try to control the thread pool startup time and interval to avoid long unit test execution time.
+9. Unit test code must also follow the [Nacos Code Style](https://github.com/alibaba/nacos/blob/develop/style/codeStyle.md).
 
-### 2.2. Nacos 单元测试示例
+### 2.2. Nacos Unit Test Example
 
 ```java
 
@@ -101,39 +101,41 @@ public class YourClassTest {
 }
 ```
 
-## 3. 运行Nacos 单元测试
+## 3. Run Nacos Unit Tests
 
-在Nacos 仓库根目录下执行`mvn -Prelease-nacos clean test -DtrimStackTrace=false -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`命令即可运行单元测试。
+Run the following command in the root directory of the Nacos repository to execute unit tests:
 
-测试运行完成后，终端中会显示测试结果，同时在各自模块下，会通过`jacoco`插件生成当前模块的测试覆盖率文件，如`api/target/site/jacoco/jacoco.xml`。
+`mvn -Prelease-nacos clean test -DtrimStackTrace=false -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
 
-## 4. 提交Nacos 单元测试
+After the tests complete, the terminal displays the test results. In each module, the `jacoco` plugin also generates the test coverage file for the current module, such as `api/target/site/jacoco/jacoco.xml`.
 
-+ **提交代码**：将你的更改提交到本地仓库。
+## 4. Submit Nacos Unit Tests
+
++ **Commit code**: Commit your changes to the local repository.
 
 ```shell
 git add .
 git commit -m "Add new unit test for class/packages/modules"
 ```
 
-+ **推送到远程仓库**：将更改推送到你的 GitHub 仓库。
++ **Push to the remote repository**: Push the changes to your GitHub repository.
 
 ```shell
 git push origin $your_branch_name
 ```
 
-## 5. 创建 Pull Request
+## 5. Create a Pull Request
 
-+ **创建 PR**：回到 GitHub 页面，点击 "New pull request" 按钮，选择你的分支与 `alibaba/nacos` 的主分支(一般为`develop`)进行比较，然后创建 Pull Request。
-+ **等待审查**：PR中会通过`Github Action`对您提交的单元测试及其他修改进行一系列的检查工作，同时项目维护者会对你的 PR 进行审查，可能会提出一些修改意见。根据运行结果和反馈进行相应的调整。
-+ **合并**：一旦 PR 被批准，它会被合并到主分支中。
++ **Create a PR**: Return to the GitHub page, click the "New pull request" button, select your branch and compare it with the main branch of `alibaba/nacos`, usually `develop`, and then create the pull request.
++ **Wait for review**: The PR uses `Github Action` to run a series of checks on the submitted unit tests and other changes. Project maintainers also review your PR and may request changes. Adjust your changes based on the results and feedback.
++ **Merge**: Once the PR is approved, it is merged into the main branch.
 
-通过以上步骤，你就可以成功地向 `alibaba/nacos` 项目中新增测试用例了。
+With these steps, you can successfully add test cases to the `alibaba/nacos` project.
 
-## 6. 测试报告
+## 6. Test Reports
 
-在PR中以及PR被合并后的`Github Action`中，会对运行之后的单元测试报告，提交到[CodeCov](https://app.codecov.io/gh/alibaba/nacos/)上进行统计和分析，可以查看到测试覆盖率情况。
+In the PR and in `Github Action` after the PR is merged, the generated unit test reports are submitted to [CodeCov](https://app.codecov.io/gh/alibaba/nacos/) for statistics and analysis, where you can view test coverage.
 
-同时在PR中, 会有`Coverage`的简略报告，评论在PR中，原则上在测试覆盖率出现降低时，社区维护人员可能会选择不进行PR的合并，并在评论中提醒您补充单元测试。
+At the same time, the PR contains a brief `Coverage` report as a comment. In principle, when test coverage decreases, community maintainers may choose not to merge the PR and remind you in the comment to add unit tests.
 
-> 当前部分模块的测试覆盖率还有待提高，欢迎社区同学贡献测试代码。
+> The test coverage of some modules still needs improvement. Community contributions to test code are welcome.

--- a/src/content/docs/next/en/manual/test/nacos-e2e.md
+++ b/src/content/docs/next/en/manual/test/nacos-e2e.md
@@ -6,58 +6,58 @@ sidebar:
     order: 2
 ---
 
-# Nacos E2E 测试
+# Nacos E2E Tests
 
-[`nacos-group/nacos-e2e`](https://github.com/nacos-group/nacos-e2e) 项目是 Nacos 的端到端测试项目，用于验证 Nacos 在不同场景下的功能正确性。如果你想要向这个项目中新增测试用例，可以按照以下步骤进行：
+The [`nacos-group/nacos-e2e`](https://github.com/nacos-group/nacos-e2e) project is the end-to-end testing project for Nacos. It verifies the functional correctness of Nacos in different scenarios. To add test cases to this project, follow these steps:
 
-## 1. 准备工作
+## 1. Preparation
 
-+ **Fork 仓库**：首先你需要在 GitHub 上 Fork `nacos-group/nacos-e2e` 仓库到你自己的账号下。
-+ **克隆仓库**：将 Fork 后的仓库克隆到本地。
++ **Fork the repository**: First, fork the `nacos-group/nacos-e2e` repository to your own GitHub account.
++ **Clone the repository**: Clone the forked repository locally.
 
 ```shell
 git clone https://github.com/your-username/nacos-e2e.git
 cd nacos-e2e
 ```
 
-+**设置上游仓库**：为了能够拉取官方最新的更新，建议设置上游仓库。
++ **Set the upstream repository**: To pull the latest official updates, set the upstream repository.
 
 ```shell
 git remote add upstream https://github.com/nacos-group/nacos-e2e.git
 ```
 
-## 2. 理解现有结构
+## 2. Understand the Existing Structure
 
-查看项目的目录结构，目前主要按客户端测试语言类型和CI部署Nacos的依赖区分，其中java按客户端版本范围和鉴权用例区分
+View the project directory structure. It is mainly organized by client test language type and dependencies used by CI to deploy Nacos. The Java directory is further organized by client version range and authentication test cases.
 
-+ cicd，build目录包含docker相关文件、构建脚本和Nacos部署的配置文件；helm目录包含Kubernetes 的包管理器，它简化了在 Kubernetes 集群上部署应用程序的过程
-+ cpp，用C++语言编写的用例，测试C++客户端
-+ csharp，用csharp语言编写的用例，测试csharp客户端
-+ golang，用golang语言编写的用例，测试go客户端
-+ java，用java语言编写的用例，测试java客户端，其中4个目录分别验证：
-    - auth，部署单例模式的Nacos，验证开启鉴权后的场景
-    - nacos-1X，1.X客户端在1.3版本以上及2.0版本以下时的测试场景
-    - nacos-1X-1.3down，1.X客户端在1.3及以下版本时的测试场景
-    - nacos-2X，2.X客户在2.0及以上版本时的测试场景
-+ nodejs，用nodejs语言编写的用例，测试nodejs客户端
-+ python，用python语言编写的用例，测试python客户端
++ `cicd`: The `build` directory contains Docker-related files, build scripts, and Nacos deployment configuration files. The `helm` directory contains the Kubernetes package manager content, which simplifies application deployment on Kubernetes clusters.
++ `cpp`: Test cases written in C++ to test the C++ client.
++ `csharp`: Test cases written in C# to test the C# client.
++ `golang`: Test cases written in Go to test the Go client.
++ `java`: Test cases written in Java to test the Java client. The four directories verify the following scenarios:
+    - `auth`: Deploys Nacos in standalone mode and verifies scenarios after authentication is enabled.
+    - `nacos-1X`: Test scenarios for 1.x clients with versions later than 1.3 and earlier than 2.0.
+    - `nacos-1X-1.3down`: Test scenarios for 1.x clients with version 1.3 or earlier.
+    - `nacos-2X`: Test scenarios for 2.x clients with version 2.0 or later.
++ `nodejs`: Test cases written in Node.js to test the Node.js client.
++ `python`: Test cases written in Python to test the Python client.
 
-## 3. 新增测试用例
+## 3. Add Test Cases
 
-下面以在`java/nacos-2X`目录下新增一个配置中心相关用例举例：
+The following example shows how to add a config center-related test case under the `java/nacos-2X` directory:
 
-+ **选择合适的包**：根据你要测试的客户端语言和客户端版本，选择或创建一个合适的包（例如 `/nacos-e2e/java/nacos-2X/src/test/java/com/alibaba/nacos/config`）。
-+ **编写测试类**：在选定的包下创建一个新的测试类，例如 `YourFeatureTest.java`。
-    - 每个目录下会继承一个测试基类，如此配置继承ConfigBase基类，此基类进行配置测试用到的常量声明以及在@BeforeAll  @AfterAll 中定义在所有测试方法执行之前或之后运行的方法
-    - ConfigBase基类继承BaseOperate，定义一些通用的操作，比如配置中心和服务中心初始化连接时用到的Properties
-    - BaseOperate继承ResourceInit，定义初始化时用到的变量（从环境变量或者本地文件中获取到的变量）、所有用例启动前服务端的数据写入，初始化一些必要数据（比如命名空间），获取当前服务端客户端的数据（服务端版本、客户端版本等）
-+ **配置依赖**：如果需要引入新的依赖，请修改 `pom.xml` 或其他构建文件。
-+ **测试类规范**：
-    - @BeforeEach 注解的方法中对每个用例数据进行随机初始化和配置
-    - @AfterEach 注解的方法中对每个用例写入数据进行删除等操作清理
-    - @Test 注解的方法中进行用例逻辑编写，在@DisplayName 中描述当前用例测试的场景
++ **Choose a suitable package**: Based on the client language and client version you want to test, choose or create a suitable package, such as `/nacos-e2e/java/nacos-2X/src/test/java/com/alibaba/nacos/config`.
++ **Write a test class**: Create a new test class under the selected package, such as `YourFeatureTest.java`.
+    - Each directory inherits from a test base class. For example, config tests inherit from the `ConfigBase` base class. This base class declares constants used by config tests and defines methods annotated with `@BeforeAll` and `@AfterAll` that run before or after all test methods.
+    - The `ConfigBase` base class inherits from `BaseOperate`, which defines common operations, such as the `Properties` used to initialize config center and service center connections.
+    - `BaseOperate` inherits from `ResourceInit`, which defines variables used during initialization, obtained from environment variables or local files, writes server-side data before all cases start, initializes necessary data such as namespaces, and obtains current server and client data such as server version and client version.
++ **Configure dependencies**: If new dependencies are required, modify `pom.xml` or other build files.
++ **Test class specifications**:
+    - Methods annotated with `@BeforeEach` randomly initialize and configure data for each test case.
+    - Methods annotated with `@AfterEach` delete or otherwise clean up data written by each test case.
+    - Methods annotated with `@Test` contain the test case logic, and `@DisplayName` describes the scenario tested by the current case.
 
-示例代码：
+Example code:
 
 ```java
 package com.alibaba.nacos.config;
@@ -115,49 +115,48 @@ public class YourFeatureTest extends ConfigBase{
 
 ```
 
-## 4. 运行测试
+## 4. Run Tests
 
-java目录下的用例，修改每个module的daily.conf文件中serverList变量为指定服务端IP:Port，或者在执行命令中传入，亦或本地编译器中执行
+For cases under the `java` directory, modify the `serverList` variable in the `daily.conf` file of each module to the specified server `IP:Port`, pass it in the command, or run the tests in a local IDE.
 
-+ **用例执行命令：**
++ **Test case execution command:**
 
 ```shell
 mvn clean test -B -Dtest=YourFeatureTest -DserverList=127.0.0.1
 ```
 
-其他语言下的用例执行，可以参考每种语言的module下bin目录的run.sh文件，在语言环境具备情况下，安装必要的包和设置环境变量后执行，亦或安装相应的编译器本地执行
+For cases in other languages, refer to the `run.sh` file in the `bin` directory of each language module. After the language environment is ready, install the required packages and set environment variables before running the tests, or install the corresponding IDE and run them locally.
 
-## 5. 提交更改
+## 5. Submit Changes
 
-+ **提交代码**：将你的更改提交到本地仓库。
++ **Commit code**: Commit your changes to the local repository.
 
 ```shell
 git add .
 git commit -m "Add new e2e test for your feature"
 ```
 
-+ **推送到远程仓库**：将更改推送到你的 GitHub 仓库。
++ **Push to the remote repository**: Push the changes to your GitHub repository.
 
 ```shell
 git push origin main
 ```
 
-## 6. 创建 Pull Request
+## 6. Create a Pull Request
 
-+ **创建 PR**：回到 GitHub 页面，点击 "New pull request" 按钮，选择你的分支与 `nacos-group/nacos-e2e` 的主分支进行比较，然后创建 Pull Request。
-+ **等待审查**：项目维护者会对你的 PR 进行审查，可能会提出一些修改意见。根据反馈进行相应的调整。
++ **Create a PR**: Return to the GitHub page, click the "New pull request" button, select your branch and compare it with the main branch of `nacos-group/nacos-e2e`, and then create the pull request.
++ **Wait for review**: Project maintainers review your PR and may request changes. Adjust your changes based on the feedback.
 
-## 7. 合并 PR
+## 7. Merge the PR
 
-+ **合并**：一旦 PR 被批准，它会被合并到主分支中。
++ **Merge**: Once the PR is approved, it is merged into the main branch.
 
-通过以上步骤，你就可以成功地向 `nacos-group/nacos-e2e` 项目中新增测试用例了。
+With these steps, you can successfully add test cases to the `nacos-group/nacos-e2e` project.
 
-## 8. Nacos主仓库CI能力
+## 8. CI Capabilities in the Main Nacos Repository
 
-1. 成功地向 `nacos-group/nacos-e2e` 项目中新增测试用例后，用例最终在`alibaba/nacos` 仓库的actions中触发运行。
-2. CI通过使用阿里云ASK能力为每次PUSH和PR提供一个独立的Nacos环境进行E2E测试，部署使用nacos-group/nacos-e2e仓库中的helm chart(nacos-e2e/cicd)，镜像为当次提交的代码。
-3. 由于安全性考虑，将PR和PUSH动作的CI分离为两个流水线。PR触发E2E测试后回写评论至PR中，可以关联跳转到对应的测试报告。
-4. 测试报告可视化，每次E2E测试的报告在CI当次执行页面上可视化展示，无需查看日志，方便排查。
-5. 支持兼容性测试，并发执行多OS和JDK版本的测试。
-
+1. After test cases are successfully added to the `nacos-group/nacos-e2e` project, they are eventually triggered and run in the actions of the `alibaba/nacos` repository.
+2. CI uses Alibaba Cloud ASK capabilities to provide an independent Nacos environment for each push and PR for E2E testing. Deployment uses the Helm chart in the `nacos-group/nacos-e2e` repository (`nacos-e2e/cicd`), and the image is built from the code of the current commit.
+3. For security reasons, CI for PR and push events is separated into two pipelines. After a PR triggers E2E testing, a comment is written back to the PR and can link to the corresponding test report.
+4. Test reports are visualized. The report for each E2E test is displayed visually on the CI execution page, so you do not need to inspect logs, making troubleshooting easier.
+5. Compatibility testing is supported, with tests for multiple OS and JDK versions executed concurrently.

--- a/src/content/docs/next/en/manual/test/nacos-unit-test.md
+++ b/src/content/docs/next/en/manual/test/nacos-unit-test.md
@@ -6,39 +6,39 @@ sidebar:
     order: 1
 ---
 
-# Nacos 单元测试
+# Nacos Unit Tests
 
-Nacos 单元测试主要指的是Nacos 核心仓库[`alibaba/nacos`](https://github.com/alibaba/nacos)中的最基本的单元测试，用于测试各个最小测试单元（一般是Class）的逻辑正确性及改动正确性。
+Nacos unit tests mainly refer to the most basic unit tests in the Nacos core repository [`alibaba/nacos`](https://github.com/alibaba/nacos). They are used to verify the logic correctness of each smallest test unit, usually a class, and the correctness of changes.
 
-该文档将介绍Nacos 单元测试的规范，以及运行单元测试的步骤，帮助开发者快速了解在修改功能代码后如何撰写并贡献对应的单元测试代码。
+This document describes the Nacos unit test specifications and the steps to run unit tests, helping developers quickly understand how to write and contribute corresponding unit test code after modifying feature code.
 
-## 1. Nacos 单元测试准备工作
+## 1. Prepare for Nacos Unit Tests
 
-- 可参考[Nacos 贡献流程](../../contribution/contributing-flow.md)的前3个步骤，进行仓库克隆、和本地Git的设置。
-- 安装JDK1.8+ 以上版本
-- 安装Maven3.2.5 以上版本。
+- Refer to the first three steps in [Nacos Contribution Process](../../contribution/contributing-flow.md) to clone the repository and configure local Git.
+- Install JDK 1.8 or later.
+- Install Maven 3.2.5 or later.
 
-## 2. 新增Nacos 单元测试用例
+## 2. Add Nacos Unit Test Cases
 
-Nacos 的单元测试基于`junit5`,`mockito`两个测试框架，详细使用方法请参考[JUnit5](https://junit.org/junit5/docs/current/user-guide/)和[Mockito](https://site.mockito.org/#features)。
+Nacos unit tests are based on the `junit5` and `mockito` test frameworks. For detailed usage, see [JUnit5](https://junit.org/junit5/docs/current/user-guide/) and [Mockito](https://site.mockito.org/#features).
 
-新建的单元测试用例类需尽量与所测试类的模块、包名一致；若已经存在单元测试类，请尽量在原有测试类中添加测试用例，不要新建测试类，部分情况为避免用例互相干扰，可以新增单元测试类，但需要在新类名中进行说明和表达。
+The newly created unit test class should be in the same module and package as the class being tested whenever possible. If a unit test class already exists, add test cases to the existing test class instead of creating a new one. In some cases, to avoid interference between test cases, you can create a new unit test class, but the new class name should clearly explain the scenario.
 
-新增的单元测试类需要遵循如下规范：
+New unit test classes must follow these specifications:
 
-### 2.1. Nacos 单元测试规范
+### 2.1. Nacos Unit Test Specifications
 
-1. 单元测试类必须以`Test`结尾，前面的类名必须与测试类名一致；如：类名为`NacosNamingService`，则单元测试类名为`NacosNamingServiceTest`。
-2. 单元测试的用例必须以`test`开头，后接需要测试的方法名，以驼峰命名法命名测试用例，如：`testRegisterInstance`。
-3. 单元测试用例中必须存在断言。
-4. 单元测试中不允许依赖外部资源，如：数据库, 若有需要，请使用Mockito进行模拟。
-5. 单元测试的用例若遇到所测试方法存在多个分支和测试用例的情况，请创建多个用例，且通过`For`,`With`,`Without`等描述测试用例场景，如：`DefaultParamCheckerTest`的`testCheckParamInfoForNamespaceShowName`、`testCheckParamInfoForNamespaceId`等。
-6. 单元测试用例中如果存在设置 static 变量，请使用 `@AfterAll` 或 `@AfterEach` 注解在用例结束后进行回滚，避免影响其他测试用例。
-7. 单元测试用例中所需要的依赖尽量使用`@Mock`注解进行模拟，需要用到的前置设置和初始化，尽量在`@BeforeAll` 和 `@BeforeEach`注解中完成，避免大量重复初始化代码。
-8. 单元测试若需要测试异步方法，尽量使用mock的线程池进行，若无法使用mock线程池，可以尝试控制线程池的启动时间和间隔周期，避免单元测试运行时间过长。
-9. 单元测试代码同样需要遵循[Nacos代码规范](https://github.com/alibaba/nacos/blob/develop/style/codeStyle.md)。
+1. The unit test class name must end with `Test`, and the preceding class name must match the class under test. For example, if the class name is `NacosNamingService`, the unit test class name should be `NacosNamingServiceTest`.
+2. Unit test case names must start with `test`, followed by the method name to be tested, and use camel case, such as `testRegisterInstance`.
+3. Assertions must exist in unit test cases.
+4. Unit tests must not depend on external resources, such as databases. Use Mockito to mock them if needed.
+5. If the method under test has multiple branches and test scenarios, create multiple test cases and use words such as `For`, `With`, and `Without` to describe the scenario, such as `testCheckParamInfoForNamespaceShowName` and `testCheckParamInfoForNamespaceId` in `DefaultParamCheckerTest`.
+6. If a unit test case sets static variables, use `@AfterAll` or `@AfterEach` to roll them back after the case ends to avoid affecting other test cases.
+7. Use the `@Mock` annotation to mock dependencies required by unit test cases whenever possible. Complete required setup and initialization in `@BeforeAll` and `@BeforeEach` whenever possible to avoid large amounts of repeated initialization code.
+8. If a unit test needs to test asynchronous methods, use a mocked thread pool whenever possible. If a mocked thread pool cannot be used, try to control the thread pool startup time and interval to avoid long unit test execution time.
+9. Unit test code must also follow the [Nacos Code Style](https://github.com/alibaba/nacos/blob/develop/style/codeStyle.md).
 
-### 2.2. Nacos 单元测试示例
+### 2.2. Nacos Unit Test Example
 
 ```java
 
@@ -101,39 +101,41 @@ public class YourClassTest {
 }
 ```
 
-## 3. 运行Nacos 单元测试
+## 3. Run Nacos Unit Tests
 
-在Nacos 仓库根目录下执行`mvn -Prelease-nacos clean test -DtrimStackTrace=false -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`命令即可运行单元测试。
+Run the following command in the root directory of the Nacos repository to execute unit tests:
 
-测试运行完成后，终端中会显示测试结果，同时在各自模块下，会通过`jacoco`插件生成当前模块的测试覆盖率文件，如`api/target/site/jacoco/jacoco.xml`。
+`mvn -Prelease-nacos clean test -DtrimStackTrace=false -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
 
-## 4. 提交Nacos 单元测试
+After the tests complete, the terminal displays the test results. In each module, the `jacoco` plugin also generates the test coverage file for the current module, such as `api/target/site/jacoco/jacoco.xml`.
 
-+ **提交代码**：将你的更改提交到本地仓库。
+## 4. Submit Nacos Unit Tests
+
++ **Commit code**: Commit your changes to the local repository.
 
 ```shell
 git add .
 git commit -m "Add new unit test for class/packages/modules"
 ```
 
-+ **推送到远程仓库**：将更改推送到你的 GitHub 仓库。
++ **Push to the remote repository**: Push the changes to your GitHub repository.
 
 ```shell
 git push origin $your_branch_name
 ```
 
-## 5. 创建 Pull Request
+## 5. Create a Pull Request
 
-+ **创建 PR**：回到 GitHub 页面，点击 "New pull request" 按钮，选择你的分支与 `alibaba/nacos` 的主分支(一般为`develop`)进行比较，然后创建 Pull Request。
-+ **等待审查**：PR中会通过`Github Action`对您提交的单元测试及其他修改进行一系列的检查工作，同时项目维护者会对你的 PR 进行审查，可能会提出一些修改意见。根据运行结果和反馈进行相应的调整。
-+ **合并**：一旦 PR 被批准，它会被合并到主分支中。
++ **Create a PR**: Return to the GitHub page, click the "New pull request" button, select your branch and compare it with the main branch of `alibaba/nacos`, usually `develop`, and then create the pull request.
++ **Wait for review**: The PR uses `Github Action` to run a series of checks on the submitted unit tests and other changes. Project maintainers also review your PR and may request changes. Adjust your changes based on the results and feedback.
++ **Merge**: Once the PR is approved, it is merged into the main branch.
 
-通过以上步骤，你就可以成功地向 `alibaba/nacos` 项目中新增测试用例了。
+With these steps, you can successfully add test cases to the `alibaba/nacos` project.
 
-## 6. 测试报告
+## 6. Test Reports
 
-在PR中以及PR被合并后的`Github Action`中，会对运行之后的单元测试报告，提交到[CodeCov](https://app.codecov.io/gh/alibaba/nacos/)上进行统计和分析，可以查看到测试覆盖率情况。
+In the PR and in `Github Action` after the PR is merged, the generated unit test reports are submitted to [CodeCov](https://app.codecov.io/gh/alibaba/nacos/) for statistics and analysis, where you can view test coverage.
 
-同时在PR中, 会有`Coverage`的简略报告，评论在PR中，原则上在测试覆盖率出现降低时，社区维护人员可能会选择不进行PR的合并，并在评论中提醒您补充单元测试。
+At the same time, the PR contains a brief `Coverage` report as a comment. In principle, when test coverage decreases, community maintainers may choose not to merge the PR and remind you in the comment to add unit tests.
 
-> 当前部分模块的测试覆盖率还有待提高，欢迎社区同学贡献测试代码。
+> The test coverage of some modules still needs improvement. Community contributions to test code are welcome.


### PR DESCRIPTION
## Summary
- Translate the Nacos unit test guide for latest and next English docs.
- Translate the Nacos E2E test guide for latest and next English docs.
- Keep commands, code examples, and repository links unchanged.

## Validation
- rg -n "[\p{Han}]" src/content/docs/latest/en/manual/test src/content/docs/next/en/manual/test
- git diff --check develop-astro-nacos..HEAD
- npm run build (blocked locally by Rollup optional native dependency @rollup/rollup-darwin-arm64 failing to load with ERR_DLOPEN_FAILED / code signature Team ID mismatch)