### PR TITLE
docs: align English upgrade guide

### DIFF
--- a/src/content/docs/latest/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/latest/en/manual/admin/upgrading.mdx
@@ -41,11 +41,11 @@ Compare the schema file of your currently deployed Nacos version with the schema
 If there are schema changes, apply the database alterations first. MySQL example:
 
 ```SQL
--- 从 2.0.X 升级时需要执行下列所有SQL, 从2.1.X之后版本升级仅需执行最后三行。
-ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `config_info_beta` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
+-- When upgrading from 2.0.X, execute all SQL statements below. When upgrading from versions later than 2.1.X, execute only the last three lines.
+ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
+ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
+ALTER TABLE `config_info_beta` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
+ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
 ALTER TABLE `his_config_info` ADD COLUMN `publish_type` varchar(50)  DEFAULT 'formal' COMMENT 'publish type gray or formal';
 ALTER TABLE `his_config_info` ADD COLUMN `gray_name` varchar(50)  DEFAULT NULL COMMENT 'gray name';
 ALTER TABLE `his_config_info` ADD COLUMN `ext_info`  longtext DEFAULT NULL COMMENT 'ext info';
@@ -55,62 +55,62 @@ Version 3.2.0 introduces new AI-related tables. The following tables must be cre
 
 ```SQL
 CREATE TABLE IF NOT EXISTS `pipeline_execution` (
-    `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
-    `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
-    `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
-    `namespace_id`  varchar(128) DEFAULT NULL COMMENT '命名空间ID',
-    `version`       varchar(64)  DEFAULT NULL COMMENT '版本',
-    `status`        varchar(32)  NOT NULL COMMENT '执行状态',
-    `pipeline`      longtext     NOT NULL COMMENT 'pipeline节点结果JSON',
-    `create_time`   bigint(20)   NOT NULL COMMENT '创建时间',
-    `update_time`   bigint(20)   NOT NULL COMMENT '修改时间',
+    `execution_id`  varchar(64)  NOT NULL COMMENT 'execution ID',
+    `resource_type` varchar(32)  NOT NULL COMMENT 'resource type',
+    `resource_name` varchar(256) NOT NULL COMMENT 'resource name',
+    `namespace_id`  varchar(128) DEFAULT NULL COMMENT 'namespace ID',
+    `version`       varchar(64)  DEFAULT NULL COMMENT 'version',
+    `status`        varchar(32)  NOT NULL COMMENT 'execution status',
+    `pipeline`      longtext     NOT NULL COMMENT 'pipeline node result JSON',
+    `create_time`   bigint(20)   NOT NULL COMMENT 'creation time',
+    `update_time`   bigint(20)   NOT NULL COMMENT 'update time',
     PRIMARY KEY (`execution_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源发布审核Pipeline执行记录';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource publish review pipeline execution record';
 
 CREATE TABLE IF NOT EXISTS `ai_resource` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
-    `name` varchar(256) NOT NULL COMMENT '资源名称',
-    `type` varchar(32) NOT NULL COMMENT '资源类型',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT '资源描述',
-    `status` varchar(32) DEFAULT NULL COMMENT '资源状态',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
-    `biz_tags` varchar(1024) DEFAULT NULL COMMENT '业务标签',
-    `ext` longtext DEFAULT NULL COMMENT '扩展信息(JSON)',
-    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT '来源标识(导入/同步来源)',
-    `version_info` longtext DEFAULT NULL COMMENT '版本信息(JSON)',
-    `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT '元数据版本(乐观锁)',
-    `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT '可见性: PUBLIC/PRIVATE',
-    `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
+    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'creation time',
+    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'modification time',
+    `name` varchar(256) NOT NULL COMMENT 'resource name',
+    `type` varchar(32) NOT NULL COMMENT 'resource type',
+    `c_desc` varchar(2048) DEFAULT NULL COMMENT 'resource description',
+    `status` varchar(32) DEFAULT NULL COMMENT 'resource status',
+    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'namespace ID',
+    `biz_tags` varchar(1024) DEFAULT NULL COMMENT 'business tags',
+    `ext` longtext DEFAULT NULL COMMENT 'extension information (JSON)',
+    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT 'source identifier (import/sync source)',
+    `version_info` longtext DEFAULT NULL COMMENT 'version information (JSON)',
+    `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT 'metadata version (optimistic lock)',
+    `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT 'visibility: PUBLIC/PRIVATE',
+    `owner` varchar(128) NOT NULL DEFAULT '' COMMENT 'creator username',
+    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT 'download count',
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
     KEY `idx_ai_resource_name` (`name`),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource metadata table';
 
 CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
-    `type` varchar(32) NOT NULL COMMENT '资源类型',
-    `author` varchar(128) DEFAULT NULL COMMENT '作者',
-    `name` varchar(256) NOT NULL COMMENT '资源名称',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT '版本描述',
-    `status` varchar(32) NOT NULL COMMENT '版本状态',
-    `version` varchar(64) NOT NULL COMMENT '版本号',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
-    `storage` longtext DEFAULT NULL COMMENT '存储信息(JSON)',
-    `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
+    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'creation time',
+    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'modification time',
+    `type` varchar(32) NOT NULL COMMENT 'resource type',
+    `author` varchar(128) DEFAULT NULL COMMENT 'author',
+    `name` varchar(256) NOT NULL COMMENT 'resource name',
+    `c_desc` varchar(2048) DEFAULT NULL COMMENT 'version description',
+    `status` varchar(32) NOT NULL COMMENT 'version status',
+    `version` varchar(64) NOT NULL COMMENT 'version number',
+    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'namespace ID',
+    `storage` longtext DEFAULT NULL COMMENT 'storage information (JSON)',
+    `publish_pipeline_info` longtext DEFAULT NULL COMMENT 'publish pipeline information (JSON)',
+    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT 'download count',
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
     KEY `idx_ai_resource_ver_name` (`name`),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource version table';
 ```
 
 If you use PostgreSQL and upgrade from 3.2.1 or earlier to 3.2.2, check whether `tenant_id` in the config-related tables is already `NOT NULL DEFAULT ''` before the upgrade. Nacos 3.2.2 validates the PostgreSQL schema during startup. If older tables still allow `tenant_id` to be null, the server may fail to start. See [alibaba/nacos#15275](https://github.com/alibaba/nacos/issues/15275) for the related discussion.
@@ -149,7 +149,7 @@ ALTER TABLE his_config_info ALTER COLUMN tenant_id SET NOT NULL;
 
 <Tabs>
   <TabItem label="Official Website">
-    Go to the Nacos official [download page](/download/nacos-server/), select the [stable version](/download/nacos-server/#稳定版本), and click the `${nacos.version}.zip` link in the `Binary Package` column to download.
+    Go to the Nacos official [download page](/download/nacos-server/), select the [stable version](/download/nacos-server/#stable-version), and click the `${nacos.version}.zip` link in the `Binary Package` column to download.
 
     > Note: During peak download times, you may encounter rate limiting. If the download fails, please wait and retry, or use the `GitHub download` method instead.
   </TabItem>
@@ -261,7 +261,7 @@ Please refer to [2.1.1 Verify Database Schema](#211-verify-database-schema) to c
 
 #### 2.2.2. Verify Environment Variables
 
-Compare the environment variables of your current deployment with [System Parameters - Image Environment Variables](./system-configurations/#2-镜像环境变量) to check for changes. If there are any, update the Docker environment variable file or Kubernetes configmap/secret accordingly.
+Compare the environment variables of your current deployment with [System Parameters - Image Environment Variables](./system-configurations/#2-image-environment-variables) to check for changes. If there are any, update the Docker environment variable file or Kubernetes configmap/secret accordingly.
 
 For example, add the following environment variables:
 

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -41,11 +41,11 @@ Compare the schema file of your currently deployed Nacos version with the schema
 If there are schema changes, apply the database alterations first. MySQL example:
 
 ```SQL
--- 从 2.0.X 升级时需要执行下列所有SQL, 从2.1.X之后版本升级仅需执行最后三行。
-ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `config_info_beta` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
+-- When upgrading from 2.0.X, execute all SQL statements below. When upgrading from versions later than 2.1.X, execute only the last three lines.
+ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
+ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
+ALTER TABLE `config_info_beta` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
+ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
 ALTER TABLE `his_config_info` ADD COLUMN `publish_type` varchar(50)  DEFAULT 'formal' COMMENT 'publish type gray or formal';
 ALTER TABLE `his_config_info` ADD COLUMN `gray_name` varchar(50)  DEFAULT NULL COMMENT 'gray name';
 ALTER TABLE `his_config_info` ADD COLUMN `ext_info`  longtext DEFAULT NULL COMMENT 'ext info';
@@ -55,62 +55,62 @@ Version 3.2.0 introduces new AI-related tables. The following tables must be cre
 
 ```SQL
 CREATE TABLE IF NOT EXISTS `pipeline_execution` (
-    `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
-    `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
-    `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
-    `namespace_id`  varchar(128) DEFAULT NULL COMMENT '命名空间ID',
-    `version`       varchar(64)  DEFAULT NULL COMMENT '版本',
-    `status`        varchar(32)  NOT NULL COMMENT '执行状态',
-    `pipeline`      longtext     NOT NULL COMMENT 'pipeline节点结果JSON',
-    `create_time`   bigint(20)   NOT NULL COMMENT '创建时间',
-    `update_time`   bigint(20)   NOT NULL COMMENT '修改时间',
+    `execution_id`  varchar(64)  NOT NULL COMMENT 'execution ID',
+    `resource_type` varchar(32)  NOT NULL COMMENT 'resource type',
+    `resource_name` varchar(256) NOT NULL COMMENT 'resource name',
+    `namespace_id`  varchar(128) DEFAULT NULL COMMENT 'namespace ID',
+    `version`       varchar(64)  DEFAULT NULL COMMENT 'version',
+    `status`        varchar(32)  NOT NULL COMMENT 'execution status',
+    `pipeline`      longtext     NOT NULL COMMENT 'pipeline node result JSON',
+    `create_time`   bigint(20)   NOT NULL COMMENT 'creation time',
+    `update_time`   bigint(20)   NOT NULL COMMENT 'update time',
     PRIMARY KEY (`execution_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源发布审核Pipeline执行记录';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource publish review pipeline execution record';
 
 CREATE TABLE IF NOT EXISTS `ai_resource` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
-    `name` varchar(256) NOT NULL COMMENT '资源名称',
-    `type` varchar(32) NOT NULL COMMENT '资源类型',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT '资源描述',
-    `status` varchar(32) DEFAULT NULL COMMENT '资源状态',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
-    `biz_tags` varchar(1024) DEFAULT NULL COMMENT '业务标签',
-    `ext` longtext DEFAULT NULL COMMENT '扩展信息(JSON)',
-    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT '来源标识(导入/同步来源)',
-    `version_info` longtext DEFAULT NULL COMMENT '版本信息(JSON)',
-    `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT '元数据版本(乐观锁)',
-    `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT '可见性: PUBLIC/PRIVATE',
-    `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
+    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'creation time',
+    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'modification time',
+    `name` varchar(256) NOT NULL COMMENT 'resource name',
+    `type` varchar(32) NOT NULL COMMENT 'resource type',
+    `c_desc` varchar(2048) DEFAULT NULL COMMENT 'resource description',
+    `status` varchar(32) DEFAULT NULL COMMENT 'resource status',
+    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'namespace ID',
+    `biz_tags` varchar(1024) DEFAULT NULL COMMENT 'business tags',
+    `ext` longtext DEFAULT NULL COMMENT 'extension information (JSON)',
+    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT 'source identifier (import/sync source)',
+    `version_info` longtext DEFAULT NULL COMMENT 'version information (JSON)',
+    `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT 'metadata version (optimistic lock)',
+    `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT 'visibility: PUBLIC/PRIVATE',
+    `owner` varchar(128) NOT NULL DEFAULT '' COMMENT 'creator username',
+    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT 'download count',
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
     KEY `idx_ai_resource_name` (`name`),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource metadata table';
 
 CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
-    `type` varchar(32) NOT NULL COMMENT '资源类型',
-    `author` varchar(128) DEFAULT NULL COMMENT '作者',
-    `name` varchar(256) NOT NULL COMMENT '资源名称',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT '版本描述',
-    `status` varchar(32) NOT NULL COMMENT '版本状态',
-    `version` varchar(64) NOT NULL COMMENT '版本号',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
-    `storage` longtext DEFAULT NULL COMMENT '存储信息(JSON)',
-    `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
+    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'creation time',
+    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'modification time',
+    `type` varchar(32) NOT NULL COMMENT 'resource type',
+    `author` varchar(128) DEFAULT NULL COMMENT 'author',
+    `name` varchar(256) NOT NULL COMMENT 'resource name',
+    `c_desc` varchar(2048) DEFAULT NULL COMMENT 'version description',
+    `status` varchar(32) NOT NULL COMMENT 'version status',
+    `version` varchar(64) NOT NULL COMMENT 'version number',
+    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'namespace ID',
+    `storage` longtext DEFAULT NULL COMMENT 'storage information (JSON)',
+    `publish_pipeline_info` longtext DEFAULT NULL COMMENT 'publish pipeline information (JSON)',
+    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT 'download count',
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
     KEY `idx_ai_resource_ver_name` (`name`),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource version table';
 ```
 
 If you use PostgreSQL and upgrade from 3.2.1 or earlier to 3.2.2, check whether `tenant_id` in the config-related tables is already `NOT NULL DEFAULT ''` before the upgrade. Nacos 3.2.2 validates the PostgreSQL schema during startup. If older tables still allow `tenant_id` to be null, the server may fail to start. See [alibaba/nacos#15275](https://github.com/alibaba/nacos/issues/15275) for the related discussion.
@@ -149,7 +149,7 @@ ALTER TABLE his_config_info ALTER COLUMN tenant_id SET NOT NULL;
 
 <Tabs>
   <TabItem label="Official Website">
-    Go to the Nacos official [download page](/download/nacos-server/), select the [stable version](/download/nacos-server/#稳定版本), and click the `${nacos.version}.zip` link in the `Binary Package` column to download.
+    Go to the Nacos official [download page](/download/nacos-server/), select the [stable version](/download/nacos-server/#stable-version), and click the `${nacos.version}.zip` link in the `Binary Package` column to download.
 
     > Note: During peak download times, you may encounter rate limiting. If the download fails, please wait and retry, or use the `GitHub download` method instead.
   </TabItem>
@@ -261,7 +261,7 @@ Please refer to [2.1.1 Verify Database Schema](#211-verify-database-schema) to c
 
 #### 2.2.2. Verify Environment Variables
 
-Compare the environment variables of your current deployment with [System Parameters - Image Environment Variables](./system-configurations/#2-镜像环境变量) to check for changes. If there are any, update the Docker environment variable file or Kubernetes configmap/secret accordingly.
+Compare the environment variables of your current deployment with [System Parameters - Image Environment Variables](./system-configurations/#2-image-environment-variables) to check for changes. If there are any, update the Docker environment variable file or Kubernetes configmap/secret accordingly.
 
 For example, add the following environment variables:
 


### PR DESCRIPTION
## Summary
- translate remaining SQL comments in the English upgrade guide
- update English anchors for stable download and image environment variable links
- keep latest and next upgrade guide docs aligned

## Validation
- rg -n "[\p{Han}]" src/content/docs/latest/en/manual/admin/upgrading.mdx src/content/docs/next/en/manual/admin/upgrading.mdx
- rg -n "[，。；：！？（）“”、]| " src/content/docs/latest/en/manual/admin/upgrading.mdx src/content/docs/next/en/manual/admin/upgrading.mdx
- git diff --check develop-astro-nacos..HEAD
- npm run build (fails locally because Rollup optional native package @rollup/rollup-darwin-arm64 cannot be loaded due macOS code signature Team ID mismatch, same local environment issue as prior batches)