### PR TITLE
docs: align English ecology docs

### DIFF
--- a/src/content/docs/latest/en/ecology/use-nacos-controller-to-sync-service.md
+++ b/src/content/docs/latest/en/ecology/use-nacos-controller-to-sync-service.md
@@ -1,44 +1,44 @@
 ---
-title: 使用Nacos Controller同步k8s服务到Nacos
-keywords: [Nacos Controller,使用手册]
-description: Nacos Controller 使用手册
+title: Use Nacos Controller to Sync Kubernetes Services to Nacos
+keywords: [Nacos Controller, User Guide]
+description: Nacos Controller User Guide
 sidebar:
     order: 10
 ---
 
-# 使用Nacos Controller同步k8s服务到Nacos
+# Use Nacos Controller to Sync Kubernetes Services to Nacos
 
-## 概述
+## Overview
 
-Nacos Controller支持k8s配置双向同步及服务同步到Nacos。本文讲述如何使用Nacos Controller同步k8s服务到Nacos。
+Nacos Controller supports bidirectional synchronization of Kubernetes configurations and synchronization of Kubernetes services to Nacos. This document describes how to use Nacos Controller to sync Kubernetes services to Nacos.
 
-## 前置条件
+## Prerequisites
 
-*   安装[kubectl](https://kubernetes.io/zh-cn/docs/tasks/tools/)、[helm](https://helm.sh/zh/docs/intro/install/)
+*   Install [kubectl](https://kubernetes.io/docs/tasks/tools/) and [helm](https://helm.sh/docs/intro/install/).
     
 
-## 部署自定义资源
+## Deploy Custom Resources
 
 ```shell
-#克隆仓库
+# Clone the repository
 git clone https://github.com/nacos-group/nacos-controller.git
 cd nacos-controller/charts/nacos-controller
-#导出k8s集群配置文件路径
+# Export the Kubernetes cluster configuration file path
 export KUBECONFIG=/path/to/your/kubeconfig/file
-# 创建CRD安装的命名空间
+# Create the namespace for CRD installation
 kubectl create ns nacos
-# 安装CRD
+# Install the CRD
 helm install -n nacos nacos-controller .
 ```
 
-安装成功后，使用"kubectl get crd  | grep nacos" 检查结果，如下结果表示正常：
+After installation succeeds, run `kubectl get crd | grep nacos` to check the result. The following output indicates that the CRDs are installed correctly:
 
 ![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Pd6l2Z7XEAxGMl7M/img/ea77285e-8fc2-4ea3-b89f-064c8844f693.png)
 
-## 创建Secret
+## Create a Secret
 
-创建Nacos鉴权使用的Secret，包括Nacos用户名、密码。如果使用了MSE Nacos，并且开启了鉴权，还需要配置AK、SK。**注意：参数值为base64编码之后的值。**
-* 创建secret配置文件
+Create a Secret for Nacos authentication, including the Nacos username and password. If you use MSE Nacos with authentication enabled, you must also configure the access key and secret key. **Note: parameter values must be base64-encoded.**
+* Create a Secret configuration file.
 
   ```yaml
   apiVersion: v1
@@ -51,13 +51,13 @@ helm install -n nacos nacos-controller .
       username: <base64 your-nacos-username>
       password: <base64 your-nacos-password>
   ```
-* 创建secret
+* Create the Secret.
   ```shell
   kubectl apply -f secret.yaml -n nacoskubectl 
   ```
 
-## 创建ServiceDiscovery
-* 创建ServiceDiscovery配置文件
+## Create ServiceDiscovery
+* Create a ServiceDiscovery configuration file.
   ```yaml
   apiVersion: nacos.io/v1
   kind: ServiceDiscovery
@@ -65,26 +65,26 @@ helm install -n nacos nacos-controller .
     name: sd-demo
   spec:
     nacosServer:
-        # serverAddr: Nacos地址
+        # serverAddr: Nacos address
         serverAddr: <nacos-addr>
-        # namespace: 需要把k8s服务同步到Nacos的命名空间Id
+        # namespace: namespace ID used to sync Kubernetes services to Nacos
         namespace: <nacos-namespace-id>
-        # authRef: 包含 Nacos 客户端认证凭据的 Secret（支持用户名/密码或 AK/SK；如果 Nacos 服务器认证已禁用则可省略
+        # authRef: Secret that contains Nacos client credentials (username/password or AK/SK). It can be omitted if authentication is disabled on the Nacos server.
         authRef:
           apiVersion: v1
           kind: Secret
           name: nacos-auth
-    # 需要同步的服务列表，如果需要同步全量服务则可忽略
-    services: ["my-nginx"，"test1"]
+    # Service list to sync. Omit this field to sync all services.
+    services: ["my-nginx", "test1"]
   ```
-* 创建 Service Discovery
+* Create ServiceDiscovery.
   ```yaml
   kubectl apply -f sd.yaml -n nacos
   ```
 
-## 创建Deployment
+## Create a Deployment
 
-* 以nginx为例创建deployment配置文件
+* Create a Deployment configuration file. The following example uses nginx.
 
 ```yaml
 apiVersion: apps/v1
@@ -111,9 +111,9 @@ spec:
 kubectl apply -f nginx-deployment.yaml -n nacos
 ```
 
-## 创建Service
+## Create a Service
 
-* 创建yaml文件
+* Create a YAML file.
   ```yaml
   apiVersion: v1
   kind: Service
@@ -129,19 +129,19 @@ kubectl apply -f nginx-deployment.yaml -n nacos
       app: nginx-test
   ```
 
-* 部署Service
+* Deploy the Service.
     
   ```shell
   kubectl apply -f nginx-service.yaml -n nacos
   ```
 
-* 查看Service endpoint
+* View the Service endpoint.
   ```shell
   kubectl describe svc my-nginx -n nacos
   ```
   ![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Pd6l2Z7XEAxGMl7M/img/b3c62ce8-e7e2-4672-bcf5-885c45b92678.png)
 
-## 查看同步结果
+## View the Synchronization Result
   ```shell
   curl "$NACOS_ADDR/nacos/v3/admin/ns/instance/list?serviceName=my-nginx' -H "userName:$USER_NAME" -H "password:$PASSWORD"
   ```

--- a/src/content/docs/latest/en/ecology/use-nacos-mcp-router.md
+++ b/src/content/docs/latest/en/ecology/use-nacos-mcp-router.md
@@ -1,53 +1,53 @@
 ---
-title: Nacos MCP Router 使用手册
-keywords: [Nacos MCP Router,MCP,使用手册]
-description: Nacos MCP Router 使用手册
+title: Nacos MCP Router User Guide
+keywords: [Nacos MCP Router, MCP, User Guide]
+description: Nacos MCP Router User Guide
 sidebar:
     order: 9
 ---
 
-## 概述
-Nacos MCP Router是一个基于MCP官方标准SDK实现的的MCP Server。它提供了一组工具，提供MCP Server推荐、分发、安装及代理其他MCP Server的功能，帮助用户更方便的使用MCP Server服务， 其主要架构如下：
+## Overview
+Nacos MCP Router is an MCP Server implemented based on the official MCP standard SDK. It provides tools for MCP Server recommendation, distribution, installation, and proxying other MCP Servers, helping users consume MCP Server services more conveniently. Its main architecture is as follows:
     
 ![alt text](/img/doc/ecology/nacos-mcp-router/router-architecture.png)
 
-## 功能介绍
-Nacos MCP Router 有两种工作模式：
-1. router模式：默认模式，通过MCP Server推荐、安装及代理其他MCP Server的功能，帮助用户更方便的使用MCP Server服务。
-2. prroxy模式：使用环境变量MODE=proxy指定，通过简单配置可以把sse、stdio协议MCP Server转换为streamableHTTP协议MCP Server。
+## Features
+Nacos MCP Router provides two working modes:
+1. Router mode: the default mode. It helps users consume MCP Server services more conveniently through MCP Server recommendation, installation, and proxying other MCP Servers.
+2. Proxy mode: enabled by setting the `MODE=proxy` environment variable. With simple configuration, it converts MCP Servers that use the SSE or stdio protocol into MCP Servers that use the streamable HTTP protocol.
 
-在router 模式下，Nacos MCP Router 作为一个标准MCP Server，提供MCP Server推荐、分发、安装及代理其他MCP Server的功能。其主要工具列表为
+In router mode, Nacos MCP Router works as a standard MCP Server and provides MCP Server recommendation, distribution, installation, and proxy capabilities. The main tools are:
 1. `search_mcp_server`
-    - 根据任务描述及关键字从MCP注册中心（Nacos）中搜索相关的MCP Server列表
-    - 输入:
-      - `task_description`(string): 任务描述，示例：今天杭州天气如何
-      - `key_words`(string): 任务关键字，示例：天气、杭州
-    - 输出: list of MCP servers and instructions to complete the task.
+    - Searches the MCP registry (Nacos) for related MCP Servers based on a task description and keywords.
+    - Input:
+      - `task_description` (string): task description. Example: "What is the weather in Hangzhou today?"
+      - `key_words` (string): task keywords. Example: "weather, Hangzhou"
+    - Output: list of MCP servers and instructions to complete the task.
 2. `add_mcp_server`
-    - 添加并初始化一个MCP Server，根据Nacos中的配置与该MCP Server建立连接，等待调用。
-    - 输入:
-      - `mcp_server_name`(string): 需要添加的MCP Server名字
-    - 输出: MCP Server工具列表及使用方法
+    - Adds and initializes an MCP Server, establishes a connection to it based on the configuration in Nacos, and waits for calls.
+    - Input:
+      - `mcp_server_name` (string): name of the MCP Server to add.
+    - Output: MCP Server tool list and usage instructions.
 3. `use_tool`
-   - 代理其他MCP Server的工具
-   - 输入:
-     - `mcp_server_name`(string): 被调的目标MCP Server名称.
-     - `mcp_tool_name`(string): 被调的目标MCP Server的工具名称
-     - `params`(map): 被调的目标MCP Server的工具的参数
-   - 输出: 被调的目标MCP Server的工具的输出结果
+   - Proxies tools from other MCP Servers.
+   - Input:
+     - `mcp_server_name` (string): name of the target MCP Server to call.
+     - `mcp_tool_name` (string): name of the target MCP Server tool to call.
+     - `params` (map): parameters of the target MCP Server tool to call.
+   - Output: output from the target MCP Server tool.
 
-在proxy 模式下，Nacos MCP Router 仅提供代理功能，无需代码改动即可实现stdio、sse协议一键转换为streamableHTTP协议。
-## 快速开始
-### 准备工作
-Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动 Nacos 服务，可先行参考 [Nacos 快速入门](../quickstart/quick-start.mdx)。 
+In proxy mode, Nacos MCP Router only provides proxy capabilities and can convert stdio or SSE protocol MCP Servers to the streamable HTTP protocol without code changes.
+## Quick Start
+### Prerequisites
+Nacos MCP Router uses Nacos as the MCP Registry. Make sure the Nacos service has been started in the background. For more information, see [Nacos Quick Start](../quickstart/quick-start.mdx).
 
-### router模式
-1. 注册MCP Server
-在Nacos控制台注册可能要用到的MCP Server，并设置MCP Server的配置, 以高德地图为例。
+### Router Mode
+1. Register an MCP Server.
+Register the MCP Server that may be used in the Nacos console and configure the MCP Server. The following example uses AutoNavi Maps.
 ![alt text](/img/doc/ecology/nacos-mcp-router/mcp-register.png)
-2. 启动Nacos MCP Router
-    - stdio模式启动，stdio模式需直接配置在Claude、Clineor CherryStudio中。
-        * uvx启动
+2. Start Nacos MCP Router.
+    - Start in stdio mode. In stdio mode, configure Nacos MCP Router directly in Claude, Cline, or CherryStudio.
+        * Start with uvx.
         ```json
         {
             "mcpServers":
@@ -61,15 +61,15 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
                     ],
                     "env":
                     {
-                        "NACOS_ADDR": "<NACOS-ADDR>, 选填，默认为127.0.0.1:8848",
-                        "NACOS_USERNAME": "<NACOS-USERNAME>, 选填，默认为nacos",
-                        "NACOS_PASSWORD": "<NACOS-PASSWORD>, 必填"
+                        "NACOS_ADDR": "<NACOS-ADDR>, optional, defaults to 127.0.0.1:8848",
+                        "NACOS_USERNAME": "<NACOS-USERNAME>, optional, defaults to nacos",
+                        "NACOS_PASSWORD": "<NACOS-PASSWORD>, required"
                     }
                 }
             }
         }   
         ```
-        * docker启动
+        * Start with Docker.
         ```json
         {
             "mcpServers": {
@@ -83,8 +83,8 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         }
         ```
 
-    - sse模式启动
-        * uvx启动
+    - Start in SSE mode.
+        * Start with uvx.
         ```shell
         export NACOS_ADDR=127.0.0.1:8848
         export NACOS_USERNAME=nacos
@@ -93,12 +93,13 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         uvx nacos-mcp-router@latest
 
         ```
-        * docker启动
+        * Start with Docker.
         ```shell
         docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=sse nacos-mcp-router:latest
+        ```
 
-    - streamableHTTP模式启动
-        * uvx启动
+    - Start in streamable HTTP mode.
+        * Start with uvx.
         ```shell
         export NACOS_ADDR=127.0.0.1:8848
         export NACOS_USERNAME=nacos
@@ -106,12 +107,12 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         export TRANSPORT_TYPE=streamable_http
         uvx nacos-mcp-router@latest
         ```
-        * docker启动
+        * Start with Docker.
         ```shell
         docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http nacos-mcp-router:latest
         ```
-3. 使用Claude、Cline、CherryStudio等App测试，以CherryStudio为例，MCP配置如下
-    * stdio模式配置
+3. Test with apps such as Claude, Cline, or CherryStudio. The following example uses CherryStudio.
+    * stdio mode configuration.
     ```json
     {
             "mcpServers": {
@@ -125,7 +126,7 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         }
     ```
 
-    * sse模式配置
+    * SSE mode configuration.
     ```json
     {
             "mcpServers": {
@@ -136,7 +137,7 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         }
     ```
 
-    * streamableHTTP模式配置
+    * streamable HTTP mode configuration.
     ```json
      {
             "mcpServers": {
@@ -146,34 +147,33 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
             }
         }
     ```
-4. 体验Nacos MCP Router
+4. Try Nacos MCP Router.
     ![alt text](/img/doc/ecology/nacos-mcp-router/router-weather-question.png)
 
 
-### proxy模式
-proxy模式诞生的初衷是帮助存量stdio、sse协议的MCP Server转换为streamableHTTP协议，享受streamableHTTP协议带来的好处。proxy模式下，Nacos MCP Router仅做请求透明转发，对外暴露目标MCP Server的工具列表。
+### Proxy Mode
+Proxy mode is designed to help existing MCP Servers that use stdio or SSE convert to the streamable HTTP protocol and benefit from streamable HTTP. In proxy mode, Nacos MCP Router only transparently forwards requests and exposes the tool list of the target MCP Server.
 
-proxy模式下，需设置环境变量MODE=proxy和PROXIED_MCP_NAME， 示例如下
+In proxy mode, set the `MODE=proxy` and `PROXIED_MCP_NAME` environment variables. Example:
 ```bash
 docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http -e MODE=proxy -e PROXIED_MCP_NAME=$PROXIED_MCP_NAME  nacos-mcp-router:latest
 ```
 
-启动成功后，设置CherryStudio MCP的配置项,即可看到被代理的MCP工具列表。
+After startup succeeds, configure the CherryStudio MCP settings. You can then see the proxied MCP tool list.
 ![alt text](/img/doc/ecology/nacos-mcp-router/router-proxy-cherry-studio.png)
 
 ![alt text](/img/doc/ecology/nacos-mcp-router/router-proxy-cherry-studio-tools.png)
 
 
-## 环境变量配置
+## Environment Variables
 
-|    |               |                |      |                                           |
-|----|---------------|----------------|------|-------------------------------------------|
-|  参数 | 描述            | 默认值            | 是否必填 | 备注                                        |
-| NACOS_ADDR | Nacos 服务器地址   | 127.0.0.1:8848 | 否    | 填写 Nacos 服务器的地址，如 192.168.1.1:8848，注意要写端口 |
-| NACOS_USERNAME | Nacos 用户名     | nacos          | 否    | 填写 Nacos 用户名，如 nacos                      |
-| NACOS_PASSWORD | Nacos 密码      | 密码             | 是    | 填写 Nacos 密码，如 nacos                       |
-|NACOS_NAMESPACE| Nacos命名空间     | public         | 否    | Nacos命名空间，如 public                        |
-| TRANSPORT_TYPE | 传输协议类型        | stdio          | 否    | 填写传输协议类型，可选值：stdio、sse、streamable_http    |
-| PROXIED_MCP_NAME | 代理的 MCP 服务器名称 | -              | 否    | proxy模式下需要被转换的 MCP 服务器名称，需要先注册到Nacos      |
-| MODE | 工作模式          | router         | 否    | 可选的值：router、proxy                         |
-| PORT | 服务端口          | 8000           | 否    | 协议类型为sse或streamable时使用                    |
+| Parameter | Description | Default value | Required | Remarks |
+|-----------|-------------|---------------|----------|---------|
+| NACOS_ADDR | Nacos server address | 127.0.0.1:8848 | No | Enter the Nacos server address, such as 192.168.1.1:8848. Include the port. |
+| NACOS_USERNAME | Nacos username | nacos | No | Enter the Nacos username, such as nacos. |
+| NACOS_PASSWORD | Nacos password | password | Yes | Enter the Nacos password, such as nacos. |
+| NACOS_NAMESPACE | Nacos namespace | public | No | Nacos namespace, such as public. |
+| TRANSPORT_TYPE | Transport protocol type | stdio | No | Optional values: stdio, sse, streamable_http. |
+| PROXIED_MCP_NAME | Proxied MCP Server name | - | No | Name of the MCP Server to convert in proxy mode. The MCP Server must be registered in Nacos first. |
+| MODE | Working mode | router | No | Optional values: router and proxy. |
+| PORT | Service port | 8000 | No | Used when the protocol type is SSE or streamable HTTP. |

--- a/src/content/docs/latest/en/ecology/use-nacos-with-dubbo.md
+++ b/src/content/docs/latest/en/ecology/use-nacos-with-dubbo.md
@@ -98,10 +98,10 @@ Similarly, suppose you Dubbo applications using Nacos as registry, and the serve
     xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
     xsi:schemaLocation="http://www.springframework.org/schema/beans        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd        http://dubbo.apache.org/schema/dubbo        http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
  
-    <!-- 提供方应用信息，用于计算依赖关系 -->
+    <!-- Provider application information, used to calculate dependencies -->
     <dubbo:application name="dubbo-provider-xml-demo"  />
  
-    <!-- 使用 Nacos 注册中心 -->
+    <!-- Use the Nacos registry -->
     <dubbo:registry address="nacos://10.20.153.10:8848" />
      <!-- If you want to use your own namespace, you can use the following configuration -->
     <!-- <dubbo:registry address="nacos://10.20.153.10:8848?namespace=5cbb70a5-xxx-xxx-xxx-d43479ae0932" /> -->
@@ -343,21 +343,21 @@ The Spring XML configuration driven programming model is a traditional Spring as
        xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd        http://dubbo.apache.org/schema/dubbo        http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
 
-    <!-- 提供方应用信息，用于计算依赖关系 -->
+    <!-- Provider application information, used to calculate dependencies -->
     <dubbo:application name="dubbo-provider-xml-demo"/>
 
-    <!-- 使用 Nacos 注册中心 -->
+    <!-- Use the Nacos registry -->
     <dubbo:registry address="nacos://127.0.0.1:8848"/>
     <!-- If you want to use your own namespace, you can use the following configuration -->
     <!-- <dubbo:registry address="nacos://127.0.0.1:8848?namespace=5cbb70a5-xxx-xxx-xxx-d43479ae0932" /> -->
 
-    <!-- 用dubbo协议在随机端口暴露服务 -->
+    <!-- Expose the service on a random port through the Dubbo protocol -->
     <dubbo:protocol name="dubbo" port="-1"/>
 
-    <!-- 声明需要暴露的服务接口 -->
+    <!-- Declare the service interface to expose -->
     <dubbo:service interface="com.alibaba.nacos.example.dubbo.service.DemoService" ref="demoService" version="2.0.0"/>
 
-    <!-- 和本地bean一样实现服务 -->
+    <!-- Implement the service in the same way as a local bean -->
     <bean id="demoService" class="com.alibaba.nacos.example.dubbo.service.DefaultService"/>
 </beans>
 ```
@@ -398,15 +398,15 @@ public class DemoServiceProviderXmlBootstrap {
        xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
        xsi:schemaLocation="http://www.springframework.org/schema/beans        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd        http://dubbo.apache.org/schema/dubbo        http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
 
-    <!-- 提供方应用信息，用于计算依赖关系 -->
+    <!-- Provider application information, used to calculate dependencies -->
     <dubbo:application name="dubbo-consumer-xml-demo"/>
 
-    <!-- 使用 Nacos 注册中心 -->
+    <!-- Use the Nacos registry -->
     <dubbo:registry address="nacos://127.0.0.1:8848"/>
     <!-- If you want to use your own namespace, you can use the following configuration -->
     <!-- <dubbo:registry address="nacos://127.0.0.1:8848?namespace=5cbb70a5-xxx-xxx-xxx-d43479ae0932" /> -->
 
-    <!-- 引用服务接口 -->
+    <!-- Reference the service interface -->
     <dubbo:reference id="demoService" interface="com.alibaba.nacos.example.dubbo.service.DemoService" version="2.0.0"/>
 
 </beans>
@@ -468,6 +468,6 @@ Results also runs and load balancing is normal, but because the current sample h
 
 If your attention or love Dubbo and Nacos open source project, as well as for their points of "star", related links:
 
-- Apache Dubbo：https://github.com/apache/dubbo
-- Dubbo Nacos Registry：https://github.com/apache/dubbo/tree/master/dubbo-registry/dubbo-registry-nacos
-- Alibaba Nacos：https://github.com/alibaba/nacos
+- Apache Dubbo: https://github.com/apache/dubbo
+- Dubbo Nacos Registry: https://github.com/apache/dubbo/tree/master/dubbo-registry/dubbo-registry-nacos
+- Alibaba Nacos: https://github.com/alibaba/nacos

--- a/src/content/docs/latest/en/ecology/use-nacos-with-istio.md
+++ b/src/content/docs/latest/en/ecology/use-nacos-with-istio.md
@@ -1,32 +1,28 @@
 ---
-title: Nacos 融合Istio 下发xDS协议
+title: Use Nacos with Istio to Deliver the xDS Protocol
 keywords: [ Istio,xDs,Envoy ]
-description: Nacos 融合Istio 下发xDS协议
+description: Use Nacos with Istio to Deliver the xDS Protocol
 ---
 
-# Istio 指南
+# Istio Guide
 
-支持了 xDS 协议中的 CDS、EDS 服务，并为 EDS 以及 MCP 实现了增量推送。用户可以使用 Envoy 或其他支持 xDS 协议的客户端与 Nacos
-进行对接，实现服务发现功能。
+Nacos supports the CDS and EDS services in the xDS protocol and implements incremental push for EDS and MCP. You can connect Envoy or any other xDS-compatible client to Nacos to implement service discovery.
 
-## 配置
+## Configuration
 
-### 服务端
+### Server
 
-对于发行包，修改 `nacos/conf/application.properties` 中的 `nacos.istio.mcp.server.enabled`
-和`nacos.extension.naming.istio.enabled` 为 true；
+For a release package, set `nacos.istio.mcp.server.enabled` and `nacos.extension.naming.istio.enabled` in `nacos/conf/application.properties` to `true`.
 
-对于源码，修改 `nacos/distribution/conf/application.properties` 中的 `nacos.istio.mcp.server.enabled`
-和`nacos.extension.naming.istio.enabled` 为 true 。
+For source code, set `nacos.istio.mcp.server.enabled` and `nacos.extension.naming.istio.enabled` in `nacos/distribution/conf/application.properties` to `true`.
 
-若要使用 MCP 增量服务，除上述配置需修改外，还需修改 `nacos/istio/misc/IstioConfig` 中的 `nacos.istio.server.full` 为
-false。
+To use the MCP incremental service, in addition to the preceding settings, set `nacos.istio.server.full` in `nacos/istio/misc/IstioConfig` to `false`.
 
-### 客户端
+### Client
 
-关于客户端，下面示例中使用的是 Envoy，可直接下载 Envoy 或创建镜像并将下述配置文件进行挂载即可。
+The following client example uses Envoy. You can download Envoy directly, or build an image and mount the following configuration files.
 
-**Config**：其中使用的端口号根据需求可自行更改
+**Config**: You can change the port numbers as needed.
 
 ```yaml
 node:
@@ -71,7 +67,7 @@ static_resources:
                       port_value: 18848
 ```
 
-**lds**：对于监听的服务获取 CDS 后会主动向服务端获取 EDS，监听的服务可自行更改
+**lds**: After the listened service obtains CDS, it actively obtains EDS from the server. You can change the listened service as needed.
 
 ```yaml
 resources:
@@ -106,29 +102,29 @@ resources:
                 - name: envoy.filters.http.router
 ```
 
-## 运行
+## Run
 
-注：同一服务下的各个实例使用的协议需一致，EDS 默认使用增量推送。
+Note: instances under the same service must use the same protocol. EDS uses incremental push by default.
 
-1. 部署 Nacos，[部署参考](https://nacos.io/docs/next/quickstart/quick-start/)；
-2. 按上述要求修改配置；
-3. 启动服务器，详细的启动命令可在上述部署参考中查看；
+1. Deploy Nacos. For deployment details, see the [deployment reference](https://nacos.io/docs/next/quickstart/quick-start/).
+2. Modify the configuration as described above.
+3. Start the server. For detailed startup commands, see the deployment reference above.
 
    ```bash
    bash startup.sh -m standalone -p embedded
    ```
 
-4. 启动客户端。
+4. Start the client.
 
    ```bash
    docker start envoy
    ```
 
-## CDS 示例
+## CDS Example
 
-注：日志在 nacos/logs/istio-main.log 查看
+Note: view logs in `nacos/logs/istio-main.log`.
 
-示例中注册的服务配置如下，[示例参考](https://github.com/nacos-group/nacos-examples/tree/master/nacos-spring-cloud-example/nacos-spring-cloud-discovery-example)。
+The service registered in this example uses the following configuration. For more information, see the [example reference](https://github.com/nacos-group/nacos-examples/tree/master/nacos-spring-cloud-example/nacos-spring-cloud-discovery-example).
 
 ```properties
 server.port=8071
@@ -139,15 +135,15 @@ spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
 
 ![CDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341241-4e9b2dde-55c7-43ae-af1e-dc081565ab72.png)
 
-## EDS 示例
+## EDS Example
 
-服务配置如上
+The service configuration is the same as above.
 
 ![EDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341176-fe312687-6488-41c2-bdd1-346d7a344bd2.png)
 
-## 全量 CDS 示例
+## Full CDS Example
 
-现注册两个服务，其配置分别如下：
+Register two services with the following configurations:
 
 ```properties
 #service-provider
@@ -161,12 +157,12 @@ spring.application.name=service-consumer
 spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
 ```
 
-在控制台仅修改 service-consumer 服务配置，推送如下：
+Only modify the `service-consumer` service configuration in the console. The push result is as follows:
 
 ![Full CDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341233-bc35de56-5653-4d5f-a510-819180dfe7f0.png)
 
-## 增量 EDS 示例
+## Incremental EDS Example
 
-在控制台仅修改 service-consumer 实例配置，推送如下：
+Only modify the `service-consumer` instance configuration in the console. The push result is as follows:
 
 ![Incremental EDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341234-aa195810-c76d-4ff5-977a-55626775e697.png)

--- a/src/content/docs/next/en/ecology/use-nacos-controller-to-sync-service.md
+++ b/src/content/docs/next/en/ecology/use-nacos-controller-to-sync-service.md
@@ -1,44 +1,44 @@
 ---
-title: 使用Nacos Controller同步k8s服务到Nacos
-keywords: [Nacos Controller,使用手册]
-description: Nacos Controller 使用手册
+title: Use Nacos Controller to Sync Kubernetes Services to Nacos
+keywords: [Nacos Controller, User Guide]
+description: Nacos Controller User Guide
 sidebar:
     order: 10
 ---
 
-# 使用Nacos Controller同步k8s服务到Nacos
+# Use Nacos Controller to Sync Kubernetes Services to Nacos
 
-## 概述
+## Overview
 
-Nacos Controller支持k8s配置双向同步及服务同步到Nacos。本文讲述如何使用Nacos Controller同步k8s服务到Nacos。
+Nacos Controller supports bidirectional synchronization of Kubernetes configurations and synchronization of Kubernetes services to Nacos. This document describes how to use Nacos Controller to sync Kubernetes services to Nacos.
 
-## 前置条件
+## Prerequisites
 
-*   安装[kubectl](https://kubernetes.io/zh-cn/docs/tasks/tools/)、[helm](https://helm.sh/zh/docs/intro/install/)
+*   Install [kubectl](https://kubernetes.io/docs/tasks/tools/) and [helm](https://helm.sh/docs/intro/install/).
     
 
-## 部署自定义资源
+## Deploy Custom Resources
 
 ```shell
-#克隆仓库
+# Clone the repository
 git clone https://github.com/nacos-group/nacos-controller.git
 cd nacos-controller/charts/nacos-controller
-#导出k8s集群配置文件路径
+# Export the Kubernetes cluster configuration file path
 export KUBECONFIG=/path/to/your/kubeconfig/file
-# 创建CRD安装的命名空间
+# Create the namespace for CRD installation
 kubectl create ns nacos
-# 安装CRD
+# Install the CRD
 helm install -n nacos nacos-controller .
 ```
 
-安装成功后，使用"kubectl get crd  | grep nacos" 检查结果，如下结果表示正常：
+After installation succeeds, run `kubectl get crd | grep nacos` to check the result. The following output indicates that the CRDs are installed correctly:
 
 ![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Pd6l2Z7XEAxGMl7M/img/ea77285e-8fc2-4ea3-b89f-064c8844f693.png)
 
-## 创建Secret
+## Create a Secret
 
-创建Nacos鉴权使用的Secret，包括Nacos用户名、密码。如果使用了MSE Nacos，并且开启了鉴权，还需要配置AK、SK。**注意：参数值为base64编码之后的值。**
-* 创建secret配置文件
+Create a Secret for Nacos authentication, including the Nacos username and password. If you use MSE Nacos with authentication enabled, you must also configure the access key and secret key. **Note: parameter values must be base64-encoded.**
+* Create a Secret configuration file.
 
   ```yaml
   apiVersion: v1
@@ -51,13 +51,13 @@ helm install -n nacos nacos-controller .
       username: <base64 your-nacos-username>
       password: <base64 your-nacos-password>
   ```
-* 创建secret
+* Create the Secret.
   ```shell
   kubectl apply -f secret.yaml -n nacoskubectl 
   ```
 
-## 创建ServiceDiscovery
-* 创建ServiceDiscovery配置文件
+## Create ServiceDiscovery
+* Create a ServiceDiscovery configuration file.
   ```yaml
   apiVersion: nacos.io/v1
   kind: ServiceDiscovery
@@ -65,26 +65,26 @@ helm install -n nacos nacos-controller .
     name: sd-demo
   spec:
     nacosServer:
-        # serverAddr: Nacos地址
+        # serverAddr: Nacos address
         serverAddr: <nacos-addr>
-        # namespace: 需要把k8s服务同步到Nacos的命名空间Id
+        # namespace: namespace ID used to sync Kubernetes services to Nacos
         namespace: <nacos-namespace-id>
-        # authRef: 包含 Nacos 客户端认证凭据的 Secret（支持用户名/密码或 AK/SK；如果 Nacos 服务器认证已禁用则可省略
+        # authRef: Secret that contains Nacos client credentials (username/password or AK/SK). It can be omitted if authentication is disabled on the Nacos server.
         authRef:
           apiVersion: v1
           kind: Secret
           name: nacos-auth
-    # 需要同步的服务列表，如果需要同步全量服务则可忽略
-    services: ["my-nginx"，"test1"]
+    # Service list to sync. Omit this field to sync all services.
+    services: ["my-nginx", "test1"]
   ```
-* 创建 Service Discovery
+* Create ServiceDiscovery.
   ```yaml
   kubectl apply -f sd.yaml -n nacos
   ```
 
-## 创建Deployment
+## Create a Deployment
 
-* 以nginx为例创建deployment配置文件
+* Create a Deployment configuration file. The following example uses nginx.
 
 ```yaml
 apiVersion: apps/v1
@@ -111,9 +111,9 @@ spec:
 kubectl apply -f nginx-deployment.yaml -n nacos
 ```
 
-## 创建Service
+## Create a Service
 
-* 创建yaml文件
+* Create a YAML file.
   ```yaml
   apiVersion: v1
   kind: Service
@@ -129,19 +129,19 @@ kubectl apply -f nginx-deployment.yaml -n nacos
       app: nginx-test
   ```
 
-* 部署Service
+* Deploy the Service.
     
   ```shell
   kubectl apply -f nginx-service.yaml -n nacos
   ```
 
-* 查看Service endpoint
+* View the Service endpoint.
   ```shell
   kubectl describe svc my-nginx -n nacos
   ```
   ![image.png](https://alidocs.oss-cn-zhangjiakou.aliyuncs.com/res/Pd6l2Z7XEAxGMl7M/img/b3c62ce8-e7e2-4672-bcf5-885c45b92678.png)
 
-## 查看同步结果
+## View the Synchronization Result
   ```shell
   curl "$NACOS_ADDR/nacos/v3/admin/ns/instance/list?serviceName=my-nginx' -H "userName:$USER_NAME" -H "password:$PASSWORD"
   ```

--- a/src/content/docs/next/en/ecology/use-nacos-mcp-router.md
+++ b/src/content/docs/next/en/ecology/use-nacos-mcp-router.md
@@ -1,53 +1,53 @@
 ---
-title: Nacos MCP Router 使用手册
-keywords: [Nacos MCP Router,MCP,使用手册]
-description: Nacos MCP Router 使用手册
+title: Nacos MCP Router User Guide
+keywords: [Nacos MCP Router, MCP, User Guide]
+description: Nacos MCP Router User Guide
 sidebar:
     order: 9
 ---
 
-## 概述
-Nacos MCP Router是一个基于MCP官方标准SDK实现的的MCP Server。它提供了一组工具，提供MCP Server推荐、分发、安装及代理其他MCP Server的功能，帮助用户更方便的使用MCP Server服务， 其主要架构如下：
+## Overview
+Nacos MCP Router is an MCP Server implemented based on the official MCP standard SDK. It provides tools for MCP Server recommendation, distribution, installation, and proxying other MCP Servers, helping users consume MCP Server services more conveniently. Its main architecture is as follows:
     
 ![alt text](/img/doc/ecology/nacos-mcp-router/router-architecture.png)
 
-## 功能介绍
-Nacos MCP Router 有两种工作模式：
-1. router模式：默认模式，通过MCP Server推荐、安装及代理其他MCP Server的功能，帮助用户更方便的使用MCP Server服务。
-2. prroxy模式：使用环境变量MODE=proxy指定，通过简单配置可以把sse、stdio协议MCP Server转换为streamableHTTP协议MCP Server。
+## Features
+Nacos MCP Router provides two working modes:
+1. Router mode: the default mode. It helps users consume MCP Server services more conveniently through MCP Server recommendation, installation, and proxying other MCP Servers.
+2. Proxy mode: enabled by setting the `MODE=proxy` environment variable. With simple configuration, it converts MCP Servers that use the SSE or stdio protocol into MCP Servers that use the streamable HTTP protocol.
 
-在router 模式下，Nacos MCP Router 作为一个标准MCP Server，提供MCP Server推荐、分发、安装及代理其他MCP Server的功能。其主要工具列表为
+In router mode, Nacos MCP Router works as a standard MCP Server and provides MCP Server recommendation, distribution, installation, and proxy capabilities. The main tools are:
 1. `search_mcp_server`
-    - 根据任务描述及关键字从MCP注册中心（Nacos）中搜索相关的MCP Server列表
-    - 输入:
-      - `task_description`(string): 任务描述，示例：今天杭州天气如何
-      - `key_words`(string): 任务关键字，示例：天气、杭州
-    - 输出: list of MCP servers and instructions to complete the task.
+    - Searches the MCP registry (Nacos) for related MCP Servers based on a task description and keywords.
+    - Input:
+      - `task_description` (string): task description. Example: "What is the weather in Hangzhou today?"
+      - `key_words` (string): task keywords. Example: "weather, Hangzhou"
+    - Output: list of MCP servers and instructions to complete the task.
 2. `add_mcp_server`
-    - 添加并初始化一个MCP Server，根据Nacos中的配置与该MCP Server建立连接，等待调用。
-    - 输入:
-      - `mcp_server_name`(string): 需要添加的MCP Server名字
-    - 输出: MCP Server工具列表及使用方法
+    - Adds and initializes an MCP Server, establishes a connection to it based on the configuration in Nacos, and waits for calls.
+    - Input:
+      - `mcp_server_name` (string): name of the MCP Server to add.
+    - Output: MCP Server tool list and usage instructions.
 3. `use_tool`
-   - 代理其他MCP Server的工具
-   - 输入:
-     - `mcp_server_name`(string): 被调的目标MCP Server名称.
-     - `mcp_tool_name`(string): 被调的目标MCP Server的工具名称
-     - `params`(map): 被调的目标MCP Server的工具的参数
-   - 输出: 被调的目标MCP Server的工具的输出结果
+   - Proxies tools from other MCP Servers.
+   - Input:
+     - `mcp_server_name` (string): name of the target MCP Server to call.
+     - `mcp_tool_name` (string): name of the target MCP Server tool to call.
+     - `params` (map): parameters of the target MCP Server tool to call.
+   - Output: output from the target MCP Server tool.
 
-在proxy 模式下，Nacos MCP Router 仅提供代理功能，无需代码改动即可实现stdio、sse协议一键转换为streamableHTTP协议。
-## 快速开始
-### 准备工作
-Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动 Nacos 服务，可先行参考 [Nacos 快速入门](../quickstart/quick-start.mdx)。 
+In proxy mode, Nacos MCP Router only provides proxy capabilities and can convert stdio or SSE protocol MCP Servers to the streamable HTTP protocol without code changes.
+## Quick Start
+### Prerequisites
+Nacos MCP Router uses Nacos as the MCP Registry. Make sure the Nacos service has been started in the background. For more information, see [Nacos Quick Start](../quickstart/quick-start.mdx).
 
-### router模式
-1. 注册MCP Server
-在Nacos控制台注册可能要用到的MCP Server，并设置MCP Server的配置, 以高德地图为例。
+### Router Mode
+1. Register an MCP Server.
+Register the MCP Server that may be used in the Nacos console and configure the MCP Server. The following example uses AutoNavi Maps.
 ![alt text](/img/doc/ecology/nacos-mcp-router/mcp-register.png)
-2. 启动Nacos MCP Router
-    - stdio模式启动，stdio模式需直接配置在Claude、Clineor CherryStudio中。
-        * uvx启动
+2. Start Nacos MCP Router.
+    - Start in stdio mode. In stdio mode, configure Nacos MCP Router directly in Claude, Cline, or CherryStudio.
+        * Start with uvx.
         ```json
         {
             "mcpServers":
@@ -61,15 +61,15 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
                     ],
                     "env":
                     {
-                        "NACOS_ADDR": "<NACOS-ADDR>, 选填，默认为127.0.0.1:8848",
-                        "NACOS_USERNAME": "<NACOS-USERNAME>, 选填，默认为nacos",
-                        "NACOS_PASSWORD": "<NACOS-PASSWORD>, 必填"
+                        "NACOS_ADDR": "<NACOS-ADDR>, optional, defaults to 127.0.0.1:8848",
+                        "NACOS_USERNAME": "<NACOS-USERNAME>, optional, defaults to nacos",
+                        "NACOS_PASSWORD": "<NACOS-PASSWORD>, required"
                     }
                 }
             }
         }   
         ```
-        * docker启动
+        * Start with Docker.
         ```json
         {
             "mcpServers": {
@@ -83,8 +83,8 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         }
         ```
 
-    - sse模式启动
-        * uvx启动
+    - Start in SSE mode.
+        * Start with uvx.
         ```shell
         export NACOS_ADDR=127.0.0.1:8848
         export NACOS_USERNAME=nacos
@@ -93,12 +93,13 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         uvx nacos-mcp-router@latest
 
         ```
-        * docker启动
+        * Start with Docker.
         ```shell
         docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=sse nacos-mcp-router:latest
+        ```
 
-    - streamableHTTP模式启动
-        * uvx启动
+    - Start in streamable HTTP mode.
+        * Start with uvx.
         ```shell
         export NACOS_ADDR=127.0.0.1:8848
         export NACOS_USERNAME=nacos
@@ -106,12 +107,12 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         export TRANSPORT_TYPE=streamable_http
         uvx nacos-mcp-router@latest
         ```
-        * docker启动
+        * Start with Docker.
         ```shell
         docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http nacos-mcp-router:latest
         ```
-3. 使用Claude、Cline、CherryStudio等App测试，以CherryStudio为例，MCP配置如下
-    * stdio模式配置
+3. Test with apps such as Claude, Cline, or CherryStudio. The following example uses CherryStudio.
+    * stdio mode configuration.
     ```json
     {
             "mcpServers": {
@@ -125,7 +126,7 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         }
     ```
 
-    * sse模式配置
+    * SSE mode configuration.
     ```json
     {
             "mcpServers": {
@@ -136,7 +137,7 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
         }
     ```
 
-    * streamableHTTP模式配置
+    * streamable HTTP mode configuration.
     ```json
      {
             "mcpServers": {
@@ -146,34 +147,33 @@ Nacos MCP Router 使用Nacos 作为MCP Registry，请请确保后台已经启动
             }
         }
     ```
-4. 体验Nacos MCP Router
+4. Try Nacos MCP Router.
     ![alt text](/img/doc/ecology/nacos-mcp-router/router-weather-question.png)
 
 
-### proxy模式
-proxy模式诞生的初衷是帮助存量stdio、sse协议的MCP Server转换为streamableHTTP协议，享受streamableHTTP协议带来的好处。proxy模式下，Nacos MCP Router仅做请求透明转发，对外暴露目标MCP Server的工具列表。
+### Proxy Mode
+Proxy mode is designed to help existing MCP Servers that use stdio or SSE convert to the streamable HTTP protocol and benefit from streamable HTTP. In proxy mode, Nacos MCP Router only transparently forwards requests and exposes the tool list of the target MCP Server.
 
-proxy模式下，需设置环境变量MODE=proxy和PROXIED_MCP_NAME， 示例如下
+In proxy mode, set the `MODE=proxy` and `PROXIED_MCP_NAME` environment variables. Example:
 ```bash
 docker run -i --rm --network host -e NACOS_ADDR=$NACOS_ADDR -e NACOS_USERNAME=$NACOS_USERNAME -e NACOS_PASSWORD=$NACOS_PASSWORD -e TRANSPORT_TYPE=streamable_http -e MODE=proxy -e PROXIED_MCP_NAME=$PROXIED_MCP_NAME  nacos-mcp-router:latest
 ```
 
-启动成功后，设置CherryStudio MCP的配置项,即可看到被代理的MCP工具列表。
+After startup succeeds, configure the CherryStudio MCP settings. You can then see the proxied MCP tool list.
 ![alt text](/img/doc/ecology/nacos-mcp-router/router-proxy-cherry-studio.png)
 
 ![alt text](/img/doc/ecology/nacos-mcp-router/router-proxy-cherry-studio-tools.png)
 
 
-## 环境变量配置
+## Environment Variables
 
-|    |               |                |      |                                           |
-|----|---------------|----------------|------|-------------------------------------------|
-|  参数 | 描述            | 默认值            | 是否必填 | 备注                                        |
-| NACOS_ADDR | Nacos 服务器地址   | 127.0.0.1:8848 | 否    | 填写 Nacos 服务器的地址，如 192.168.1.1:8848，注意要写端口 |
-| NACOS_USERNAME | Nacos 用户名     | nacos          | 否    | 填写 Nacos 用户名，如 nacos                      |
-| NACOS_PASSWORD | Nacos 密码      | 密码             | 是    | 填写 Nacos 密码，如 nacos                       |
-|NACOS_NAMESPACE| Nacos命名空间     | public         | 否    | Nacos命名空间，如 public                        |
-| TRANSPORT_TYPE | 传输协议类型        | stdio          | 否    | 填写传输协议类型，可选值：stdio、sse、streamable_http    |
-| PROXIED_MCP_NAME | 代理的 MCP 服务器名称 | -              | 否    | proxy模式下需要被转换的 MCP 服务器名称，需要先注册到Nacos      |
-| MODE | 工作模式          | router         | 否    | 可选的值：router、proxy                         |
-| PORT | 服务端口          | 8000           | 否    | 协议类型为sse或streamable时使用                    |
+| Parameter | Description | Default value | Required | Remarks |
+|-----------|-------------|---------------|----------|---------|
+| NACOS_ADDR | Nacos server address | 127.0.0.1:8848 | No | Enter the Nacos server address, such as 192.168.1.1:8848. Include the port. |
+| NACOS_USERNAME | Nacos username | nacos | No | Enter the Nacos username, such as nacos. |
+| NACOS_PASSWORD | Nacos password | password | Yes | Enter the Nacos password, such as nacos. |
+| NACOS_NAMESPACE | Nacos namespace | public | No | Nacos namespace, such as public. |
+| TRANSPORT_TYPE | Transport protocol type | stdio | No | Optional values: stdio, sse, streamable_http. |
+| PROXIED_MCP_NAME | Proxied MCP Server name | - | No | Name of the MCP Server to convert in proxy mode. The MCP Server must be registered in Nacos first. |
+| MODE | Working mode | router | No | Optional values: router and proxy. |
+| PORT | Service port | 8000 | No | Used when the protocol type is SSE or streamable HTTP. |

--- a/src/content/docs/next/en/ecology/use-nacos-with-dubbo.md
+++ b/src/content/docs/next/en/ecology/use-nacos-with-dubbo.md
@@ -98,10 +98,10 @@ Similarly, suppose you Dubbo applications using Nacos as registry, and the serve
     xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
     xsi:schemaLocation="http://www.springframework.org/schema/beans        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd        http://dubbo.apache.org/schema/dubbo        http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
  
-    <!-- 提供方应用信息，用于计算依赖关系 -->
+    <!-- Provider application information, used to calculate dependencies -->
     <dubbo:application name="dubbo-provider-xml-demo"  />
  
-    <!-- 使用 Nacos 注册中心 -->
+    <!-- Use the Nacos registry -->
     <dubbo:registry address="nacos://10.20.153.10:8848" />
      <!-- If you want to use your own namespace, you can use the following configuration -->
     <!-- <dubbo:registry address="nacos://10.20.153.10:8848?namespace=5cbb70a5-xxx-xxx-xxx-d43479ae0932" /> -->
@@ -343,21 +343,21 @@ The Spring XML configuration driven programming model is a traditional Spring as
        xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd        http://dubbo.apache.org/schema/dubbo        http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
 
-    <!-- 提供方应用信息，用于计算依赖关系 -->
+    <!-- Provider application information, used to calculate dependencies -->
     <dubbo:application name="dubbo-provider-xml-demo"/>
 
-    <!-- 使用 Nacos 注册中心 -->
+    <!-- Use the Nacos registry -->
     <dubbo:registry address="nacos://127.0.0.1:8848"/>
     <!-- If you want to use your own namespace, you can use the following configuration -->
     <!-- <dubbo:registry address="nacos://127.0.0.1:8848?namespace=5cbb70a5-xxx-xxx-xxx-d43479ae0932" /> -->
 
-    <!-- 用dubbo协议在随机端口暴露服务 -->
+    <!-- Expose the service on a random port through the Dubbo protocol -->
     <dubbo:protocol name="dubbo" port="-1"/>
 
-    <!-- 声明需要暴露的服务接口 -->
+    <!-- Declare the service interface to expose -->
     <dubbo:service interface="com.alibaba.nacos.example.dubbo.service.DemoService" ref="demoService" version="2.0.0"/>
 
-    <!-- 和本地bean一样实现服务 -->
+    <!-- Implement the service in the same way as a local bean -->
     <bean id="demoService" class="com.alibaba.nacos.example.dubbo.service.DefaultService"/>
 </beans>
 ```
@@ -398,15 +398,15 @@ public class DemoServiceProviderXmlBootstrap {
        xmlns:dubbo="http://dubbo.apache.org/schema/dubbo"
        xsi:schemaLocation="http://www.springframework.org/schema/beans        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd        http://dubbo.apache.org/schema/dubbo        http://dubbo.apache.org/schema/dubbo/dubbo.xsd">
 
-    <!-- 提供方应用信息，用于计算依赖关系 -->
+    <!-- Provider application information, used to calculate dependencies -->
     <dubbo:application name="dubbo-consumer-xml-demo"/>
 
-    <!-- 使用 Nacos 注册中心 -->
+    <!-- Use the Nacos registry -->
     <dubbo:registry address="nacos://127.0.0.1:8848"/>
     <!-- If you want to use your own namespace, you can use the following configuration -->
     <!-- <dubbo:registry address="nacos://127.0.0.1:8848?namespace=5cbb70a5-xxx-xxx-xxx-d43479ae0932" /> -->
 
-    <!-- 引用服务接口 -->
+    <!-- Reference the service interface -->
     <dubbo:reference id="demoService" interface="com.alibaba.nacos.example.dubbo.service.DemoService" version="2.0.0"/>
 
 </beans>
@@ -468,6 +468,6 @@ Results also runs and load balancing is normal, but because the current sample h
 
 If your attention or love Dubbo and Nacos open source project, as well as for their points of "star", related links:
 
-- Apache Dubbo：https://github.com/apache/dubbo
-- Dubbo Nacos Registry：https://github.com/apache/dubbo/tree/master/dubbo-registry/dubbo-registry-nacos
-- Alibaba Nacos：https://github.com/alibaba/nacos
+- Apache Dubbo: https://github.com/apache/dubbo
+- Dubbo Nacos Registry: https://github.com/apache/dubbo/tree/master/dubbo-registry/dubbo-registry-nacos
+- Alibaba Nacos: https://github.com/alibaba/nacos

--- a/src/content/docs/next/en/ecology/use-nacos-with-istio.md
+++ b/src/content/docs/next/en/ecology/use-nacos-with-istio.md
@@ -1,32 +1,28 @@
 ---
-title: Nacos 融合Istio 下发xDS协议
+title: Use Nacos with Istio to Deliver the xDS Protocol
 keywords: [ Istio,xDs,Envoy ]
-description: Nacos 融合Istio 下发xDS协议
+description: Use Nacos with Istio to Deliver the xDS Protocol
 ---
 
-# Istio 指南
+# Istio Guide
 
-支持了 xDS 协议中的 CDS、EDS 服务，并为 EDS 以及 MCP 实现了增量推送。用户可以使用 Envoy 或其他支持 xDS 协议的客户端与 Nacos
-进行对接，实现服务发现功能。
+Nacos supports the CDS and EDS services in the xDS protocol and implements incremental push for EDS and MCP. You can connect Envoy or any other xDS-compatible client to Nacos to implement service discovery.
 
-## 配置
+## Configuration
 
-### 服务端
+### Server
 
-对于发行包，修改 `nacos/conf/application.properties` 中的 `nacos.istio.mcp.server.enabled`
-和`nacos.extension.naming.istio.enabled` 为 true；
+For a release package, set `nacos.istio.mcp.server.enabled` and `nacos.extension.naming.istio.enabled` in `nacos/conf/application.properties` to `true`.
 
-对于源码，修改 `nacos/distribution/conf/application.properties` 中的 `nacos.istio.mcp.server.enabled`
-和`nacos.extension.naming.istio.enabled` 为 true 。
+For source code, set `nacos.istio.mcp.server.enabled` and `nacos.extension.naming.istio.enabled` in `nacos/distribution/conf/application.properties` to `true`.
 
-若要使用 MCP 增量服务，除上述配置需修改外，还需修改 `nacos/istio/misc/IstioConfig` 中的 `nacos.istio.server.full` 为
-false。
+To use the MCP incremental service, in addition to the preceding settings, set `nacos.istio.server.full` in `nacos/istio/misc/IstioConfig` to `false`.
 
-### 客户端
+### Client
 
-关于客户端，下面示例中使用的是 Envoy，可直接下载 Envoy 或创建镜像并将下述配置文件进行挂载即可。
+The following client example uses Envoy. You can download Envoy directly, or build an image and mount the following configuration files.
 
-**Config**：其中使用的端口号根据需求可自行更改
+**Config**: You can change the port numbers as needed.
 
 ```yaml
 node:
@@ -71,7 +67,7 @@ static_resources:
                       port_value: 18848
 ```
 
-**lds**：对于监听的服务获取 CDS 后会主动向服务端获取 EDS，监听的服务可自行更改
+**lds**: After the listened service obtains CDS, it actively obtains EDS from the server. You can change the listened service as needed.
 
 ```yaml
 resources:
@@ -106,29 +102,29 @@ resources:
                 - name: envoy.filters.http.router
 ```
 
-## 运行
+## Run
 
-注：同一服务下的各个实例使用的协议需一致，EDS 默认使用增量推送。
+Note: instances under the same service must use the same protocol. EDS uses incremental push by default.
 
-1. 部署 Nacos，[部署参考](https://nacos.io/docs/next/quickstart/quick-start/)；
-2. 按上述要求修改配置；
-3. 启动服务器，详细的启动命令可在上述部署参考中查看；
+1. Deploy Nacos. For deployment details, see the [deployment reference](https://nacos.io/docs/next/quickstart/quick-start/).
+2. Modify the configuration as described above.
+3. Start the server. For detailed startup commands, see the deployment reference above.
 
    ```bash
    bash startup.sh -m standalone -p embedded
    ```
 
-4. 启动客户端。
+4. Start the client.
 
    ```bash
    docker start envoy
    ```
 
-## CDS 示例
+## CDS Example
 
-注：日志在 nacos/logs/istio-main.log 查看
+Note: view logs in `nacos/logs/istio-main.log`.
 
-示例中注册的服务配置如下，[示例参考](https://github.com/nacos-group/nacos-examples/tree/master/nacos-spring-cloud-example/nacos-spring-cloud-discovery-example)。
+The service registered in this example uses the following configuration. For more information, see the [example reference](https://github.com/nacos-group/nacos-examples/tree/master/nacos-spring-cloud-example/nacos-spring-cloud-discovery-example).
 
 ```properties
 server.port=8071
@@ -139,15 +135,15 @@ spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
 
 ![CDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341241-4e9b2dde-55c7-43ae-af1e-dc081565ab72.png)
 
-## EDS 示例
+## EDS Example
 
-服务配置如上
+The service configuration is the same as above.
 
 ![EDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341176-fe312687-6488-41c2-bdd1-346d7a344bd2.png)
 
-## 全量 CDS 示例
+## Full CDS Example
 
-现注册两个服务，其配置分别如下：
+Register two services with the following configurations:
 
 ```properties
 #service-provider
@@ -161,12 +157,12 @@ spring.application.name=service-consumer
 spring.cloud.nacos.discovery.server-addr=127.0.0.1:8848
 ```
 
-在控制台仅修改 service-consumer 服务配置，推送如下：
+Only modify the `service-consumer` service configuration in the console. The push result is as follows:
 
 ![Full CDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341233-bc35de56-5653-4d5f-a510-819180dfe7f0.png)
 
-## 增量 EDS 示例
+## Incremental EDS Example
 
-在控制台仅修改 service-consumer 实例配置，推送如下：
+Only modify the `service-consumer` instance configuration in the console. The push result is as follows:
 
 ![Incremental EDS](https://cdn.nlark.com/yuque/0/2022/png/28990648/1666247341234-aa195810-c76d-4ff5-977a-55626775e697.png)


### PR DESCRIPTION
## Summary
- translate English ecology docs for Nacos Controller service sync, Istio, and MCP Router
- clean Dubbo example comments and reference link punctuation in latest/next English docs
- keep latest and next English ecology docs aligned

## Validation
- rg -n "[\p{Han}]" src/content/docs/latest/en/ecology src/content/docs/next/en/ecology
- rg -n "[，。；：！？（）“”、]| " selected changed ecology docs
- git diff --check develop-astro-nacos..HEAD
- npm run build (fails locally because Rollup optional native package @rollup/rollup-darwin-arm64 cannot be loaded due macOS code signature Team ID mismatch, same local environment issue as prior batches)