### PR TITLE
docs: align English admin deployment docs

### DIFF
--- a/src/content/docs/latest/en/manual/admin/deployment/deployment-cluster.md
+++ b/src/content/docs/latest/en/manual/admin/deployment/deployment-cluster.md
@@ -1,45 +1,45 @@
 ---
 title: Cluster Deployment
-keywords: [Nacos,Deployment,Cluster]
-description: The Manual fo Nacos cluster deployment.
+keywords: [Nacos, Deployment, Cluster]
+description: The manual for Nacos cluster deployment.
 sidebar:
     order: 3
 ---
 
-# Nacos集群模式
+# Nacos Cluster Mode
 
-本部署手册是帮忙您快速在你的电脑上，下载安装并使用Nacos，部署生产使用的集群模式。
+This deployment guide helps you quickly download, install, and use Nacos on your computer, and deploy cluster mode for production use.
 
-### 集群部署架构图
+### Cluster Deployment Architecture
 
-无论采用何种部署方式，推荐用户把Nacos集群中所有服务节点放到一个vip下面，然后挂到一个域名下面。
+Regardless of the deployment method, we recommend placing all service nodes in the Nacos cluster behind one VIP and then binding the VIP to a domain name.
 
-`<http://ip1:port/openAPI>`  直连ip模式，机器挂则需要修改ip才可以使用。
+`<http://ip1:port/openAPI>` Direct IP mode. If the machine fails, you must modify the IP address before the endpoint can be used again.
 
-`<http://SLB:port/openAPI>`  挂载SLB模式(内网SLB，不可暴露到公网，以免带来安全风险)，直连SLB即可，下面挂server真实ip，可读性不好。
+`<http://SLB:port/openAPI>` SLB mode. Use an internal SLB and do not expose it to the public network to avoid security risks. Clients connect directly to the SLB, and real server IPs are mounted behind it, which is less readable.
 
-`<http://nacos.com:port/openAPI>`  域名 + SLB模式(内网SLB，不可暴露到公网，以免带来安全风险)，可读性好，而且换ip方便，推荐模式
+`<http://nacos.com:port/openAPI>` Domain name plus SLB mode. Use an internal SLB and do not expose it to the public network to avoid security risks. This mode is readable and makes IP replacement easier. It is the recommended mode.
 
 ![deployDnsVipMode.jpg](/img/doc/manual/admin/deployment/deploy-dns-vip-mode.svg)
 
-在使用VIP时，需要开放Nacos服务的主端口(默认8848)以及gRPC端口(默认9848)、同时如果对Nacos的主端口有所修改的话，需要对vip中的端口映射作出配置，具体端口的映射方式参考[部署手册概览-Nacos部署架构](./deployment-overview/#1-Nacos部署架构)
+When using a VIP, open the main Nacos service port (default `8848`) and the gRPC port (default `9848`). If you change the main Nacos port, configure the corresponding port mapping in the VIP. For port mapping details, see [Deployment Overview - Nacos Deployment Architecture](./deployment-overview/#1-nacos-deployment-architecture).
 
-## 1. 发行版部署
+## 1. Release Package Deployment
 
-### 1.1. 使用MySQL数据库（推荐）
+### 1.1. Use MySQL Database (Recommended)
 
-#### 1.1.1. 环境准备
+#### 1.1.1. Environment Preparation
 
-参考[快速开始](../../../quickstart/quick-start.mdx)中，进行Nacos的环境准备、发行版的下载等。
+Refer to [Quick Start](../../../quickstart/quick-start.mdx) to prepare the Nacos environment and download the release package.
 
-同时在使用MySQL数据源部署Nacos单机模式时，需要自行准备MySQL数据库：
+When deploying Nacos cluster mode with a MySQL data source, prepare the MySQL database yourself:
 
-- 1.安装数据库，版本要求：5.6.5+
-- 2.初始化mysql数据库，数据库初始化文件：[mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql)
+- 1. Install the database. The required version is 5.6.5 or later.
+- 2. Initialize the MySQL database. Database initialization file: [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql).
 
-#### 1.1.2. 配置集群配置文件
+#### 1.1.2. Configure the Cluster Configuration File
 
-在nacos的解压目录nacos/的conf目录下，有配置文件cluster.conf，请每行配置成ip:port。（请配置3个或3个以上节点）
+In the `conf` directory under the Nacos decompression directory `nacos/`, configure the `cluster.conf` file with one `ip:port` entry per line. Configure three or more nodes.
 
 ```plain
 # ip:port
@@ -48,9 +48,9 @@ sidebar:
 200.8.9.18:8848
 ```
 
-#### 1.1.3. 修改配置文件
+#### 1.1.3. Modify Configuration Files
 
-然后修改`${nacos.home}/conf/application.properties`文件，增加支持MySQL数据源配置，添加MySQL数据源的url、用户名和密码。
+Then modify `${nacos.home}/conf/application.properties`, add the MySQL data source configuration, and configure the MySQL data source URL, username, and password.
 
 ```
 spring.sql.init.platform=mysql
@@ -61,32 +61,32 @@ db.user=${mysql_user}
 db.password=${mysql_password}
 ```
 
-##### 1.1.3.1. 开启默认鉴权插件
+##### 1.1.3.1. Enable the Default Authentication Plugin
 
-> 自3.0.0版本开始，Nacos控制台默认开启访问鉴权，所以鉴权相关配置必须进行配置。
+> Since Nacos 3.0.0, console access authentication is enabled by default, so authentication-related configurations must be configured.
 
-修改`conf`目录下的`application.properties`文件。
+Modify `application.properties` in the `conf` directory.
 
-设置其中
+Set the following items:
 
 ```properties
-## 开启客户端访问鉴权，默认为关闭，可选
+## Enable client access authentication. Disabled by default and optional.
 nacos.core.auth.enabled=true
-## 开启控制台访问鉴权，默认为开启
+## Enable console access authentication. Enabled by default.
 nacos.core.auth.console.enabled=true
 nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
+nacos.core.auth.plugin.nacos.token.secret.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.value=${custom_value_same_on_all_nodes}
 ```
 
-上述内容详情可查看[权限认证](../../../plugin/auth-plugin.md).
+For details, see [Authentication](../../../plugin/auth-plugin.md).
 
-> 注意，文档中的默认值`SecretKey012345678901234567890123456789012345678901234567890123456789`和`VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=`为公开默认值，可用于临时测试，实际使用时请**务必**更换为自定义的其他有效值。
+> Note: the default values `SecretKey012345678901234567890123456789012345678901234567890123456789` and `VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=` in the documentation are public default values and can be used only for temporary testing. In actual use, **replace them with other custom valid values**.
 
-#### 1.1.4. 启动Nacos集群
+#### 1.1.4. Start the Nacos Cluster
 
-在每个部署节点上，执行如下命名，逐台或同时启动Nacos节点。
+On each deployment node, run the following commands to start Nacos nodes one by one or at the same time.
 
 ```bash
 # Linux/Unix/Mac 
@@ -100,7 +100,7 @@ bash startup.sh
 startup.cmd
 ```
 
-随后启动程序会提示您输入`3个`鉴权相关配置
+The startup program then prompts you to enter the following `3` authentication-related configurations:
 
 ```
 `nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
@@ -115,20 +115,20 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 ```
 
 ::: note
-若您已经在[修改配置文件](#1131-开启默认鉴权插件)步骤中设置过这3个配置，则不会提示您输入。
+If you have configured these `3` settings in [Modify Configuration Files](#1131-enable-the-default-authentication-plugin), you will not be prompted to enter them.
 :::
 
-### 1.2. 使用Derby数据库
+### 1.2. Use Derby Database
 
-> 注意：Derby数据库为本地内置数据库，本身不支持集群模式，Nacos通过Raft协议将各个节点的Derby数据库组成逻辑集群，因此使用此模式部署集群模式的Nacos时，需要对Raft协议较为熟悉，能够进行问题排查、恢复等，建议使用MySQL数据库进行部署。
+> Note: Derby is a local built-in database and does not support cluster mode by itself. Nacos uses the Raft protocol to form a logical cluster from the Derby databases of each node. Therefore, when deploying Nacos cluster mode with this mode, you must be familiar with the Raft protocol and be able to troubleshoot and recover issues. We recommend deploying with a MySQL database.
 
-#### 1.2.1. 环境准备
+#### 1.2.1. Environment Preparation
 
-参考[快速开始](../../../quickstart/quick-start.mdx)中，进行Nacos的环境准备、发行版的下载等。
+Refer to [Quick Start](../../../quickstart/quick-start.mdx) to prepare the Nacos environment and download the release package.
 
-#### 1.2.2. 配置集群配置文件
+#### 1.2.2. Configure the Cluster Configuration File
 
-在nacos的解压目录nacos/的conf目录下，有配置文件cluster.conf，请每行配置成ip:port。（请配置3个或3个以上节点）
+In the `conf` directory under the Nacos decompression directory `nacos/`, configure the `cluster.conf` file with one `ip:port` entry per line. Configure three or more nodes.
 
 ```plain
 # ip:port
@@ -137,32 +137,32 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 200.8.9.18:8848
 ```
 
-#### 1.2.3. 开启默认鉴权插件
+#### 1.2.3. Enable the Default Authentication Plugin
 
-> 自3.0.0版本开始，Nacos控制台默认开启访问鉴权，所以鉴权相关配置必须进行配置。
+> Since Nacos 3.0.0, console access authentication is enabled by default, so authentication-related configurations must be configured.
 
-修改`conf`目录下的`application.properties`文件。
+Modify `application.properties` in the `conf` directory.
 
-设置其中
+Set the following items:
 
 ```properties
-## 开启客户端访问鉴权，默认为关闭，可选
+## Enable client access authentication. Disabled by default and optional.
 nacos.core.auth.enabled=true
-## 开启控制台访问鉴权，默认为开启
+## Enable console access authentication. Enabled by default.
 nacos.core.auth.console.enabled=true
 nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
+nacos.core.auth.plugin.nacos.token.secret.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.value=${custom_value_same_on_all_nodes}
 ```
 
-上述内容详情可查看[权限认证](../../../plugin/auth-plugin.md).
+For details, see [Authentication](../../../plugin/auth-plugin.md).
 
-> 注意，文档中的默认值`SecretKey012345678901234567890123456789012345678901234567890123456789`和`VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=`为公开默认值，可用于临时测试，实际使用时请**务必**更换为自定义的其他有效值。
+> Note: the default values `SecretKey012345678901234567890123456789012345678901234567890123456789` and `VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=` in the documentation are public default values and can be used only for temporary testing. In actual use, **replace them with other custom valid values**.
 
-#### 1.2.4. 启动Nacos集群
+#### 1.2.4. Start the Nacos Cluster
 
-在每个部署节点上，执行如下命名，逐台或同时启动Nacos节点。
+On each deployment node, run the following commands to start Nacos nodes one by one or at the same time.
 
 ```bash
 # Linux/Unix/Mac 
@@ -176,67 +176,67 @@ bash startup.sh -p embedded
 startup.cmd -p embedded
 ```
 
-### 1.3. 高级使用
+### 1.3. Advanced Usage
 
-#### 1.3.1. 自定义配置
+#### 1.3.1. Custom Configuration
 
-Nacos提供了丰富的可配置项，帮助您调整Nacos的性能、控制Nacos提供的功能能力，例如鉴权、监控、数据库、连接、日志等；详情请参考[系统参数](../system-configurations.md)。
+Nacos provides rich configuration items that help you tune Nacos performance and control Nacos features, such as authentication, monitoring, databases, connections, and logs. For details, see [System Parameters](../system-configurations.md).
 
-## 2. Docker部署
+## 2. Docker Deployment
 
-### 2.1. 使用MySQL数据库（推荐）
+### 2.1. Use MySQL Database (Recommended)
 
-参考[快速开始 Docker](../../../quickstart/quick-start-docker.mdx)中，进行`nacos-docker`项目的下载，然后执行如下命令，即可启动Nacos集群。
+Refer to [Quick Start Docker](../../../quickstart/quick-start-docker.mdx) to download the `nacos-docker` project, and then run the following command to start the Nacos cluster.
 
 ```powershell
 docker-compose -f example/cluster-hostname.yaml up 
 ```
 
-### 2.2. 使用Derby数据库
+### 2.2. Use Derby Database
 
-> 注意：Derby数据库为本地内置数据库，本身不支持集群模式，Nacos通过Raft协议将各个节点的Derby数据库组成逻辑集群，因此使用此模式部署集群模式的Nacos时，需要对Raft协议较为熟悉，能够进行问题排查、恢复等，建议使用MySQL数据库进行部署。
+> Note: Derby is a local built-in database and does not support cluster mode by itself. Nacos uses the Raft protocol to form a logical cluster from the Derby databases of each node. Therefore, when deploying Nacos cluster mode with this mode, you must be familiar with the Raft protocol and be able to troubleshoot and recover issues. We recommend deploying with a MySQL database.
 
-参考[快速开始 Docker](../../../quickstart/quick-start-docker.mdx)中，进行`nacos-docker`项目的下载，然后执行如下命令，即可启动Nacos集群。
+Refer to [Quick Start Docker](../../../quickstart/quick-start-docker.mdx) to download the `nacos-docker` project, and then run the following command to start the Nacos cluster.
 
 ```powershell
 docker-compose -f example/cluster-embedded.yaml up 
 ```
 
-### 2.3 高级配置
+### 2.3 Advanced Configuration
 
-如果你有很多自定义配置的需求，可以通过指定[系统参数-镜像环境变量](../system-configurations/#2-镜像环境变量)的方式进行配置，例如需要开启鉴权时：
+If you need many custom configurations, you can configure them by specifying [System Parameters - Image Environment Variables](../system-configurations/#2-image-environment-variables). For example, to enable authentication:
 
 ```powershell
 docker run --name nacos-cluster-auth -e MODE=cluster -e NACOS_AUTH_ENABLE=true -e NACOS_AUTH_TOKEN=${customToken} -e NACOS_AUTH_IDENTITY_KEY=${customKey} NACOS_AUTH_IDENTITY_VALUE=${customValue} -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-同时，可以通过对application.properties文件进行挂卷定义的方式，将更多复杂的自定义配置导入Nacos容器中，强烈建议在生产环境中使用方式，例如：
+You can also mount the `application.properties` file to import more complex custom configurations into the Nacos container. This method is strongly recommended for production environments. Example:
 
 ```powershell
 docker run --name nacos-cluster -e MODE=cluster -v /path/application.properties:/home/nacos/conf/application.properties -v /path/cluster.conf:/home/nacos/conf/cluster.conf -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-如果仍然无法满足自定义需求，可以基于nacos-docker项目中的`Dockerfile`自行构建镜像。
+If this still cannot meet your customization requirements, you can build an image based on the `Dockerfile` in the `nacos-docker` project.
 
-## 3. Kubernetes部署
+## 3. Kubernetes Deployment
 
-通过[快速开始 Kubernetes](../../../quickstart/quick-start-kubernetes.mdx)文档，已经能够部署使用MySQL数据库的Nacos的集群模式。
+[Quick Start Kubernetes](../../../quickstart/quick-start-kubernetes.mdx) can deploy Nacos cluster mode with a MySQL database.
 
-但快速开始所部署的Nacos集群没有使用持久化卷的,可能存在数据丢失风险；因此推荐使用PVC持久卷方式进行部署，本例中将使用的是NFS来使用PVC。
+However, the Nacos cluster deployed by the quick start does not use persistent volumes and may have data loss risks. Therefore, we recommend deploying with PVC persistent volumes. This example uses NFS with PVC.
 
 #### Tips
 
-* 推荐使用[Nacos Operator](https://github.com/nacos-group/nacos-k8s/blob/master/operator/README-CN.md)在Kubernetes部署Nacos Server.
+* We recommend using [Nacos Operator](https://github.com/nacos-group/nacos-k8s/blob/master/operator/README-CN.md) to deploy Nacos Server on Kubernetes.
 
-### 3.1. 部署 NFS
+### 3.1. Deploy NFS
 
-* 创建角色
+* Create roles.
 
 ```shell
 kubectl create -f deploy/nfs/rbac.yaml
 ```
 
-> 如果的K8S命名空间不是**default**，请在部署RBAC之前执行以下脚本:
+> If the Kubernetes namespace is not **default**, run the following script before deploying RBAC:
 
 ```shell
 # Set the subject of the RBAC objects to the current namespace where the provisioner is being deployed
@@ -246,25 +246,25 @@ $ sed -i'' "s/namespace:.*/namespace: $NAMESPACE/g" ./deploy/nfs/rbac.yaml
 
 ```
 
-* 创建 `ServiceAccount` 和部署 `NFS-Client Provisioner`
+* Create the `ServiceAccount` and deploy `NFS-Client Provisioner`.
 
 ```shell
 kubectl create -f deploy/nfs/deployment.yaml
 ```
 
-* 创建 NFS StorageClass
+* Create the NFS StorageClass.
 
 ```shell
 kubectl create -f deploy/nfs/class.yaml
 ```
 
-* 验证NFS部署成功
+* Verify that NFS is deployed successfully.
 
 ```shell
 kubectl get pod -l app=nfs-client-provisioner
 ```
 
-### 3.2. 部署数据库
+### 3.2. Deploy Database
 
 ```shell
 
@@ -273,7 +273,7 @@ cd nacos-k8s
 kubectl create -f deploy/mysql/mysql-nfs.yaml
 ```
 
-* 验证数据库是否正常工作
+* Verify that the database works properly.
 
 ```shell
 
@@ -282,30 +282,30 @@ NAME                         READY   STATUS    RESTARTS   AGE
 mysql-gf2vd                        1/1     Running   0          111m
 
 ```
-### 3.3. 执行数据库初始化语句
+### 3.3. Execute Database Initialization Statements
 
-数据库初始化语句位置 [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql)
+Database initialization statements are located in [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql).
 
-### 3.4. 部署Nacos
+### 3.4. Deploy Nacos
 
-* 修改  **deploy/nacos/nacos-pvc-nfs.yaml**
+* Modify **deploy/nacos/nacos-pvc-nfs.yaml**.
 
 ```yaml
 data:
-  mysql.host: "数据库地址"
-  mysql.db.name: "数据库名称"
-  mysql.port: "端口"
-  mysql.user: "用户名"
-  mysql.password: "密码"
+  mysql.host: "database address"
+  mysql.db.name: "database name"
+  mysql.port: "port"
+  mysql.user: "username"
+  mysql.password: "password"
 ```
 
-* 创建 Nacos
+* Create Nacos.
 
 ``` shell
 kubectl create -f nacos-k8s/deploy/nacos/nacos-pvc-nfs.yaml
 ```
 
-* 验证Nacos节点启动成功
+* Verify that Nacos nodes start successfully.
 
 ```shell
 kubectl get pod -l app=nacos
@@ -317,19 +317,19 @@ nacos-1   1/1     Running   0          19h
 nacos-2   1/1     Running   0          19h
 ```
 
-### 3.5. 扩容测试
+### 3.5. Scale-Out Test
 
-* 在扩容前，使用 [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec)获取在pod中的Nacos集群配置文件信息
+* Before scaling out, use [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec) to obtain the Nacos cluster configuration file information in the pods.
 
 ```powershell
 for i in 0 1; do echo nacos-$i; kubectl exec nacos-$i cat conf/cluster.conf; done
 ```
 
-StatefulSet控制器根据其序数索引为每个Pod提供唯一的主机名。 主机名采用<statefulset name />  -  <ordinal index />的形式。 因为nacos StatefulSet的副本字段设置为2，所以当前集群文件中只有两个Nacos节点地址
+The StatefulSet controller provides a unique hostname for each pod based on its ordinal index. The hostname format is `<statefulset name>-<ordinal index>`. Because the `replicas` field of the Nacos StatefulSet is set to `2`, the current cluster file contains only two Nacos node addresses.
 
 ![k8s](https://cdn.nlark.com/yuque/0/2019/gif/338441/1562846123635-e361d2b5-4bbe-4347-acad-8f11f75e6d38.gif)
 
-* 使用kubectl scale 对Nacos动态扩容
+* Use `kubectl scale` to dynamically scale out Nacos.
 
 ```bash
 kubectl scale sts nacos --replicas=3
@@ -337,7 +337,7 @@ kubectl scale sts nacos --replicas=3
 
 ![scale](https://cdn.nlark.com/yuque/0/2019/gif/338441/1562846139093-7a79b709-9afa-448a-b7d6-f57571d3a902.gif)
 
-* 在扩容后，使用 [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec)获取在pod中的Nacos集群配置文件信息
+* After scaling out, use [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec) to obtain the Nacos cluster configuration file information in the pods.
 
 ```bash
 for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i cat conf/cluster.conf; done
@@ -345,49 +345,49 @@ for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i cat conf/cluster.conf; d
 
 ![get_cluster_after](https://cdn.nlark.com/yuque/0/2019/gif/338441/1562846177553-c1c7f379-1b41-4026-9f0b-23e15dde02a8.gif)
 
-* 使用 [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec)执行Nacos API 在每台节点上获取当前**Leader**是否一致
+* Use [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec) to call the Nacos API on each node and check whether the current **Leader** is consistent.
 
 ```bash
 for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i curl -X GET "http://localhost:8848/nacos/v1/ns/raft/state"; done
 ```
 
-到这里你可以发现新节点已经正常加入Nacos集群当中。
+At this point, the new node has joined the Nacos cluster successfully.
 
-### 3.6. 配置属性
+### 3.6. Configuration Properties
 
 * `nacos-pvc-nfs.yaml` or `nacos-quick-start.yaml`
 
-| 名称                     | 必要 | 描述                                    |
-| ----------------------- | -------- | --------------------------------------- |
-| `mysql.host`            | Y       | 自建数据库地址,使用外部数据库时必须指定                      |
-| `mysql.db.name`         | Y       | 数据库名称                      |
-| `mysql.port`            | N       | 数据库端口                        |
-| `mysql.user`            | Y       | 数据库用户名(请不要含有符号```,```)     |
-| `mysql.password`        | Y       | 数据库密码(请不要含有符号```,```)                     |
-| `SPRING_DATASOURCE_PLATFORM`        | Y       |   数据库类型,默认为embedded嵌入式数据库,参数只支持mysql或embedded	                   |
-| `NACOS_REPLICAS`        | N      | 确定执行Nacos启动节点数量,如果不适用动态扩容插件,就必须配置这个属性，否则使用扩容插件后不会生效 |
-| `NACOS_SERVER_PORT`     | N       | Nacos 端口 为peer_finder插件提供端口|
-| `NACOS_APPLICATION_PORT`     | N       | Nacos 端口|
-| `PREFER_HOST_MODE`      | Y       | 启动Nacos集群按域名解析 |
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `mysql.host` | Y | Self-managed database address. Required when an external database is used. |
+| `mysql.db.name` | Y | Database name. |
+| `mysql.port` | N | Database port. |
+| `mysql.user` | Y | Database username. Do not include the `,` character. |
+| `mysql.password` | Y | Database password. Do not include the `,` character. |
+| `SPRING_DATASOURCE_PLATFORM` | Y | Database type. The default value is `embedded`, which means the embedded database. Only `mysql` and `embedded` are supported. |
+| `NACOS_REPLICAS` | N | Determines the number of Nacos startup nodes. If you do not use the dynamic scale-out plugin, configure this property. After the scale-out plugin is used, this property does not take effect. |
+| `NACOS_SERVER_PORT` | N | Nacos port provided to the `peer_finder` plugin. |
+| `NACOS_APPLICATION_PORT` | N | Nacos port. |
+| `PREFER_HOST_MODE` | Y | Starts the Nacos cluster with domain-name resolution. |
 
 * **nfs** `deployment.yaml`
 
-| 名称          | 必要 | 描述                     |
-| ------------ | --------| ------------------------ |
-| `NFS_SERVER` | Y       | NFS 服务端地址         |
-| `NFS_PATH`   | Y       | NFS 共享目录 |
-| `server`     | Y       | NFS 服务端地址  |
-| `path`       | Y       | NFS 共享目录 |
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `NFS_SERVER` | Y | NFS server address. |
+| `NFS_PATH` | Y | NFS shared directory. |
+| `server` | Y | NFS server address. |
+| `path` | Y | NFS shared directory. |
 
 * mysql
 
-| 名称                     | 必要 | 描述                                                      |
-| -------------------------- | -------- | ----------------------------------------------------------- |
-| `MYSQL_ROOT_PASSWORD`        | N       | ROOT 密码                                                    |
-| `MYSQL_DATABASE`             | Y       | 数据库名称                                   |
-| `MYSQL_USER`                 | Y       | 数据库用户名                                  |
-| `MYSQL_PASSWORD`             | Y       | 数据库密码                              |
-| `MYSQL_REPLICATION_USER`     | Y       | 数据库复制用户            |
-| `MYSQL_REPLICATION_PASSWORD` | Y       | 数据库复制用户密码      |
-| `Nfs:server`                 | N      | NFS 服务端地址，如果使用本地部署不需要配置 |
-| `Nfs:path`                   | N     | NFS 共享目录，如果使用本地部署不需要配置 |
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `MYSQL_ROOT_PASSWORD` | N | Root password. |
+| `MYSQL_DATABASE` | Y | Database name. |
+| `MYSQL_USER` | Y | Database username. |
+| `MYSQL_PASSWORD` | Y | Database password. |
+| `MYSQL_REPLICATION_USER` | Y | Database replication user. |
+| `MYSQL_REPLICATION_PASSWORD` | Y | Database replication user password. |
+| `Nfs:server` | N | NFS server address. It is not required for local deployment. |
+| `Nfs:path` | N | NFS shared directory. It is not required for local deployment. |

--- a/src/content/docs/latest/en/manual/admin/deployment/deployment-independent.md
+++ b/src/content/docs/latest/en/manual/admin/deployment/deployment-independent.md
@@ -1,55 +1,55 @@
 ---
 title: Independent Console
-keywords: [ Nacos,independent deployment,console ]
-description: The Manual fo Nacos independent deployment for Nacos Console and Nacos Engine.
+keywords: [ Nacos, independent deployment, console ]
+description: The manual for independent deployment of Nacos Console and Nacos Server.
 sidebar:
   order: 4
 ---
 
-# 控制台独立部署
+# Independent Console Deployment
 
-> Nacos定义为一个IDC内部应用组件，并非面向公网环境的产品，建议在内部隔离网络环境中部署，强烈不建议部署在公共网络环境。
+> Nacos is positioned as an internal IDC application component, not as a product for public network environments. Deploy it in an isolated internal network. Public network deployment is strongly discouraged.
 >
-> 以下文档中提及的VIP，网卡等所有网络相关概念均处于内部网络环境。
+> Network-related concepts mentioned in this documentation, such as VIPs and network interface cards, refer to internal network environments.
 
-## 1. Nacos 控制台独立部署概览
+## 1. Independent Nacos Console Deployment Overview
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
-Nacos 3.0 版本开始，Nacos支持将控制台进行独立部署，通过进一步拆分高风险请求和高资源消耗的请求，从而提高Nacos的安全性和稳定性。
+Starting from Nacos 3.0, Nacos supports independent console deployment. By further separating high-risk requests from resource-intensive requests, independent console deployment improves Nacos security and stability.
 
-要将Nacos控制台独立部署，首先需要先部署一个`Nacos 无控制台的集群服务`或`Nacos 无控制台的单机服务`，然后再单独启动`Nacos控制台`，并确认两者的部分配置一致。
+To deploy the Nacos console independently, first deploy a `Nacos cluster service without console` or a `Nacos standalone service without console`, then start `Nacos Console` separately and make sure some configurations are consistent between the two.
 
-## 2. 部署Nacos 无控制台服务
+## 2. Deploy Nacos Service Without Console
 
-首先参考[Nacos集群模式部署](./deployment-cluster.md#1-发行版部署)或[Nacos单机模式部署](./deployment-standalone.mdx#1-发行版部署)，将`启动Nacos服务`步骤中的 `sh startup.sh`或`sh startup.sh -m standalone` 更换为`sh startup.sh -d server`或`sh startup.sh -m standalone -d server`.
+First, refer to [Nacos Cluster Deployment](./deployment-cluster.md#1-release-package-deployment) or [Nacos Standalone Deployment](./deployment-standalone.mdx#1-release-package-deployment). In the `Start Nacos Service` step, replace `sh startup.sh` or `sh startup.sh -m standalone` with `sh startup.sh -d server` or `sh startup.sh -m standalone -d server`.
 
-待Nacos服务启动成功后，复制`conf/cluster.conf`文件或记录Nacos服务的`ip:port`，以便后续使用。
+After the Nacos service starts successfully, copy the `conf/cluster.conf` file or record the `ip:port` of the Nacos service for later use.
 
-## 3. 部署Nacos 控制台
+## 3. Deploy Nacos Console
 
-### 3.1. 环境准备
+### 3.1. Environment Preparation
 
-Nacos 控制台 依赖 [Java](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) 环境来运行，请确保是在以下版本环境中安装使用:
+Nacos Console depends on [Java](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) to run. Make sure the following environment is available:
 
-1. 64 bit OS，支持 Linux/Unix/Mac/Windows，推荐选用 Linux/Unix/Mac。
-2. 64 bit JDK 17+；[下载](https://www.oracle.com/java/technologies/downloads/#java17) & [配置](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/)。
+1. 64-bit OS, including Linux, Unix, macOS, or Windows. Linux, Unix, or macOS is recommended.
+2. 64-bit JDK 17 or later. [Download](https://www.oracle.com/java/technologies/downloads/#java17) and [configure](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) it.
 
-### 3.2. 解压缩Nacos 控制台发行包
+### 3.2. Decompress the Nacos Console Release Package
 
-Nacos独立控制台的发行包与Nacos服务的发行包相同， 只需要从上一步骤[部署Nacos 无控制台服务](#2-部署nacos-无控制台服务)中复制发布包到控制台部署环境中即可，随后执行以下命令进行解压：
+The release package for the independent Nacos console is the same as the Nacos service release package. Copy the release package from the previous [Deploy Nacos Service Without Console](#2-deploy-nacos-service-without-console) step to the console deployment environment, and then run the following commands to decompress it:
 
 ```bash
   unzip nacos-server-$version.zip 
-  # 或者 tar -xvf nacos-server-$version.tar.gz
+  # or tar -xvf nacos-server-$version.tar.gz
   cd nacos/bin
 ```
 
-### 3.3. 配置Nacos 无控制台服务地址配置文件
+### 3.3. Configure the Nacos Service Address File
 
-由于Nacos 独立控制台不进行数据的存储，因此需要访问实际的Nacos服务进度数据的获取，因此需要配置Nacos 无控制台服务地址在对应的配置文件中。
+Because the independent Nacos console does not store data, it must access the actual Nacos service to obtain data. Therefore, configure the Nacos service address in the corresponding configuration file.
 
-在nacos的解压目录nacos/的conf目录下，有配置文件`cluster.conf`，请每行配置成`ip:port`, 其内容为[部署Nacos 无控制台服务](#2-部署nacos-无控制台服务)中记录的`conf/cluster.conf`文件或记录Nacos服务的`ip:port`，示例如下：
+In the `conf` directory under the Nacos decompression directory `nacos/`, configure the `cluster.conf` file with one `ip:port` entry per line. Its content should be the `conf/cluster.conf` file or the recorded Nacos service `ip:port` from [Deploy Nacos Service Without Console](#2-deploy-nacos-service-without-console). Example:
 
 ```plain
 # ip:port
@@ -58,9 +58,9 @@ Nacos独立控制台的发行包与Nacos服务的发行包相同， 只需要从
 200.8.9.18:8848
 ```
 
-### 3.4. 修改配置文件（可选）
+### 3.4. Modify Configuration Files (Optional)
 
-修改nacos的解压目录nacos的`conf`目录下的配置文件`application.properties`，查找以 `nacos.console` 开头的配置项，修改为对应配置，示例如下：
+Modify `application.properties` in the `conf` directory under the Nacos decompression directory. Find the configuration items that start with `nacos.console` and modify them as needed. Example:
 
 ```properties
 ### Nacos Console Main port
@@ -71,7 +71,7 @@ nacos.console.contextPath=
 nacos.console.remote.server.context-path=/nacos
 ```
 
-同时需要配置鉴权相关配置，避免启动失败或无法访问Nacos 服务， 示例如下：
+You must also configure authentication-related settings to avoid startup failures or access failures to the Nacos service. Example:
 
 ```properties
 nacos.core.auth.server.identity.key=${your_custom_server_identity_key}
@@ -80,12 +80,12 @@ nacos.core.auth.plugin.nacos.token.secret.key=${your_custom_token_secret_key}
 ```
 
 :::note
-`nacos.core.auth.server.identity.key`和`nacos.core.auth.server.identity.value`需要设置的与Nacos 无控制台服务进行鉴权时设置的值一致，否则将无法访问Nacos 无控制台服务。
+`nacos.core.auth.server.identity.key` and `nacos.core.auth.server.identity.value` must be the same as the values configured for authentication with the Nacos service without console. Otherwise, the console cannot access that Nacos service.
 :::
 
-### 3.5. 启动Nacos 控制台
+### 3.5. Start Nacos Console
 
-通过如下命令，启动Nacos 控制台：
+Run the following commands to start Nacos Console:
 
 ```bash
 # Linux/Unix/Mac 
@@ -99,7 +99,7 @@ bash startup.sh -d console
 startup.cmd -d console
 ```
 
-随后启动程序会提示您输入`3个`鉴权相关配置
+The startup program then prompts you to enter the following `3` authentication-related configurations:
 
 ```
 `nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
@@ -114,13 +114,13 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 ```
 
 :::note
-若您已经在[修改配置文件](#34-修改配置文件可选)步骤中设置过这3个配置，则不会提示您输入。
+If you have configured these `3` settings in [Modify Configuration Files](#34-modify-configuration-files-optional), you will not be prompted to enter them.
 
-同时`nacos.core.auth.server.identity.key`和`nacos.core.auth.server.identity.value`需要设置的与Nacos 无控制台服务进行鉴权时设置的值一致，否则将无法访问Nacos 无控制台服务。
+`nacos.core.auth.server.identity.key` and `nacos.core.auth.server.identity.value` must be the same as the values configured for authentication with the Nacos service without console. Otherwise, the console cannot access that Nacos service.
 :::
 
-### 3.6. 进入Nacos 控制台
+### 3.6. Access Nacos Console
 
-启动完成后，您可以在浏览器中访问`http://{ip}:{port}`，其中`{ip}`为Nacos 控制台的ip地址，`{port}`为Nacos 控制台的端口，默认为`8080`。
+After startup is complete, access `http://{ip}:{port}` in your browser. `{ip}` is the IP address of Nacos Console, and `{port}` is the Nacos Console port, which defaults to `8080`.
 
-Nacos控制台的使用，请参考文档[控制台手册](../console.md)
+For Nacos console usage, see [Console Guide](../console.md).

--- a/src/content/docs/latest/en/manual/admin/deployment/deployment-overview.md
+++ b/src/content/docs/latest/en/manual/admin/deployment/deployment-overview.md
@@ -1,110 +1,109 @@
 ---
 title: Deployment Overview
 keywords: [ Nacos, Deployment mode ]
-description: Nacos Support three types of deployments.
+description: Nacos supports three deployment modes.
 sidebar:
   order: 1
 ---
 
-# Nacos部署手册
+# Nacos Deployment Guide
 
-> Nacos定义为一个IDC内部应用组件，并非面向公网环境的产品，建议在内部隔离网络环境中部署，强烈不建议部署在公共网络环境。
+> Nacos is positioned as an internal IDC application component, not as a product for public network environments. Deploy it in an isolated internal network. Public network deployment is strongly discouraged.
 >
-> 以下文档中提及的VIP，网卡等所有网络相关概念均处于内部网络环境。
+> Network-related concepts mentioned in this documentation, such as VIPs and network interface cards, refer to internal network environments.
 
-## 1. Nacos部署架构
+## 1. Nacos Deployment Architecture
 
-Nacos自3.0版本在2.X版本的基础上，对Nacos控制台和Nacos本身进行了拆分和优化。
+Since Nacos 3.0, Nacos has split and optimized the Nacos console and the Nacos server based on the 2.x architecture.
 
-在网络上，Nacos自3.0开始新增Nacos控制台的网络访问端口，不再与Nacos的主端口（server.port，默认8848）进行耦合，以提升Nacos的安全性。
+At the network layer, Nacos 3.0 adds a separate network access port for the Nacos console. The console is no longer coupled to the main Nacos port (`server.port`, default `8848`), which improves Nacos security.
 
-| 端口   | 与主端口的偏移量 | 描述                                                 |
-|------|----------|----------------------------------------------------|
-| 8848 | 0        | Nacos HTTP API 端口，用于Nacos AdminAPI及HTTP OpenAPI的访问 |
-| 9848 | 1000     | 客户端gRPC请求服务端端口，用于客户端向服务端发起连接和请求                    |
-| 9849 | 1001     | 服务端gRPC请求服务端端口，用于服务间同步等                            |
-| 7848 | -1000    | Jraft请求服务端端口，用于处理服务端间的Raft相关请求                     |
-| 8080 | 独立配置     | Nacos控制台端口，访问Nacos控制台及Nacos控制台的API                 |
+| Port | Offset from the main port | Description |
+|------|---------------------------|-------------|
+| 8848 | 0 | Nacos HTTP API port, used to access Nacos Admin APIs and HTTP Open APIs |
+| 9848 | 1000 | Client gRPC port on the server, used by clients to connect to and request the server |
+| 9849 | 1001 | Server gRPC port on the server, used for inter-server synchronization |
+| 7848 | -1000 | JRaft port on the server, used to process Raft requests between servers |
+| 8080 | Independently configured | Nacos console port, used to access the Nacos console and Nacos console APIs |
 
-> **使用VIP/nginx请求时，对于Nacos的gRPC端口（默认9848）需要配置成TCP转发，不能配置http/http2转发，否则连接会被nginx断开。**
+> **When using VIP or nginx requests, configure the Nacos gRPC port (default `9848`) for TCP forwarding. Do not configure HTTP or HTTP/2 forwarding, otherwise nginx will disconnect the connection.**
 >
-> **对外暴露端口时，建议仅暴露控制台端口（默认8080）和gRPC端口（默认9848）；同时按需暴露主端口（默认8848），其他端口为服务端之间的通信端口，请勿暴露其他端口，同时建议所有端口均不暴露在公网下。**
+> **When exposing ports externally, expose only the console port (default `8080`) and the gRPC port (default `9848`). Expose the main port (default `8848`) only when needed. Other ports are used for inter-server communication. Do not expose them, and do not expose any port to the public network.**
 
 ![nacos_port_exposure.png](/img/doc/manual/admin/deployment/deploy-port-export-3.0.svg)
 
-客户端的大多数请求会通过gRPC端口(默认9848)请求到服务端上，但会有部分插件请求（如Nacos 鉴权插件的login）会通过Nacos主端口（默认8848）进行请求。同时Nacos3.0的客户端为了方便用户升级及兼容使用习惯，Nacos3.0客户端仍然保留着和Nacos2.X客户端相同的计算逻辑，既：**配置主端口(默认8848)，通过相同的偏移量，计算对应gRPC端口(默认9848)**。
+Most client requests are sent to the server through the gRPC port (default `9848`), but some plugin requests, such as login requests from the Nacos authentication plugin, are sent through the Nacos main port (default `8848`). To make upgrades easier and keep compatibility with existing usage habits, the Nacos 3.0 client keeps the same port calculation logic as the Nacos 2.x client: **configure the main port (default `8848`) and calculate the corresponding gRPC port (default `9848`) by using the same offset**.
 
-因此如果客户端和服务端之前存在端口转发，或防火墙时，需要对端口转发配置和防火墙配置做相应的调整。
+Therefore, if port forwarding or a firewall exists between the client and server, adjust the port forwarding and firewall configurations accordingly.
 
-## 2. Nacos支持三种部署模式
+## 2. Nacos Deployment Modes
 
-* 单机模式 - 又称单例模式，主要用于测试和单机试用。
-* 集群模式 - 主要用于生产环境，确保高可用。
-* 多集群模式（TODO） - 用于多数据中心场景。
+Nacos supports three deployment modes:
 
-![Nacos部署模式图](/img/doc/overview/deploy-structure.svg)
+* Standalone mode, also called single-instance mode. It is mainly used for testing and single-machine trials.
+* Cluster mode. It is mainly used in production environments to ensure high availability.
+* Multi-cluster mode (TODO). It is used for multi-data-center scenarios.
 
-### 2.1. 单机模式
+![Nacos deployment mode diagram](/img/doc/overview/deploy-structure.svg)
 
-单机模式又称`单例模式`,
-拥有所有Nacos的功能及特性，具有极易部署、快速启动等优点。但无法与其他节点组成集群，无法在节点或网络故障时提供高可用能力。单机模式同样可以使用内置Derby数据库（默认）和外置数据库进行存储。
+### 2.1. Standalone Mode
 
-单机模式主要适合于工程师于本地搭建或于测试环境中搭建Nacos环境，主要用于开发调试及测试使用；也能够兼顾部分对稳定性和可用性要求不高的业务场景。
+Standalone mode, also called `single-instance mode`, provides all Nacos features and capabilities. It is easy to deploy and starts quickly. However, it cannot form a cluster with other nodes and cannot provide high availability during node or network failures. Standalone mode can use the built-in Derby database (default) or an external database for storage.
 
-单机模式的部署参考文档: [单机模式部署](./deployment-standalone.mdx)
+Standalone mode is mainly suitable for engineers who build a Nacos environment locally or in a test environment for development, debugging, and testing. It can also be used for some business scenarios with low stability and availability requirements.
 
-### 2.2. 集群模式
+For deployment details, see [Standalone Deployment](./deployment-standalone.mdx).
 
-集群模式通过自研一致性协议Distro以及Raft协议，将多个Nacos节点构建成了高可用的Nacos集群。数据将在集群中各个节点进行同步，保证数据的一致性。集群模式具有高可用、高扩展、高并发等优点，确保在故障发生时不影响业务的运行。集群模式
-**默认**采用外置数据库进行存储，但也可以通过内置数据库进行存储。
+### 2.2. Cluster Mode
 
-该模式主要适合于生产环境，也是社区最为推荐的部署模式。
+Cluster mode uses the self-developed Distro consistency protocol and the Raft protocol to build a highly available Nacos cluster from multiple Nacos nodes. Data is synchronized across nodes in the cluster to ensure consistency. Cluster mode provides high availability, scalability, and concurrency, and keeps services running when failures occur. Cluster mode uses an external database by **default**, but can also use the built-in database for storage.
 
-集群模式的部署参考文档: [集群模式部署](./deployment-cluster.md)
+This mode is mainly suitable for production environments and is the deployment mode most recommended by the community.
 
-### 2.3. 多集群模式（TODO）
+For deployment details, see [Cluster Deployment](./deployment-cluster.md).
 
-Nacos支持NameServer路由请求模式，通过它您可以设计一个有用的映射规则来控制请求转发到相应的集群，在映射规则中您可以按命名空间或租户等分片请求...
+### 2.3. Multi-Cluster Mode (TODO)
 
-## 3. Nacos控制台独立部署
+Nacos supports NameServer-based request routing. With this mode, you can design mapping rules to forward requests to the corresponding cluster, such as routing requests by namespace or tenant.
+
+## 3. Independent Nacos Console Deployment
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
-Nacos 3.0 版本开始，Nacos支持将控制台进行独立部署，通过进一步拆分高风险请求和高资源消耗的请求，从而提高Nacos的安全性和稳定性。
+Starting from Nacos 3.0, Nacos supports independent console deployment. By further separating high-risk requests from resource-intensive requests, independent console deployment improves Nacos security and stability.
 
-独立部署`Nacos Server`时，仅需要在启动命令中添加`-d server`参数，如：`sh startup.sh -d server`.
+To deploy `Nacos Server` independently, add the `-d server` parameter to the startup command, for example: `sh startup.sh -d server`.
 
-独立部署`Nacos Console`时，则需要在启动命令中添加`-d console`参数，如：`sh startup.sh -d console`.
+To deploy `Nacos Console` independently, add the `-d console` parameter to the startup command, for example: `sh startup.sh -d console`.
 
-Nacos控制台独立部署参考文档: [控制台独立部署](./deployment-independent.md)
+For independent console deployment details, see [Independent Console Deployment](./deployment-independent.md).
 
 Before going to production, continue with [Deployment Best Practices](./deployment-best-practices.md) to check internal network boundaries, independent console deployment, external database storage, authentication, visibility, traffic control, configuration encryption, and rollback plans.
 
-## 4. 多网卡IP选择
+## 4. Multi-NIC IP Selection
 
-当本地环境比较复杂的时候，Nacos服务在启动的时候需要选择运行时使用的IP或者网卡。Nacos从多网卡获取IP参考Spring
-Cloud设计，通过nacos.inetutils参数，可以指定Nacos使用的网卡和IP地址。目前支持的配置参数有:
+When the local environment is complex, Nacos needs to select the IP address or network interface card to use at startup. Nacos obtains IP addresses from multiple NICs by referring to the Spring Cloud design. You can use `nacos.inetutils` parameters to specify the NIC and IP address used by Nacos. The following configuration parameters are supported:
 
-- ip-address参数可以直接设置nacos的ip
+- `ip-address` directly sets the Nacos IP address.
 
 ```
 nacos.inetutils.ip-address=10.11.105.155
 ```
 
-- use-only-site-local-interfaces参数可以让nacos使用局域网ip，这个在nacos部署的机器有多网卡时很有用，可以让nacos选择局域网网卡
+- `use-only-site-local-interfaces` allows Nacos to use a LAN IP address. This is useful when the machine that deploys Nacos has multiple NICs and you want Nacos to select a LAN NIC.
 
 ```
 nacos.inetutils.use-only-site-local-interfaces=true
 ```
 
-- ignored-interfaces支持网卡数组，可以让nacos忽略多个网卡
+- `ignored-interfaces` supports a NIC array and allows Nacos to ignore multiple NICs.
 
 ```
 nacos.inetutils.ignored-interfaces[0]=eth0
 nacos.inetutils.ignored-interfaces[1]=eth1
 ```
 
-- preferred-networks参数可以让nacos优先选择匹配的ip，支持正则匹配和前缀匹配
+- `preferred-networks` allows Nacos to prefer matching IP addresses. Regular expression matching and prefix matching are supported.
 
 ```
 nacos.inetutils.preferred-networks[0]=30.5.124.

--- a/src/content/docs/latest/en/manual/admin/deployment/deployment-standalone.mdx
+++ b/src/content/docs/latest/en/manual/admin/deployment/deployment-standalone.mdx
@@ -1,31 +1,31 @@
 ---
 title: Standalone Deployment
-keywords: [Nacos,Deployment,Standalone]
-description: The Manual fo Nacos standalone deployment.
+keywords: [Nacos, Deployment, Standalone]
+description: The manual for Nacos standalone deployment.
 sidebar:
     order: 2
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-# Nacos单机模式
+# Nacos Standalone Mode
 
-## 1. 发行版部署
+## 1. Release Package Deployment
 
-### 1.1. 部署步骤
+### 1.1. Deployment Steps
 
 <Tabs>
-  <TabItem label="使用Derby数据库">
-    在[快速开始](../../../quickstart/quick-start.mdx)中，我们使用了内置的数据库Derby，快速部署了Nacos的单机模式，可参考该文档进行使用Derby数据库的Nacos单机模式部署。
+  <TabItem label="Use Derby Database">
+    In [Quick Start](../../../quickstart/quick-start.mdx), the built-in Derby database is used to quickly deploy Nacos in standalone mode. You can refer to that document to deploy Nacos standalone mode with Derby.
   </TabItem>
-  <TabItem label="使用MySQL数据库">
-    参考[快速开始](../../../quickstart/quick-start.mdx)中，进行Nacos的环境准备、发行版的下载等。
+  <TabItem label="Use MySQL Database">
+    Refer to [Quick Start](../../../quickstart/quick-start.mdx) to prepare the Nacos environment and download the release package.
 
-    同时在使用MySQL数据源部署Nacos单机模式时，需要自行准备MySQL数据库：
+    When deploying Nacos standalone mode with a MySQL data source, prepare the MySQL database yourself:
 
-    - 1.安装数据库，版本要求：5.6.5+
-    - 2.初始化mysql数据库，数据库初始化文件：[mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql)
+    - 1. Install the database. The required version is 5.6.5 or later.
+    - 2. Initialize the MySQL database. Database initialization file: [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql).
 
-    然后修改`${nacos.home}/conf/application.properties`文件，增加支持MySQL数据源配置，添加MySQL数据源的url、用户名和密码。
+    Then modify `${nacos.home}/conf/application.properties`, add the MySQL data source configuration, and configure the MySQL data source URL, username, and password.
 
     ```
     spring.sql.init.platform=mysql
@@ -36,31 +36,31 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     db.password=${mysql_password}
     ```
 
-    然后按照[快速开始-启动服务器](../../../quickstart/quick-start/#4修改鉴权配置)中的操作，修改Nacos的鉴权配置。
-    最后使用[快速开始-启动服务器](../../../quickstart/quick-start/#5启动服务器)中的操作，启动Nacos即可。
+    Then follow [Quick Start - Start Server](../../../quickstart/quick-start/#4-modify-authentication-configuration) to modify the Nacos authentication configuration.
+    Finally, follow [Quick Start - Start Server](../../../quickstart/quick-start/#5-start-server) to start Nacos.
   </TabItem>
 </Tabs>
 
-### 1.2. 高级配置
+### 1.2. Advanced Configuration
 
-Nacos提供了丰富的可配置项，帮助您调整Nacos的性能、控制Nacos提供的功能能力，例如鉴权、监控、数据库、连接、日志等；详情请参考[系统参数](../system-configurations.md)。
+Nacos provides rich configuration items that help you tune Nacos performance and control Nacos features, such as authentication, monitoring, databases, connections, and logs. For details, see [System Parameters](../system-configurations.md).
 
-## 2. Docker部署
+## 2. Docker Deployment
 
-### 2.1. 部署步骤
+### 2.1. Deployment Steps
 
 <Tabs>
-  <TabItem label="使用Derby数据库">
-    在[快速开始 Docker](../../../quickstart/quick-start-docker.mdx)中，我们通过`Docker`使用了内置的数据库Derby，快速部署了Nacos的单机模式，可参考该文档进行使用Derby数据库的Nacos单机模式部署。
+  <TabItem label="Use Derby Database">
+    In [Quick Start Docker](../../../quickstart/quick-start-docker.mdx), Docker is used with the built-in Derby database to quickly deploy Nacos in standalone mode. You can refer to that document to deploy Nacos standalone mode with Derby.
   </TabItem>
-  <TabItem label="使用MySQL数据库">
-    执行 docker-compose 命令启动Nacos
+  <TabItem label="Use MySQL Database">
+    Run the docker-compose command to start Nacos.
 
     ```powershell
     docker-compose -f example/standalone-mysql-8.yaml up
     ```
 
-    **如果希望使用MySQL5.7**
+    **To use MySQL 5.7**
 
     ```powershell
     docker-compose -f example/standalone-mysql-5.7.yaml up
@@ -68,22 +68,22 @@ Nacos提供了丰富的可配置项，帮助您调整Nacos的性能、控制Naco
   </TabItem>
 </Tabs>
 
-### 2.2. 高级配置
+### 2.2. Advanced Configuration
 
-如果你有很多自定义配置的需求，可以通过指定[系统参数-镜像环境变量](../system-configurations/#2-镜像环境变量)的方式进行配置，例如需要开启鉴权时：
+If you need many custom configurations, you can configure them by specifying [System Parameters - Image Environment Variables](../system-configurations/#2-image-environment-variables). For example, to enable authentication:
 
 ```powershell
 docker run --name nacos-standalone-auth -e MODE=standalone -e NACOS_AUTH_ENABLE=true -e NACOS_AUTH_TOKEN=${customToken} -e NACOS_AUTH_IDENTITY_KEY=${customKey} -e NACOS_AUTH_IDENTITY_VALUE=${customValue} -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-同时，可以通过对application.properties文件进行挂卷定义的方式，将更多复杂的自定义配置导入Nacos容器中，强烈建议在生产环境中使用方式，例如：
+You can also mount the `application.properties` file to import more complex custom configurations into the Nacos container. This method is strongly recommended for production environments. Example:
 
 ```powershell
 docker run --name nacos-standalone -e MODE=standalone -v /path/application.properties:/home/nacos/conf/application.properties -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-如果仍然无法满足自定义需求，可以基于nacos-docker项目中的`Dockerfile`自行构建镜像。
+If this still cannot meet your customization requirements, you can build an image based on the `Dockerfile` in the `nacos-docker` project.
 
-## 3. Kubernetes部署
+## 3. Kubernetes Deployment
 
-Kubernetes暂时不提供单例模式的部署，推荐使用集群模式部署。
+Kubernetes does not currently provide standalone-mode deployment. Cluster-mode deployment is recommended.

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-cluster.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-cluster.md
@@ -1,45 +1,45 @@
 ---
 title: Cluster Deployment
-keywords: [Nacos,Deployment,Cluster]
-description: The Manual fo Nacos cluster deployment.
+keywords: [Nacos, Deployment, Cluster]
+description: The manual for Nacos cluster deployment.
 sidebar:
     order: 3
 ---
 
-# Nacos集群模式
+# Nacos Cluster Mode
 
-本部署手册是帮忙您快速在你的电脑上，下载安装并使用Nacos，部署生产使用的集群模式。
+This deployment guide helps you quickly download, install, and use Nacos on your computer, and deploy cluster mode for production use.
 
-### 集群部署架构图
+### Cluster Deployment Architecture
 
-无论采用何种部署方式，推荐用户把Nacos集群中所有服务节点放到一个vip下面，然后挂到一个域名下面。
+Regardless of the deployment method, we recommend placing all service nodes in the Nacos cluster behind one VIP and then binding the VIP to a domain name.
 
-`<http://ip1:port/openAPI>`  直连ip模式，机器挂则需要修改ip才可以使用。
+`<http://ip1:port/openAPI>` Direct IP mode. If the machine fails, you must modify the IP address before the endpoint can be used again.
 
-`<http://SLB:port/openAPI>`  挂载SLB模式(内网SLB，不可暴露到公网，以免带来安全风险)，直连SLB即可，下面挂server真实ip，可读性不好。
+`<http://SLB:port/openAPI>` SLB mode. Use an internal SLB and do not expose it to the public network to avoid security risks. Clients connect directly to the SLB, and real server IPs are mounted behind it, which is less readable.
 
-`<http://nacos.com:port/openAPI>`  域名 + SLB模式(内网SLB，不可暴露到公网，以免带来安全风险)，可读性好，而且换ip方便，推荐模式
+`<http://nacos.com:port/openAPI>` Domain name plus SLB mode. Use an internal SLB and do not expose it to the public network to avoid security risks. This mode is readable and makes IP replacement easier. It is the recommended mode.
 
 ![deployDnsVipMode.jpg](/img/doc/manual/admin/deployment/deploy-dns-vip-mode.svg)
 
-在使用VIP时，需要开放Nacos服务的主端口(默认8848)以及gRPC端口(默认9848)、同时如果对Nacos的主端口有所修改的话，需要对vip中的端口映射作出配置，具体端口的映射方式参考[部署手册概览-Nacos部署架构](./deployment-overview/#1-Nacos部署架构)
+When using a VIP, open the main Nacos service port (default `8848`) and the gRPC port (default `9848`). If you change the main Nacos port, configure the corresponding port mapping in the VIP. For port mapping details, see [Deployment Overview - Nacos Deployment Architecture](./deployment-overview/#1-nacos-deployment-architecture).
 
-## 1. 发行版部署
+## 1. Release Package Deployment
 
-### 1.1. 使用MySQL数据库（推荐）
+### 1.1. Use MySQL Database (Recommended)
 
-#### 1.1.1. 环境准备
+#### 1.1.1. Environment Preparation
 
-参考[快速开始](../../../quickstart/quick-start.mdx)中，进行Nacos的环境准备、发行版的下载等。
+Refer to [Quick Start](../../../quickstart/quick-start.mdx) to prepare the Nacos environment and download the release package.
 
-同时在使用MySQL数据源部署Nacos单机模式时，需要自行准备MySQL数据库：
+When deploying Nacos cluster mode with a MySQL data source, prepare the MySQL database yourself:
 
-- 1.安装数据库，版本要求：5.6.5+
-- 2.初始化mysql数据库，数据库初始化文件：[mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql)
+- 1. Install the database. The required version is 5.6.5 or later.
+- 2. Initialize the MySQL database. Database initialization file: [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql).
 
-#### 1.1.2. 配置集群配置文件
+#### 1.1.2. Configure the Cluster Configuration File
 
-在nacos的解压目录nacos/的conf目录下，有配置文件cluster.conf，请每行配置成ip:port。（请配置3个或3个以上节点）
+In the `conf` directory under the Nacos decompression directory `nacos/`, configure the `cluster.conf` file with one `ip:port` entry per line. Configure three or more nodes.
 
 ```plain
 # ip:port
@@ -48,9 +48,9 @@ sidebar:
 200.8.9.18:8848
 ```
 
-#### 1.1.3. 修改配置文件
+#### 1.1.3. Modify Configuration Files
 
-然后修改`${nacos.home}/conf/application.properties`文件，增加支持MySQL数据源配置，添加MySQL数据源的url、用户名和密码。
+Then modify `${nacos.home}/conf/application.properties`, add the MySQL data source configuration, and configure the MySQL data source URL, username, and password.
 
 ```
 spring.sql.init.platform=mysql
@@ -61,32 +61,32 @@ db.user=${mysql_user}
 db.password=${mysql_password}
 ```
 
-##### 1.1.3.1. 开启默认鉴权插件
+##### 1.1.3.1. Enable the Default Authentication Plugin
 
-> 自3.0.0版本开始，Nacos控制台默认开启访问鉴权，所以鉴权相关配置必须进行配置。
+> Since Nacos 3.0.0, console access authentication is enabled by default, so authentication-related configurations must be configured.
 
-修改`conf`目录下的`application.properties`文件。
+Modify `application.properties` in the `conf` directory.
 
-设置其中
+Set the following items:
 
 ```properties
-## 开启客户端访问鉴权，默认为关闭，可选
+## Enable client access authentication. Disabled by default and optional.
 nacos.core.auth.enabled=true
-## 开启控制台访问鉴权，默认为开启
+## Enable console access authentication. Enabled by default.
 nacos.core.auth.console.enabled=true
 nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
+nacos.core.auth.plugin.nacos.token.secret.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.value=${custom_value_same_on_all_nodes}
 ```
 
-上述内容详情可查看[权限认证](../../../plugin/auth-plugin.md).
+For details, see [Authentication](../../../plugin/auth-plugin.md).
 
-> 注意，文档中的默认值`SecretKey012345678901234567890123456789012345678901234567890123456789`和`VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=`为公开默认值，可用于临时测试，实际使用时请**务必**更换为自定义的其他有效值。
+> Note: the default values `SecretKey012345678901234567890123456789012345678901234567890123456789` and `VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=` in the documentation are public default values and can be used only for temporary testing. In actual use, **replace them with other custom valid values**.
 
-#### 1.1.4. 启动Nacos集群
+#### 1.1.4. Start the Nacos Cluster
 
-在每个部署节点上，执行如下命名，逐台或同时启动Nacos节点。
+On each deployment node, run the following commands to start Nacos nodes one by one or at the same time.
 
 ```bash
 # Linux/Unix/Mac 
@@ -100,7 +100,7 @@ bash startup.sh
 startup.cmd
 ```
 
-随后启动程序会提示您输入`3个`鉴权相关配置
+The startup program then prompts you to enter the following `3` authentication-related configurations:
 
 ```
 `nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
@@ -115,20 +115,20 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 ```
 
 ::: note
-若您已经在[修改配置文件](#1131-开启默认鉴权插件)步骤中设置过这3个配置，则不会提示您输入。
+If you have configured these `3` settings in [Modify Configuration Files](#1131-enable-the-default-authentication-plugin), you will not be prompted to enter them.
 :::
 
-### 1.2. 使用Derby数据库
+### 1.2. Use Derby Database
 
-> 注意：Derby数据库为本地内置数据库，本身不支持集群模式，Nacos通过Raft协议将各个节点的Derby数据库组成逻辑集群，因此使用此模式部署集群模式的Nacos时，需要对Raft协议较为熟悉，能够进行问题排查、恢复等，建议使用MySQL数据库进行部署。
+> Note: Derby is a local built-in database and does not support cluster mode by itself. Nacos uses the Raft protocol to form a logical cluster from the Derby databases of each node. Therefore, when deploying Nacos cluster mode with this mode, you must be familiar with the Raft protocol and be able to troubleshoot and recover issues. We recommend deploying with a MySQL database.
 
-#### 1.2.1. 环境准备
+#### 1.2.1. Environment Preparation
 
-参考[快速开始](../../../quickstart/quick-start.mdx)中，进行Nacos的环境准备、发行版的下载等。
+Refer to [Quick Start](../../../quickstart/quick-start.mdx) to prepare the Nacos environment and download the release package.
 
-#### 1.2.2. 配置集群配置文件
+#### 1.2.2. Configure the Cluster Configuration File
 
-在nacos的解压目录nacos/的conf目录下，有配置文件cluster.conf，请每行配置成ip:port。（请配置3个或3个以上节点）
+In the `conf` directory under the Nacos decompression directory `nacos/`, configure the `cluster.conf` file with one `ip:port` entry per line. Configure three or more nodes.
 
 ```plain
 # ip:port
@@ -137,32 +137,32 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 200.8.9.18:8848
 ```
 
-#### 1.2.3. 开启默认鉴权插件
+#### 1.2.3. Enable the Default Authentication Plugin
 
-> 自3.0.0版本开始，Nacos控制台默认开启访问鉴权，所以鉴权相关配置必须进行配置。
+> Since Nacos 3.0.0, console access authentication is enabled by default, so authentication-related configurations must be configured.
 
-修改`conf`目录下的`application.properties`文件。
+Modify `application.properties` in the `conf` directory.
 
-设置其中
+Set the following items:
 
 ```properties
-## 开启客户端访问鉴权，默认为关闭，可选
+## Enable client access authentication. Disabled by default and optional.
 nacos.core.auth.enabled=true
-## 开启控制台访问鉴权，默认为开启
+## Enable console access authentication. Enabled by default.
 nacos.core.auth.console.enabled=true
 nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
-nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
+nacos.core.auth.plugin.nacos.token.secret.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.key=${custom_value_same_on_all_nodes}
+nacos.core.auth.server.identity.value=${custom_value_same_on_all_nodes}
 ```
 
-上述内容详情可查看[权限认证](../../../plugin/auth-plugin.md).
+For details, see [Authentication](../../../plugin/auth-plugin.md).
 
-> 注意，文档中的默认值`SecretKey012345678901234567890123456789012345678901234567890123456789`和`VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=`为公开默认值，可用于临时测试，实际使用时请**务必**更换为自定义的其他有效值。
+> Note: the default values `SecretKey012345678901234567890123456789012345678901234567890123456789` and `VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=` in the documentation are public default values and can be used only for temporary testing. In actual use, **replace them with other custom valid values**.
 
-#### 1.2.4. 启动Nacos集群
+#### 1.2.4. Start the Nacos Cluster
 
-在每个部署节点上，执行如下命名，逐台或同时启动Nacos节点。
+On each deployment node, run the following commands to start Nacos nodes one by one or at the same time.
 
 ```bash
 # Linux/Unix/Mac 
@@ -176,67 +176,67 @@ bash startup.sh -p embedded
 startup.cmd -p embedded
 ```
 
-### 1.3. 高级使用
+### 1.3. Advanced Usage
 
-#### 1.3.1. 自定义配置
+#### 1.3.1. Custom Configuration
 
-Nacos提供了丰富的可配置项，帮助您调整Nacos的性能、控制Nacos提供的功能能力，例如鉴权、监控、数据库、连接、日志等；详情请参考[系统参数](../system-configurations.md)。
+Nacos provides rich configuration items that help you tune Nacos performance and control Nacos features, such as authentication, monitoring, databases, connections, and logs. For details, see [System Parameters](../system-configurations.md).
 
-## 2. Docker部署
+## 2. Docker Deployment
 
-### 2.1. 使用MySQL数据库（推荐）
+### 2.1. Use MySQL Database (Recommended)
 
-参考[快速开始 Docker](../../../quickstart/quick-start-docker.mdx)中，进行`nacos-docker`项目的下载，然后执行如下命令，即可启动Nacos集群。
+Refer to [Quick Start Docker](../../../quickstart/quick-start-docker.mdx) to download the `nacos-docker` project, and then run the following command to start the Nacos cluster.
 
 ```powershell
 docker-compose -f example/cluster-hostname.yaml up 
 ```
 
-### 2.2. 使用Derby数据库
+### 2.2. Use Derby Database
 
-> 注意：Derby数据库为本地内置数据库，本身不支持集群模式，Nacos通过Raft协议将各个节点的Derby数据库组成逻辑集群，因此使用此模式部署集群模式的Nacos时，需要对Raft协议较为熟悉，能够进行问题排查、恢复等，建议使用MySQL数据库进行部署。
+> Note: Derby is a local built-in database and does not support cluster mode by itself. Nacos uses the Raft protocol to form a logical cluster from the Derby databases of each node. Therefore, when deploying Nacos cluster mode with this mode, you must be familiar with the Raft protocol and be able to troubleshoot and recover issues. We recommend deploying with a MySQL database.
 
-参考[快速开始 Docker](../../../quickstart/quick-start-docker.mdx)中，进行`nacos-docker`项目的下载，然后执行如下命令，即可启动Nacos集群。
+Refer to [Quick Start Docker](../../../quickstart/quick-start-docker.mdx) to download the `nacos-docker` project, and then run the following command to start the Nacos cluster.
 
 ```powershell
 docker-compose -f example/cluster-embedded.yaml up 
 ```
 
-### 2.3 高级配置
+### 2.3 Advanced Configuration
 
-如果你有很多自定义配置的需求，可以通过指定[系统参数-镜像环境变量](../system-configurations/#2-镜像环境变量)的方式进行配置，例如需要开启鉴权时：
+If you need many custom configurations, you can configure them by specifying [System Parameters - Image Environment Variables](../system-configurations/#2-image-environment-variables). For example, to enable authentication:
 
 ```powershell
 docker run --name nacos-cluster-auth -e MODE=cluster -e NACOS_AUTH_ENABLE=true -e NACOS_AUTH_TOKEN=${customToken} -e NACOS_AUTH_IDENTITY_KEY=${customKey} NACOS_AUTH_IDENTITY_VALUE=${customValue} -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-同时，可以通过对application.properties文件进行挂卷定义的方式，将更多复杂的自定义配置导入Nacos容器中，强烈建议在生产环境中使用方式，例如：
+You can also mount the `application.properties` file to import more complex custom configurations into the Nacos container. This method is strongly recommended for production environments. Example:
 
 ```powershell
 docker run --name nacos-cluster -e MODE=cluster -v /path/application.properties:/home/nacos/conf/application.properties -v /path/cluster.conf:/home/nacos/conf/cluster.conf -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-如果仍然无法满足自定义需求，可以基于nacos-docker项目中的`Dockerfile`自行构建镜像。
+If this still cannot meet your customization requirements, you can build an image based on the `Dockerfile` in the `nacos-docker` project.
 
-## 3. Kubernetes部署
+## 3. Kubernetes Deployment
 
-通过[快速开始 Kubernetes](../../../quickstart/quick-start-kubernetes.mdx)文档，已经能够部署使用MySQL数据库的Nacos的集群模式。
+[Quick Start Kubernetes](../../../quickstart/quick-start-kubernetes.mdx) can deploy Nacos cluster mode with a MySQL database.
 
-但快速开始所部署的Nacos集群没有使用持久化卷的,可能存在数据丢失风险；因此推荐使用PVC持久卷方式进行部署，本例中将使用的是NFS来使用PVC。
+However, the Nacos cluster deployed by the quick start does not use persistent volumes and may have data loss risks. Therefore, we recommend deploying with PVC persistent volumes. This example uses NFS with PVC.
 
 #### Tips
 
-* 推荐使用[Nacos Operator](https://github.com/nacos-group/nacos-k8s/blob/master/operator/README-CN.md)在Kubernetes部署Nacos Server.
+* We recommend using [Nacos Operator](https://github.com/nacos-group/nacos-k8s/blob/master/operator/README-CN.md) to deploy Nacos Server on Kubernetes.
 
-### 3.1. 部署 NFS
+### 3.1. Deploy NFS
 
-* 创建角色
+* Create roles.
 
 ```shell
 kubectl create -f deploy/nfs/rbac.yaml
 ```
 
-> 如果的K8S命名空间不是**default**，请在部署RBAC之前执行以下脚本:
+> If the Kubernetes namespace is not **default**, run the following script before deploying RBAC:
 
 ```shell
 # Set the subject of the RBAC objects to the current namespace where the provisioner is being deployed
@@ -246,25 +246,25 @@ $ sed -i'' "s/namespace:.*/namespace: $NAMESPACE/g" ./deploy/nfs/rbac.yaml
 
 ```
 
-* 创建 `ServiceAccount` 和部署 `NFS-Client Provisioner`
+* Create the `ServiceAccount` and deploy `NFS-Client Provisioner`.
 
 ```shell
 kubectl create -f deploy/nfs/deployment.yaml
 ```
 
-* 创建 NFS StorageClass
+* Create the NFS StorageClass.
 
 ```shell
 kubectl create -f deploy/nfs/class.yaml
 ```
 
-* 验证NFS部署成功
+* Verify that NFS is deployed successfully.
 
 ```shell
 kubectl get pod -l app=nfs-client-provisioner
 ```
 
-### 3.2. 部署数据库
+### 3.2. Deploy Database
 
 ```shell
 
@@ -273,7 +273,7 @@ cd nacos-k8s
 kubectl create -f deploy/mysql/mysql-nfs.yaml
 ```
 
-* 验证数据库是否正常工作
+* Verify that the database works properly.
 
 ```shell
 
@@ -282,30 +282,30 @@ NAME                         READY   STATUS    RESTARTS   AGE
 mysql-gf2vd                        1/1     Running   0          111m
 
 ```
-### 3.3. 执行数据库初始化语句
+### 3.3. Execute Database Initialization Statements
 
-数据库初始化语句位置 [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql)
+Database initialization statements are located in [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql).
 
-### 3.4. 部署Nacos
+### 3.4. Deploy Nacos
 
-* 修改  **deploy/nacos/nacos-pvc-nfs.yaml**
+* Modify **deploy/nacos/nacos-pvc-nfs.yaml**.
 
 ```yaml
 data:
-  mysql.host: "数据库地址"
-  mysql.db.name: "数据库名称"
-  mysql.port: "端口"
-  mysql.user: "用户名"
-  mysql.password: "密码"
+  mysql.host: "database address"
+  mysql.db.name: "database name"
+  mysql.port: "port"
+  mysql.user: "username"
+  mysql.password: "password"
 ```
 
-* 创建 Nacos
+* Create Nacos.
 
 ``` shell
 kubectl create -f nacos-k8s/deploy/nacos/nacos-pvc-nfs.yaml
 ```
 
-* 验证Nacos节点启动成功
+* Verify that Nacos nodes start successfully.
 
 ```shell
 kubectl get pod -l app=nacos
@@ -317,19 +317,19 @@ nacos-1   1/1     Running   0          19h
 nacos-2   1/1     Running   0          19h
 ```
 
-### 3.5. 扩容测试
+### 3.5. Scale-Out Test
 
-* 在扩容前，使用 [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec)获取在pod中的Nacos集群配置文件信息
+* Before scaling out, use [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec) to obtain the Nacos cluster configuration file information in the pods.
 
 ```powershell
 for i in 0 1; do echo nacos-$i; kubectl exec nacos-$i cat conf/cluster.conf; done
 ```
 
-StatefulSet控制器根据其序数索引为每个Pod提供唯一的主机名。 主机名采用<statefulset name />  -  <ordinal index />的形式。 因为nacos StatefulSet的副本字段设置为2，所以当前集群文件中只有两个Nacos节点地址
+The StatefulSet controller provides a unique hostname for each pod based on its ordinal index. The hostname format is `<statefulset name>-<ordinal index>`. Because the `replicas` field of the Nacos StatefulSet is set to `2`, the current cluster file contains only two Nacos node addresses.
 
 ![k8s](https://cdn.nlark.com/yuque/0/2019/gif/338441/1562846123635-e361d2b5-4bbe-4347-acad-8f11f75e6d38.gif)
 
-* 使用kubectl scale 对Nacos动态扩容
+* Use `kubectl scale` to dynamically scale out Nacos.
 
 ```bash
 kubectl scale sts nacos --replicas=3
@@ -337,7 +337,7 @@ kubectl scale sts nacos --replicas=3
 
 ![scale](https://cdn.nlark.com/yuque/0/2019/gif/338441/1562846139093-7a79b709-9afa-448a-b7d6-f57571d3a902.gif)
 
-* 在扩容后，使用 [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec)获取在pod中的Nacos集群配置文件信息
+* After scaling out, use [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec) to obtain the Nacos cluster configuration file information in the pods.
 
 ```bash
 for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i cat conf/cluster.conf; done
@@ -345,49 +345,49 @@ for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i cat conf/cluster.conf; d
 
 ![get_cluster_after](https://cdn.nlark.com/yuque/0/2019/gif/338441/1562846177553-c1c7f379-1b41-4026-9f0b-23e15dde02a8.gif)
 
-* 使用 [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec)执行Nacos API 在每台节点上获取当前**Leader**是否一致
+* Use [`kubectl exec`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands/#exec) to call the Nacos API on each node and check whether the current **Leader** is consistent.
 
 ```bash
 for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i curl -X GET "http://localhost:8848/nacos/v1/ns/raft/state"; done
 ```
 
-到这里你可以发现新节点已经正常加入Nacos集群当中。
+At this point, the new node has joined the Nacos cluster successfully.
 
-### 3.6. 配置属性
+### 3.6. Configuration Properties
 
 * `nacos-pvc-nfs.yaml` or `nacos-quick-start.yaml`
 
-| 名称                     | 必要 | 描述                                    |
-| ----------------------- | -------- | --------------------------------------- |
-| `mysql.host`            | Y       | 自建数据库地址,使用外部数据库时必须指定                      |
-| `mysql.db.name`         | Y       | 数据库名称                      |
-| `mysql.port`            | N       | 数据库端口                        |
-| `mysql.user`            | Y       | 数据库用户名(请不要含有符号```,```)     |
-| `mysql.password`        | Y       | 数据库密码(请不要含有符号```,```)                     |
-| `SPRING_DATASOURCE_PLATFORM`        | Y       |   数据库类型,默认为embedded嵌入式数据库,参数只支持mysql或embedded	                   |
-| `NACOS_REPLICAS`        | N      | 确定执行Nacos启动节点数量,如果不适用动态扩容插件,就必须配置这个属性，否则使用扩容插件后不会生效 |
-| `NACOS_SERVER_PORT`     | N       | Nacos 端口 为peer_finder插件提供端口|
-| `NACOS_APPLICATION_PORT`     | N       | Nacos 端口|
-| `PREFER_HOST_MODE`      | Y       | 启动Nacos集群按域名解析 |
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `mysql.host` | Y | Self-managed database address. Required when an external database is used. |
+| `mysql.db.name` | Y | Database name. |
+| `mysql.port` | N | Database port. |
+| `mysql.user` | Y | Database username. Do not include the `,` character. |
+| `mysql.password` | Y | Database password. Do not include the `,` character. |
+| `SPRING_DATASOURCE_PLATFORM` | Y | Database type. The default value is `embedded`, which means the embedded database. Only `mysql` and `embedded` are supported. |
+| `NACOS_REPLICAS` | N | Determines the number of Nacos startup nodes. If you do not use the dynamic scale-out plugin, configure this property. After the scale-out plugin is used, this property does not take effect. |
+| `NACOS_SERVER_PORT` | N | Nacos port provided to the `peer_finder` plugin. |
+| `NACOS_APPLICATION_PORT` | N | Nacos port. |
+| `PREFER_HOST_MODE` | Y | Starts the Nacos cluster with domain-name resolution. |
 
 * **nfs** `deployment.yaml`
 
-| 名称          | 必要 | 描述                     |
-| ------------ | --------| ------------------------ |
-| `NFS_SERVER` | Y       | NFS 服务端地址         |
-| `NFS_PATH`   | Y       | NFS 共享目录 |
-| `server`     | Y       | NFS 服务端地址  |
-| `path`       | Y       | NFS 共享目录 |
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `NFS_SERVER` | Y | NFS server address. |
+| `NFS_PATH` | Y | NFS shared directory. |
+| `server` | Y | NFS server address. |
+| `path` | Y | NFS shared directory. |
 
 * mysql
 
-| 名称                     | 必要 | 描述                                                      |
-| -------------------------- | -------- | ----------------------------------------------------------- |
-| `MYSQL_ROOT_PASSWORD`        | N       | ROOT 密码                                                    |
-| `MYSQL_DATABASE`             | Y       | 数据库名称                                   |
-| `MYSQL_USER`                 | Y       | 数据库用户名                                  |
-| `MYSQL_PASSWORD`             | Y       | 数据库密码                              |
-| `MYSQL_REPLICATION_USER`     | Y       | 数据库复制用户            |
-| `MYSQL_REPLICATION_PASSWORD` | Y       | 数据库复制用户密码      |
-| `Nfs:server`                 | N      | NFS 服务端地址，如果使用本地部署不需要配置 |
-| `Nfs:path`                   | N     | NFS 共享目录，如果使用本地部署不需要配置 |
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `MYSQL_ROOT_PASSWORD` | N | Root password. |
+| `MYSQL_DATABASE` | Y | Database name. |
+| `MYSQL_USER` | Y | Database username. |
+| `MYSQL_PASSWORD` | Y | Database password. |
+| `MYSQL_REPLICATION_USER` | Y | Database replication user. |
+| `MYSQL_REPLICATION_PASSWORD` | Y | Database replication user password. |
+| `Nfs:server` | N | NFS server address. It is not required for local deployment. |
+| `Nfs:path` | N | NFS shared directory. It is not required for local deployment. |

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-independent.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-independent.md
@@ -1,55 +1,55 @@
 ---
 title: Independent Console
-keywords: [ Nacos,independent deployment,console ]
-description: The Manual fo Nacos independent deployment for Nacos Console and Nacos Engine.
+keywords: [ Nacos, independent deployment, console ]
+description: The manual for independent deployment of Nacos Console and Nacos Server.
 sidebar:
   order: 4
 ---
 
-# 控制台独立部署
+# Independent Console Deployment
 
-> Nacos定义为一个IDC内部应用组件，并非面向公网环境的产品，建议在内部隔离网络环境中部署，强烈不建议部署在公共网络环境。
+> Nacos is positioned as an internal IDC application component, not as a product for public network environments. Deploy it in an isolated internal network. Public network deployment is strongly discouraged.
 >
-> 以下文档中提及的VIP，网卡等所有网络相关概念均处于内部网络环境。
+> Network-related concepts mentioned in this documentation, such as VIPs and network interface cards, refer to internal network environments.
 
-## 1. Nacos 控制台独立部署概览
+## 1. Independent Nacos Console Deployment Overview
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
-Nacos 3.0 版本开始，Nacos支持将控制台进行独立部署，通过进一步拆分高风险请求和高资源消耗的请求，从而提高Nacos的安全性和稳定性。
+Starting from Nacos 3.0, Nacos supports independent console deployment. By further separating high-risk requests from resource-intensive requests, independent console deployment improves Nacos security and stability.
 
-要将Nacos控制台独立部署，首先需要先部署一个`Nacos 无控制台的集群服务`或`Nacos 无控制台的单机服务`，然后再单独启动`Nacos控制台`，并确认两者的部分配置一致。
+To deploy the Nacos console independently, first deploy a `Nacos cluster service without console` or a `Nacos standalone service without console`, then start `Nacos Console` separately and make sure some configurations are consistent between the two.
 
-## 2. 部署Nacos 无控制台服务
+## 2. Deploy Nacos Service Without Console
 
-首先参考[Nacos集群模式部署](./deployment-cluster.md#1-发行版部署)或[Nacos单机模式部署](./deployment-standalone.mdx#1-发行版部署)，将`启动Nacos服务`步骤中的 `sh startup.sh`或`sh startup.sh -m standalone` 更换为`sh startup.sh -d server`或`sh startup.sh -m standalone -d server`.
+First, refer to [Nacos Cluster Deployment](./deployment-cluster.md#1-release-package-deployment) or [Nacos Standalone Deployment](./deployment-standalone.mdx#1-release-package-deployment). In the `Start Nacos Service` step, replace `sh startup.sh` or `sh startup.sh -m standalone` with `sh startup.sh -d server` or `sh startup.sh -m standalone -d server`.
 
-待Nacos服务启动成功后，复制`conf/cluster.conf`文件或记录Nacos服务的`ip:port`，以便后续使用。
+After the Nacos service starts successfully, copy the `conf/cluster.conf` file or record the `ip:port` of the Nacos service for later use.
 
-## 3. 部署Nacos 控制台
+## 3. Deploy Nacos Console
 
-### 3.1. 环境准备
+### 3.1. Environment Preparation
 
-Nacos 控制台 依赖 [Java](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) 环境来运行，请确保是在以下版本环境中安装使用:
+Nacos Console depends on [Java](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) to run. Make sure the following environment is available:
 
-1. 64 bit OS，支持 Linux/Unix/Mac/Windows，推荐选用 Linux/Unix/Mac。
-2. 64 bit JDK 17+；[下载](https://www.oracle.com/java/technologies/downloads/#java17) & [配置](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/)。
+1. 64-bit OS, including Linux, Unix, macOS, or Windows. Linux, Unix, or macOS is recommended.
+2. 64-bit JDK 17 or later. [Download](https://www.oracle.com/java/technologies/downloads/#java17) and [configure](https://docs.oracle.com/cd/E19182-01/820-7851/inst_cli_jdk_javahome_t/) it.
 
-### 3.2. 解压缩Nacos 控制台发行包
+### 3.2. Decompress the Nacos Console Release Package
 
-Nacos独立控制台的发行包与Nacos服务的发行包相同， 只需要从上一步骤[部署Nacos 无控制台服务](#2-部署nacos-无控制台服务)中复制发布包到控制台部署环境中即可，随后执行以下命令进行解压：
+The release package for the independent Nacos console is the same as the Nacos service release package. Copy the release package from the previous [Deploy Nacos Service Without Console](#2-deploy-nacos-service-without-console) step to the console deployment environment, and then run the following commands to decompress it:
 
 ```bash
   unzip nacos-server-$version.zip 
-  # 或者 tar -xvf nacos-server-$version.tar.gz
+  # or tar -xvf nacos-server-$version.tar.gz
   cd nacos/bin
 ```
 
-### 3.3. 配置Nacos 无控制台服务地址配置文件
+### 3.3. Configure the Nacos Service Address File
 
-由于Nacos 独立控制台不进行数据的存储，因此需要访问实际的Nacos服务进度数据的获取，因此需要配置Nacos 无控制台服务地址在对应的配置文件中。
+Because the independent Nacos console does not store data, it must access the actual Nacos service to obtain data. Therefore, configure the Nacos service address in the corresponding configuration file.
 
-在nacos的解压目录nacos/的conf目录下，有配置文件`cluster.conf`，请每行配置成`ip:port`, 其内容为[部署Nacos 无控制台服务](#2-部署nacos-无控制台服务)中记录的`conf/cluster.conf`文件或记录Nacos服务的`ip:port`，示例如下：
+In the `conf` directory under the Nacos decompression directory `nacos/`, configure the `cluster.conf` file with one `ip:port` entry per line. Its content should be the `conf/cluster.conf` file or the recorded Nacos service `ip:port` from [Deploy Nacos Service Without Console](#2-deploy-nacos-service-without-console). Example:
 
 ```plain
 # ip:port
@@ -58,9 +58,9 @@ Nacos独立控制台的发行包与Nacos服务的发行包相同， 只需要从
 200.8.9.18:8848
 ```
 
-### 3.4. 修改配置文件（可选）
+### 3.4. Modify Configuration Files (Optional)
 
-修改nacos的解压目录nacos的`conf`目录下的配置文件`application.properties`，查找以 `nacos.console` 开头的配置项，修改为对应配置，示例如下：
+Modify `application.properties` in the `conf` directory under the Nacos decompression directory. Find the configuration items that start with `nacos.console` and modify them as needed. Example:
 
 ```properties
 ### Nacos Console Main port
@@ -71,7 +71,7 @@ nacos.console.contextPath=
 nacos.console.remote.server.context-path=/nacos
 ```
 
-同时需要配置鉴权相关配置，避免启动失败或无法访问Nacos 服务， 示例如下：
+You must also configure authentication-related settings to avoid startup failures or access failures to the Nacos service. Example:
 
 ```properties
 nacos.core.auth.server.identity.key=${your_custom_server_identity_key}
@@ -80,12 +80,12 @@ nacos.core.auth.plugin.nacos.token.secret.key=${your_custom_token_secret_key}
 ```
 
 :::note
-`nacos.core.auth.server.identity.key`和`nacos.core.auth.server.identity.value`需要设置的与Nacos 无控制台服务进行鉴权时设置的值一致，否则将无法访问Nacos 无控制台服务。
+`nacos.core.auth.server.identity.key` and `nacos.core.auth.server.identity.value` must be the same as the values configured for authentication with the Nacos service without console. Otherwise, the console cannot access that Nacos service.
 :::
 
-### 3.5. 启动Nacos 控制台
+### 3.5. Start Nacos Console
 
-通过如下命令，启动Nacos 控制台：
+Run the following commands to start Nacos Console:
 
 ```bash
 # Linux/Unix/Mac 
@@ -99,7 +99,7 @@ bash startup.sh -d console
 startup.cmd -d console
 ```
 
-随后启动程序会提示您输入`3个`鉴权相关配置
+The startup program then prompts you to enter the following `3` authentication-related configurations:
 
 ```
 `nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
@@ -114,13 +114,13 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 ```
 
 :::note
-若您已经在[修改配置文件](#34-修改配置文件可选)步骤中设置过这3个配置，则不会提示您输入。
+If you have configured these `3` settings in [Modify Configuration Files](#34-modify-configuration-files-optional), you will not be prompted to enter them.
 
-同时`nacos.core.auth.server.identity.key`和`nacos.core.auth.server.identity.value`需要设置的与Nacos 无控制台服务进行鉴权时设置的值一致，否则将无法访问Nacos 无控制台服务。
+`nacos.core.auth.server.identity.key` and `nacos.core.auth.server.identity.value` must be the same as the values configured for authentication with the Nacos service without console. Otherwise, the console cannot access that Nacos service.
 :::
 
-### 3.6. 进入Nacos 控制台
+### 3.6. Access Nacos Console
 
-启动完成后，您可以在浏览器中访问`http://{ip}:{port}`，其中`{ip}`为Nacos 控制台的ip地址，`{port}`为Nacos 控制台的端口，默认为`8080`。
+After startup is complete, access `http://{ip}:{port}` in your browser. `{ip}` is the IP address of Nacos Console, and `{port}` is the Nacos Console port, which defaults to `8080`.
 
-Nacos控制台的使用，请参考文档[控制台手册](../console.md)
+For Nacos console usage, see [Console Guide](../console.md).

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-overview.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-overview.md
@@ -1,110 +1,109 @@
 ---
 title: Deployment Overview
 keywords: [ Nacos, Deployment mode ]
-description: Nacos Support three types of deployments.
+description: Nacos supports three deployment modes.
 sidebar:
   order: 1
 ---
 
-# Nacos部署手册
+# Nacos Deployment Guide
 
-> Nacos定义为一个IDC内部应用组件，并非面向公网环境的产品，建议在内部隔离网络环境中部署，强烈不建议部署在公共网络环境。
+> Nacos is positioned as an internal IDC application component, not as a product for public network environments. Deploy it in an isolated internal network. Public network deployment is strongly discouraged.
 >
-> 以下文档中提及的VIP，网卡等所有网络相关概念均处于内部网络环境。
+> Network-related concepts mentioned in this documentation, such as VIPs and network interface cards, refer to internal network environments.
 
-## 1. Nacos部署架构
+## 1. Nacos Deployment Architecture
 
-Nacos自3.0版本在2.X版本的基础上，对Nacos控制台和Nacos本身进行了拆分和优化。
+Since Nacos 3.0, Nacos has split and optimized the Nacos console and the Nacos server based on the 2.x architecture.
 
-在网络上，Nacos自3.0开始新增Nacos控制台的网络访问端口，不再与Nacos的主端口（server.port，默认8848）进行耦合，以提升Nacos的安全性。
+At the network layer, Nacos 3.0 adds a separate network access port for the Nacos console. The console is no longer coupled to the main Nacos port (`server.port`, default `8848`), which improves Nacos security.
 
-| 端口   | 与主端口的偏移量 | 描述                                                 |
-|------|----------|----------------------------------------------------|
-| 8848 | 0        | Nacos HTTP API 端口，用于Nacos AdminAPI及HTTP OpenAPI的访问 |
-| 9848 | 1000     | 客户端gRPC请求服务端端口，用于客户端向服务端发起连接和请求                    |
-| 9849 | 1001     | 服务端gRPC请求服务端端口，用于服务间同步等                            |
-| 7848 | -1000    | Jraft请求服务端端口，用于处理服务端间的Raft相关请求                     |
-| 8080 | 独立配置     | Nacos控制台端口，访问Nacos控制台及Nacos控制台的API                 |
+| Port | Offset from the main port | Description |
+|------|---------------------------|-------------|
+| 8848 | 0 | Nacos HTTP API port, used to access Nacos Admin APIs and HTTP Open APIs |
+| 9848 | 1000 | Client gRPC port on the server, used by clients to connect to and request the server |
+| 9849 | 1001 | Server gRPC port on the server, used for inter-server synchronization |
+| 7848 | -1000 | JRaft port on the server, used to process Raft requests between servers |
+| 8080 | Independently configured | Nacos console port, used to access the Nacos console and Nacos console APIs |
 
-> **使用VIP/nginx请求时，对于Nacos的gRPC端口（默认9848）需要配置成TCP转发，不能配置http/http2转发，否则连接会被nginx断开。**
+> **When using VIP or nginx requests, configure the Nacos gRPC port (default `9848`) for TCP forwarding. Do not configure HTTP or HTTP/2 forwarding, otherwise nginx will disconnect the connection.**
 >
-> **对外暴露端口时，建议仅暴露控制台端口（默认8080）和gRPC端口（默认9848）；同时按需暴露主端口（默认8848），其他端口为服务端之间的通信端口，请勿暴露其他端口，同时建议所有端口均不暴露在公网下。**
+> **When exposing ports externally, expose only the console port (default `8080`) and the gRPC port (default `9848`). Expose the main port (default `8848`) only when needed. Other ports are used for inter-server communication. Do not expose them, and do not expose any port to the public network.**
 
 ![nacos_port_exposure.png](/img/doc/manual/admin/deployment/deploy-port-export-3.0.svg)
 
-客户端的大多数请求会通过gRPC端口(默认9848)请求到服务端上，但会有部分插件请求（如Nacos 鉴权插件的login）会通过Nacos主端口（默认8848）进行请求。同时Nacos3.0的客户端为了方便用户升级及兼容使用习惯，Nacos3.0客户端仍然保留着和Nacos2.X客户端相同的计算逻辑，既：**配置主端口(默认8848)，通过相同的偏移量，计算对应gRPC端口(默认9848)**。
+Most client requests are sent to the server through the gRPC port (default `9848`), but some plugin requests, such as login requests from the Nacos authentication plugin, are sent through the Nacos main port (default `8848`). To make upgrades easier and keep compatibility with existing usage habits, the Nacos 3.0 client keeps the same port calculation logic as the Nacos 2.x client: **configure the main port (default `8848`) and calculate the corresponding gRPC port (default `9848`) by using the same offset**.
 
-因此如果客户端和服务端之前存在端口转发，或防火墙时，需要对端口转发配置和防火墙配置做相应的调整。
+Therefore, if port forwarding or a firewall exists between the client and server, adjust the port forwarding and firewall configurations accordingly.
 
-## 2. Nacos支持三种部署模式
+## 2. Nacos Deployment Modes
 
-* 单机模式 - 又称单例模式，主要用于测试和单机试用。
-* 集群模式 - 主要用于生产环境，确保高可用。
-* 多集群模式（TODO） - 用于多数据中心场景。
+Nacos supports three deployment modes:
 
-![Nacos部署模式图](/img/doc/overview/deploy-structure.svg)
+* Standalone mode, also called single-instance mode. It is mainly used for testing and single-machine trials.
+* Cluster mode. It is mainly used in production environments to ensure high availability.
+* Multi-cluster mode (TODO). It is used for multi-data-center scenarios.
 
-### 2.1. 单机模式
+![Nacos deployment mode diagram](/img/doc/overview/deploy-structure.svg)
 
-单机模式又称`单例模式`,
-拥有所有Nacos的功能及特性，具有极易部署、快速启动等优点。但无法与其他节点组成集群，无法在节点或网络故障时提供高可用能力。单机模式同样可以使用内置Derby数据库（默认）和外置数据库进行存储。
+### 2.1. Standalone Mode
 
-单机模式主要适合于工程师于本地搭建或于测试环境中搭建Nacos环境，主要用于开发调试及测试使用；也能够兼顾部分对稳定性和可用性要求不高的业务场景。
+Standalone mode, also called `single-instance mode`, provides all Nacos features and capabilities. It is easy to deploy and starts quickly. However, it cannot form a cluster with other nodes and cannot provide high availability during node or network failures. Standalone mode can use the built-in Derby database (default) or an external database for storage.
 
-单机模式的部署参考文档: [单机模式部署](./deployment-standalone.mdx)
+Standalone mode is mainly suitable for engineers who build a Nacos environment locally or in a test environment for development, debugging, and testing. It can also be used for some business scenarios with low stability and availability requirements.
 
-### 2.2. 集群模式
+For deployment details, see [Standalone Deployment](./deployment-standalone.mdx).
 
-集群模式通过自研一致性协议Distro以及Raft协议，将多个Nacos节点构建成了高可用的Nacos集群。数据将在集群中各个节点进行同步，保证数据的一致性。集群模式具有高可用、高扩展、高并发等优点，确保在故障发生时不影响业务的运行。集群模式
-**默认**采用外置数据库进行存储，但也可以通过内置数据库进行存储。
+### 2.2. Cluster Mode
 
-该模式主要适合于生产环境，也是社区最为推荐的部署模式。
+Cluster mode uses the self-developed Distro consistency protocol and the Raft protocol to build a highly available Nacos cluster from multiple Nacos nodes. Data is synchronized across nodes in the cluster to ensure consistency. Cluster mode provides high availability, scalability, and concurrency, and keeps services running when failures occur. Cluster mode uses an external database by **default**, but can also use the built-in database for storage.
 
-集群模式的部署参考文档: [集群模式部署](./deployment-cluster.md)
+This mode is mainly suitable for production environments and is the deployment mode most recommended by the community.
 
-### 2.3. 多集群模式（TODO）
+For deployment details, see [Cluster Deployment](./deployment-cluster.md).
 
-Nacos支持NameServer路由请求模式，通过它您可以设计一个有用的映射规则来控制请求转发到相应的集群，在映射规则中您可以按命名空间或租户等分片请求...
+### 2.3. Multi-Cluster Mode (TODO)
 
-## 3. Nacos控制台独立部署
+Nacos supports NameServer-based request routing. With this mode, you can design mapping rules to forward requests to the corresponding cluster, such as routing requests by namespace or tenant.
+
+## 3. Independent Nacos Console Deployment
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
-Nacos 3.0 版本开始，Nacos支持将控制台进行独立部署，通过进一步拆分高风险请求和高资源消耗的请求，从而提高Nacos的安全性和稳定性。
+Starting from Nacos 3.0, Nacos supports independent console deployment. By further separating high-risk requests from resource-intensive requests, independent console deployment improves Nacos security and stability.
 
-独立部署`Nacos Server`时，仅需要在启动命令中添加`-d server`参数，如：`sh startup.sh -d server`.
+To deploy `Nacos Server` independently, add the `-d server` parameter to the startup command, for example: `sh startup.sh -d server`.
 
-独立部署`Nacos Console`时，则需要在启动命令中添加`-d console`参数，如：`sh startup.sh -d console`.
+To deploy `Nacos Console` independently, add the `-d console` parameter to the startup command, for example: `sh startup.sh -d console`.
 
-Nacos控制台独立部署参考文档: [控制台独立部署](./deployment-independent.md)
+For independent console deployment details, see [Independent Console Deployment](./deployment-independent.md).
 
 Before going to production, continue with [Deployment Best Practices](./deployment-best-practices.md) to check internal network boundaries, independent console deployment, external database storage, authentication, visibility, traffic control, configuration encryption, and rollback plans.
 
-## 4. 多网卡IP选择
+## 4. Multi-NIC IP Selection
 
-当本地环境比较复杂的时候，Nacos服务在启动的时候需要选择运行时使用的IP或者网卡。Nacos从多网卡获取IP参考Spring
-Cloud设计，通过nacos.inetutils参数，可以指定Nacos使用的网卡和IP地址。目前支持的配置参数有:
+When the local environment is complex, Nacos needs to select the IP address or network interface card to use at startup. Nacos obtains IP addresses from multiple NICs by referring to the Spring Cloud design. You can use `nacos.inetutils` parameters to specify the NIC and IP address used by Nacos. The following configuration parameters are supported:
 
-- ip-address参数可以直接设置nacos的ip
+- `ip-address` directly sets the Nacos IP address.
 
 ```
 nacos.inetutils.ip-address=10.11.105.155
 ```
 
-- use-only-site-local-interfaces参数可以让nacos使用局域网ip，这个在nacos部署的机器有多网卡时很有用，可以让nacos选择局域网网卡
+- `use-only-site-local-interfaces` allows Nacos to use a LAN IP address. This is useful when the machine that deploys Nacos has multiple NICs and you want Nacos to select a LAN NIC.
 
 ```
 nacos.inetutils.use-only-site-local-interfaces=true
 ```
 
-- ignored-interfaces支持网卡数组，可以让nacos忽略多个网卡
+- `ignored-interfaces` supports a NIC array and allows Nacos to ignore multiple NICs.
 
 ```
 nacos.inetutils.ignored-interfaces[0]=eth0
 nacos.inetutils.ignored-interfaces[1]=eth1
 ```
 
-- preferred-networks参数可以让nacos优先选择匹配的ip，支持正则匹配和前缀匹配
+- `preferred-networks` allows Nacos to prefer matching IP addresses. Regular expression matching and prefix matching are supported.
 
 ```
 nacos.inetutils.preferred-networks[0]=30.5.124.

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-standalone.mdx
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-standalone.mdx
@@ -1,31 +1,31 @@
 ---
 title: Standalone Deployment
-keywords: [Nacos,Deployment,Standalone]
-description: The Manual fo Nacos standalone deployment.
+keywords: [Nacos, Deployment, Standalone]
+description: The manual for Nacos standalone deployment.
 sidebar:
     order: 2
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-# Nacos单机模式
+# Nacos Standalone Mode
 
-## 1. 发行版部署
+## 1. Release Package Deployment
 
-### 1.1. 部署步骤
+### 1.1. Deployment Steps
 
 <Tabs>
-  <TabItem label="使用Derby数据库">
-    在[快速开始](../../../quickstart/quick-start.mdx)中，我们使用了内置的数据库Derby，快速部署了Nacos的单机模式，可参考该文档进行使用Derby数据库的Nacos单机模式部署。
+  <TabItem label="Use Derby Database">
+    In [Quick Start](../../../quickstart/quick-start.mdx), the built-in Derby database is used to quickly deploy Nacos in standalone mode. You can refer to that document to deploy Nacos standalone mode with Derby.
   </TabItem>
-  <TabItem label="使用MySQL数据库">
-    参考[快速开始](../../../quickstart/quick-start.mdx)中，进行Nacos的环境准备、发行版的下载等。
+  <TabItem label="Use MySQL Database">
+    Refer to [Quick Start](../../../quickstart/quick-start.mdx) to prepare the Nacos environment and download the release package.
 
-    同时在使用MySQL数据源部署Nacos单机模式时，需要自行准备MySQL数据库：
+    When deploying Nacos standalone mode with a MySQL data source, prepare the MySQL database yourself:
 
-    - 1.安装数据库，版本要求：5.6.5+
-    - 2.初始化mysql数据库，数据库初始化文件：[mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql)
+    - 1. Install the database. The required version is 5.6.5 or later.
+    - 2. Initialize the MySQL database. Database initialization file: [mysql-schema.sql](https://github.com/alibaba/nacos/blob/master/distribution/conf/mysql-schema.sql).
 
-    然后修改`${nacos.home}/conf/application.properties`文件，增加支持MySQL数据源配置，添加MySQL数据源的url、用户名和密码。
+    Then modify `${nacos.home}/conf/application.properties`, add the MySQL data source configuration, and configure the MySQL data source URL, username, and password.
 
     ```
     spring.sql.init.platform=mysql
@@ -36,31 +36,31 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     db.password=${mysql_password}
     ```
 
-    然后按照[快速开始-启动服务器](../../../quickstart/quick-start/#4修改鉴权配置)中的操作，修改Nacos的鉴权配置。
-    最后使用[快速开始-启动服务器](../../../quickstart/quick-start/#5启动服务器)中的操作，启动Nacos即可。
+    Then follow [Quick Start - Start Server](../../../quickstart/quick-start/#4-modify-authentication-configuration) to modify the Nacos authentication configuration.
+    Finally, follow [Quick Start - Start Server](../../../quickstart/quick-start/#5-start-server) to start Nacos.
   </TabItem>
 </Tabs>
 
-### 1.2. 高级配置
+### 1.2. Advanced Configuration
 
-Nacos提供了丰富的可配置项，帮助您调整Nacos的性能、控制Nacos提供的功能能力，例如鉴权、监控、数据库、连接、日志等；详情请参考[系统参数](../system-configurations.md)。
+Nacos provides rich configuration items that help you tune Nacos performance and control Nacos features, such as authentication, monitoring, databases, connections, and logs. For details, see [System Parameters](../system-configurations.md).
 
-## 2. Docker部署
+## 2. Docker Deployment
 
-### 2.1. 部署步骤
+### 2.1. Deployment Steps
 
 <Tabs>
-  <TabItem label="使用Derby数据库">
-    在[快速开始 Docker](../../../quickstart/quick-start-docker.mdx)中，我们通过`Docker`使用了内置的数据库Derby，快速部署了Nacos的单机模式，可参考该文档进行使用Derby数据库的Nacos单机模式部署。
+  <TabItem label="Use Derby Database">
+    In [Quick Start Docker](../../../quickstart/quick-start-docker.mdx), Docker is used with the built-in Derby database to quickly deploy Nacos in standalone mode. You can refer to that document to deploy Nacos standalone mode with Derby.
   </TabItem>
-  <TabItem label="使用MySQL数据库">
-    执行 docker-compose 命令启动Nacos
+  <TabItem label="Use MySQL Database">
+    Run the docker-compose command to start Nacos.
 
     ```powershell
     docker-compose -f example/standalone-mysql-8.yaml up
     ```
 
-    **如果希望使用MySQL5.7**
+    **To use MySQL 5.7**
 
     ```powershell
     docker-compose -f example/standalone-mysql-5.7.yaml up
@@ -68,22 +68,22 @@ Nacos提供了丰富的可配置项，帮助您调整Nacos的性能、控制Naco
   </TabItem>
 </Tabs>
 
-### 2.2. 高级配置
+### 2.2. Advanced Configuration
 
-如果你有很多自定义配置的需求，可以通过指定[系统参数-镜像环境变量](../system-configurations/#2-镜像环境变量)的方式进行配置，例如需要开启鉴权时：
+If you need many custom configurations, you can configure them by specifying [System Parameters - Image Environment Variables](../system-configurations/#2-image-environment-variables). For example, to enable authentication:
 
 ```powershell
 docker run --name nacos-standalone-auth -e MODE=standalone -e NACOS_AUTH_ENABLE=true -e NACOS_AUTH_TOKEN=${customToken} -e NACOS_AUTH_IDENTITY_KEY=${customKey} -e NACOS_AUTH_IDENTITY_VALUE=${customValue} -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-同时，可以通过对application.properties文件进行挂卷定义的方式，将更多复杂的自定义配置导入Nacos容器中，强烈建议在生产环境中使用方式，例如：
+You can also mount the `application.properties` file to import more complex custom configurations into the Nacos container. This method is strongly recommended for production environments. Example:
 
 ```powershell
 docker run --name nacos-standalone -e MODE=standalone -v /path/application.properties:/home/nacos/conf/application.properties -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:latest
 ```
 
-如果仍然无法满足自定义需求，可以基于nacos-docker项目中的`Dockerfile`自行构建镜像。
+If this still cannot meet your customization requirements, you can build an image based on the `Dockerfile` in the `nacos-docker` project.
 
-## 3. Kubernetes部署
+## 3. Kubernetes Deployment
 
-Kubernetes暂时不提供单例模式的部署，推荐使用集群模式部署。
+Kubernetes does not currently provide standalone-mode deployment. Cluster-mode deployment is recommended.


### PR DESCRIPTION
## Summary
- translate English admin deployment overview, standalone, independent console, and cluster deployment docs
- keep latest and next English deployment docs aligned
- preserve commands, configuration keys, and deployment examples while cleaning Chinese text residue

## Validation
- rg -n "[\p{Han}]" src/content/docs/latest/en/manual/admin/deployment src/content/docs/next/en/manual/admin/deployment
- git diff --check develop-astro-nacos..HEAD
- npm run build (fails locally because Rollup optional native package @rollup/rollup-darwin-arm64 cannot be loaded due macOS code signature Team ID mismatch, same local environment issue as prior batches)