### PR TITLE
docs: add Nacos 3.3 config migration notes

### DIFF
--- a/src/content/docs/next/en/manual/admin/compatibility-and-deprecation.md
+++ b/src/content/docs/next/en/manual/admin/compatibility-and-deprecation.md
@@ -26,12 +26,20 @@ As Nacos evolves, some compatibility capabilities remain available to help users
 | --- | --- | --- |
 | v1/v2 HTTP APIs | Migrate to v3 OpenAPI or current SDKs. If a migration window is required, use the legacy adapter temporarily. | [Upgrading Manual](./upgrading.mdx), [OpenAPI Overview](../user/overview/api-overview.md) |
 | Compatibility switches | Enable them only during upgrade or migration windows. Disable them after the system becomes stable. | [System Configurations](./system-configurations.md) |
-| Beta/Tag gray release compatibility | Enable compatibility and migration configuration during upgrade, then use the new gray model after stabilization. | [Upgrading Manual](./upgrading.mdx), [System Configurations](./system-configurations.md) |
-| Default namespace migration | Pay attention to migration from empty namespace to `public`. | [Upgrading Manual](./upgrading.mdx), [Java SDK Usage](../user/java-sdk/usage.md#13-upgrade-compatibility) |
+| Beta/Tag gray release compatibility | Starting with Nacos 3.3, legacy `config_info_beta` and `config_info_tag` tables are no longer migrated automatically. Migrate them to the current `config_info_gray` gray model before upgrade. Current beta/tag APIs remain backed by `config_info_gray` and `GrayRule`. | [Upgrading Manual](./upgrading.mdx), [Configuration Gray Release](../user/config/gray-release.md) |
+| Default namespace migration | Starting with Nacos 3.3, storage migration or double-write between empty tenant values and `public` is no longer automatic. Blank or omitted namespace requests are still normalized to the default namespace `public`. | [Upgrading Manual](./upgrading.mdx), [Java SDK Usage](../user/java-sdk/usage.md#13-upgrade-compatibility) |
 | Legacy console | Use only for compatibility with existing habits. New deployments should use the new console. | [Console Manual](./console.md#legacy-console) |
 | Deprecated Java SDK properties | Do not use them in new systems. | [Java SDK Properties](../user/java-sdk/properties.md) |
 | Deprecated CLI commands | Use explicit lifecycle commands instead of shortcut publish commands. | [Nacos CLI User Guide](./nacos-cli.md) |
 | Experimental features | Use only when you accept the change risk. | [Experimental Features Overview](../../experimental/overview.md) |
+
+## Nacos 3.3 Config Compatibility Migration Removal
+
+Nacos 3.3 removes runtime compatibility migration logic for Config data from versions before 3.0, including default-namespace storage migration between legacy empty tenant values and `public`, migration from legacy `config_info_beta`/`config_info_tag` tables to `config_info_gray`, and the related double-write and mixed-version synchronization logic.
+
+When upgrading from versions before 3.0 to 3.3, if the old deployment did not use the default namespace and did not use beta gray release, this compatibility removal does not affect smooth upgrade for this compatibility area. If the old deployment used the default namespace or beta gray release, operators must complete data migration before upgrading to 3.3: migrate default-namespace data from the empty tenant to `public`, and migrate legacy beta/tag gray data to the current `config_info_gray` gray model.
+
+This does not remove current default namespace semantics or current beta/tag gray APIs. Blank or omitted namespace requests are still normalized to `public`; current beta/tag gray behavior remains backed by `config_info_gray` and `GrayRule`.
 
 ## What to confirm before using compatibility capabilities
 

--- a/src/content/docs/next/en/manual/admin/system-configurations.md
+++ b/src/content/docs/next/en/manual/admin/system-configurations.md
@@ -8,7 +8,7 @@ sidebar:
 
 # System Parameters
 
-This page summarizes common Nacos 3.2.x server-side parameters. The main source is `${nacos.home}/conf/application.properties` in the Nacos distribution, with extra notes from current configuration code.
+This page summarizes common Nacos 3.3.x server-side parameters. The main source is `${nacos.home}/conf/application.properties` in the Nacos distribution, with extra notes from current configuration code.
 
 For production deployments, read [Deployment Best Practices](./deployment/deployment-best-practices.md) first, then use this page to confirm specific properties.
 
@@ -344,14 +344,13 @@ These properties are used for upgrades, migration, or legacy compatibility. They
 | `nacos.core.api.compatibility.client.enabled` | Whether client API compatibility is enabled. | `true` |
 | `nacos.core.api.compatibility.admin.enabled` | Whether Admin API compatibility is enabled. | `false` |
 | `nacos.core.api.compatibility.console.enabled` | Whether Console API compatibility is enabled. | `false` |
-| `nacos.config.gray.compatible.model` | Whether Beta/Tag gray-release compatibility and migration to the new gray model is enabled. | `true` |
-| `nacos.gray.migrate.executor.multi` | Thread count for gray config migration. | `8` |
-| `nacos.config.namespace.compatible.mode` | Whether empty namespace IDs are migrated to `public`. | `true` |
-| `nacos.namespace.migrate.retry.times` | Retry count for namespace migration failures. | `3` |
-| `nacos.namespace.migrate.batch.size` | Namespace migration batch size. | `100` |
 
 :::note
 Auth switches and API compatibility switches are different. `nacos.core.auth.admin.enabled` controls whether Admin API authentication is enabled. `nacos.core.api.compatibility.admin.enabled` controls whether Admin API compatibility behavior accepts requests. Legacy v1/v2 HTTP APIs were removed from the main distribution starting from Nacos 3.2.0. Migrate to v3 APIs or temporarily use the legacy adapter.
+:::
+
+:::caution[Nacos 3.3 Config migration switches removed]
+`nacos.config.gray.compatible.model`, `nacos.gray.migrate.executor.multi`, `nacos.config.namespace.compatible.mode`, `nacos.namespace.migrate.retry.times`, and `nacos.namespace.migrate.batch.size` are no longer Nacos 3.3 server properties. Nacos 3.3 no longer automatically migrates pre-3.0 empty-tenant/default-namespace storage and no longer automatically migrates legacy beta/tag gray tables. Affected deployments must migrate the data before upgrading. See the [Upgrading Manual](./upgrading.mdx#217-config-compatibility-migration-removal-nacos-330).
 :::
 
 ## Startup Script and Image Variables

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -12,12 +12,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## 1. Version Upgrade Compatibility
 
-This document corresponds to Nacos 3.2.x. Upgrade compatibility for Nacos 3.2.x is as follows:
+This document corresponds to Nacos 3.3.x. Upgrade compatibility for Nacos 3.3.x is as follows:
 
 | Nacos Version | Upgrade Supported | Remarks |
 |---------------|-------------------|---------|
 | 0.X ~ 1.X | No | 0.X ~ 1.X versions must first be upgraded to 2.0 or above. Please refer to the [Nacos 2.0 Upgrade Guide](https://nacos.io/docs/v2/upgrading/200-upgrading/) to upgrade to 2.0 or 2.1 before proceeding. |
-| 2.0.X ~ 3.2.X | Yes | Upgrading from 2.0.X or later to 3.2.X is supported, but the database schema has changed. Compare the schema file for your target database before upgrading and apply the required schema changes first. |
+| 2.0.X ~ 2.5.X | Conditional | Before upgrading from versions before 3.0 to 3.3.x, read [Config Compatibility Migration Removal](#217-config-compatibility-migration-removal-nacos-330) and complete the pre-upgrade checks. If the old deployment did not use the default namespace and did not use beta gray release, this compatibility removal does not affect smooth upgrade for this compatibility area. |
+| 3.0.X ~ 3.3.X | Yes | Upgrading from 3.0.X or later to 3.3.X is supported, but the database schema has changed. Compare the schema file for your target database before upgrading and apply the required schema changes first. |
 
 ### 1.1 Client Compatibility
 
@@ -44,14 +45,13 @@ If there are schema changes, apply the database alterations first. MySQL example
 -- When upgrading from 2.0.X, execute all SQL statements below. When upgrading from versions later than 2.1.X, execute only the last three lines.
 ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
 ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
-ALTER TABLE `config_info_beta` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
 ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
 ALTER TABLE `his_config_info` ADD COLUMN `publish_type` varchar(50)  DEFAULT 'formal' COMMENT 'publish type gray or formal';
 ALTER TABLE `his_config_info` ADD COLUMN `gray_name` varchar(50)  DEFAULT NULL COMMENT 'gray name';
 ALTER TABLE `his_config_info` ADD COLUMN `ext_info`  longtext DEFAULT NULL COMMENT 'ext info';
 ```
 
-Version 3.2.0 introduces new AI-related tables. The following tables must be created when upgrading to 3.2.X from any previous version:
+Version 3.2.0 introduces new AI-related tables. The following tables must be created when upgrading to 3.3.X from any previous version:
 
 ```SQL
 CREATE TABLE IF NOT EXISTS `pipeline_execution` (
@@ -206,42 +206,28 @@ ${nacos.home}/bin/shutdown.cmd
 ${nacos.home}/bin/startup.cmd
 ```
 
-#### 2.1.7. Config Namespace Migration
+#### 2.1.7. Config Compatibility Migration Removal (Nacos 3.3.0+)
 
-In Nacos 3.0, the `empty namespace` and `public namespace` for the config center have been unified. The namespace with `namespaceId="public"` is now the default namespace, and all config data previously under `namespaceId=""` has been migrated to `namespaceId="public"`. Related [ISSUE](https://github.com/alibaba/nacos/issues/9846).
-
-To enable smooth upgrade and downgrade, Nacos 3.0 enables a config namespace compatibility mode that bidirectionally syncs config data between the `namespaceId="public"` and `namespaceId=""` namespaces, which may have some performance impact. Once the cluster upgrade is complete and running stably, you can disable the compatibility mode. Note that disabling it will remove the ability to smoothly downgrade.
-
-The namespace compatibility mode is `enabled` by default and can be disabled via the `nacos.config.namespace.compatible.mode` configuration.
-
-:::note
-After disabling namespace compatibility mode, smooth downgrade will no longer be possible. Please ensure the cluster is running correctly before disabling it.
+:::caution[Pre-upgrade check for 3.3]
+Starting from Nacos 3.3.0, the server no longer keeps Config migration compatibility logic from versions before 3.0. It no longer automatically migrates or double-writes storage between legacy empty tenant values (`tenant_id = ''`) and the default namespace `public`, and it no longer automatically migrates gray data from the legacy `config_info_beta` and `config_info_tag` tables into the current `config_info_gray` model.
 :::
 
-##### 2.1.7.1. How to Verify Config Namespace Migration is Complete
+This removal only affects historical storage migration compatibility. It does not change current Config semantics:
 
-First, check `logs/startup.log` or `logs/nacos.log` in the Nacos directory for a successful startup log message such as `Nacos started successfully in cluster mode. use xxx storage`.
+- Blank or omitted namespace requests are still normalized to the default namespace. The current default namespace ID is `public`.
+- Current beta/tag gray release APIs remain available and are backed by the `config_info_gray` and `GrayRule` model.
 
-If you see the log `[migrate] config_info namespace migrate insert failed`, it indicates a config data conflict between `namespaceId="public"` and `namespaceId=""` — there are configs with the same `dataId` and `group` but different namespaceIds (`empty` and `public`). Please delete one of the conflicting configs and restart the node.
-If you see `[migrate] config_info_gray namespace migrate insert failed`, it indicates a gray config data conflict — configs with the same `dataId`, `group`, and `grayName` but different namespaceIds. Please delete one of the conflicting gray configs and restart.
+When upgrading from versions before 3.0 to 3.3.x, if the old deployment did not use the default namespace and did not use beta gray release, this compatibility removal does not affect smooth upgrade for this compatibility area. If the old deployment used the default namespace or beta gray release, a fully smooth upgrade is no longer guaranteed. Operators must migrate and verify the affected data before upgrading to 3.3.x.
 
-If neither error appears and you instead see `[migrate] finish migrate config namespacetotal time taken: xxx ms`, it means the namespace migration is complete. After verifying your business configs are working correctly, you can disable the namespace compatibility mode.
+Affected deployments must complete at least these actions:
 
-:::note
-Due to historical reasons, config data with namespaceId `public` can only be published and deleted via Nacos 2.x clients — not through the console or 1.x clients. If you need to delete such config data, please use a 2.x client.
-:::
+1. Check whether the old database has default-namespace config data with `tenant_id = ''`.
+2. Before upgrading to 3.3.x, migrate default-namespace data from the empty tenant to `tenant_id = 'public'`. If rows with the same `data_id` and `group_id` exist under both the empty tenant and `public`, decide which business data to keep before migrating to avoid conflicts.
+3. Check whether the old database has gray data in `config_info_beta` or `config_info_tag`.
+4. Before upgrading to 3.3.x, migrate legacy beta/tag gray data into the current `config_info_gray` model and store the corresponding `grayName` and `GrayRule` metadata according to the current gray rule model.
+5. After migration, use current clients or APIs to verify default-namespace config reads, formal publish, beta gray query, tag gray query, and stopping gray release.
 
-##### 2.1.7.2. Slow First Startup Due to Namespace Migration
-
-During the upgrade, Nacos 3.0 performs a full migration of all configs under the `namespaceId=""` namespace. This may result in a longer startup time when first launching Nacos 3.0, depending on the volume of config data.
-
-During migration, you can observe the following log in `logs/nacos.log`: `[migrate] migrating config namespace from empty to public, finished:xxx`.
-
-Based on testing, with approximately 20,000 configs under `namespaceId=""`, the migration takes about `2 minutes`. This depends on the following configuration and your database's processing capacity:
-```properties
-# Number of configs to migrate per batch. Default is 100. Increasing this value speeds up migration but increases database load.
-nacos.namespace.migrate.batch.size=100
-```
+If you cannot directly confirm the migration format in your own tooling, you can first upgrade to a 3.0.x-3.2.x version that still contains this compatibility migration capability, complete the migration, run stably, verify the data, and then upgrade to 3.3.x.
 
 #### 2.1.8. Migrate MCP Services (Optional)
 

--- a/src/content/docs/next/en/manual/user/config/gray-release.md
+++ b/src/content/docs/next/en/manual/user/config/gray-release.md
@@ -31,6 +31,14 @@ One config can have multiple gray versions. Runtime query evaluates gray rules f
 
 By default, a config can have up to `10` gray versions. You can adjust this with `nacos.config.gray.version.max.count`.
 
+## Upgrade Compatibility
+
+Current beta and tag gray release behavior is backed by `config_info_gray` and `GrayRule`. Starting with Nacos 3.3, Nacos no longer automatically migrates legacy `config_info_beta` and `config_info_tag` tables from versions before 3.0 into `config_info_gray`.
+
+If you upgrade from a version before 3.0 to 3.3 and the old deployment used beta gray release, migrate the legacy beta/tag gray data to the current `config_info_gray` gray model before upgrading. If the old deployment did not use beta gray release, this compatibility removal does not affect smooth upgrade for this gray compatibility area.
+
+This change does not remove current beta/tag gray APIs. Publishing, querying, and stopping gray release with `betaIps` or `tag` still work through the current gray model.
+
 ## Query Behavior
 
 Gray query follows these rules:

--- a/src/content/docs/next/en/plugin/config-encryption-plugin.md
+++ b/src/content/docs/next/en/plugin/config-encryption-plugin.md
@@ -41,11 +41,10 @@ If `dataId` starts with `cipher-` but the matching plugin is not loaded on the s
 Configuration encryption depends on the `encrypted_data_key` column. The current default schemas already include this column in:
 
 - `config_info`
-- `config_info_beta`
 - `config_info_gray`
 - `his_config_info`
 
-When upgrading from an older version, compare the schema of your current Nacos version first and add the missing columns before the upgrade. Column types differ across databases, so prefer the schema shipped with the target Nacos version.
+When upgrading from an older version, compare the schema of your current Nacos version first and add the missing columns before the upgrade. Column types differ across databases, so prefer the schema shipped with the target Nacos version. The current Nacos 3.3 schema no longer includes legacy `config_info_beta` or `config_info_tag` tables. If the old deployment still has beta/tag gray data, migrate it to the current `config_info_gray` gray model before upgrading.
 
 ## AES Plugin
 
@@ -67,7 +66,6 @@ For existing clusters, check whether `encrypted_data_key` exists. MySQL example:
 
 ```sql
 ALTER TABLE config_info ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
-ALTER TABLE config_info_beta ADD COLUMN `encrypted_data_key` varchar(256) NOT NULL DEFAULT '' COMMENT 'encrypted_data_key';
 ALTER TABLE config_info_gray ADD COLUMN `encrypted_data_key` varchar(256) NOT NULL DEFAULT '' COMMENT 'encrypted_data_key';
 ALTER TABLE his_config_info ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
 ```

--- a/src/content/docs/next/en/plugin/datasource-plugin.md
+++ b/src/content/docs/next/en/plugin/datasource-plugin.md
@@ -136,10 +136,11 @@ The dialect and mappers for the same database type must be packaged and loaded t
 
 Current mapper coverage includes:
 
-- Config tables: `config_info`, `config_info_beta`, `config_info_gray`, `config_info_tag`, `config_tags_relation`, `his_config_info`;
+- Config tables: `config_info`, `config_info_gray`, `config_tags_relation`, `his_config_info`;
 - Capacity and namespace tables: `tenant_info`, `tenant_capacity`, `group_capacity`;
-- Config migration queries;
 - AI resource tables: `ai_resource`, `ai_resource_version`.
+
+Starting with Nacos 3.3, current mappers no longer include Config migration queries for versions before 3.0 and no longer include legacy `config_info_beta` or `config_info_tag` table mappers. Deployments that still have this legacy data must migrate beta/tag gray data into the current `config_info_gray` gray model before upgrading to 3.3.
 
 Use the official `derby`, `mysql`, `postgresql`, and `oracle` modules as references. Register plugin implementations under `META-INF/services`:
 

--- a/src/content/docs/next/zh-cn/manual/admin/compatibility-and-deprecation.md
+++ b/src/content/docs/next/zh-cn/manual/admin/compatibility-and-deprecation.md
@@ -26,12 +26,20 @@ Nacos 会在版本演进中保留一部分兼容能力，帮助用户完成升�
 | --- | --- | --- |
 | v1/v2 HTTP API | 迁移到 v3 OpenAPI 或当前 SDK。确有迁移窗口需求时，临时使用 legacy adapter。 | [升级手册](./upgrading.mdx)、[OpenAPI 概览](../user/overview/api-overview.md) |
 | 兼容开关 | 只在升级或迁移窗口期打开。稳定后关闭。 | [系统参数](./system-configurations.md) |
-| Beta/Tag 灰度配置兼容 | 升级时打开兼容和迁移配置，稳定后使用新版灰度模型。 | [升级手册](./upgrading.mdx)、[系统参数](./system-configurations.md) |
-| 默认命名空间迁移 | 关注空命名空间到 `public` 的迁移行为。 | [升级手册](./upgrading.mdx)、[Java SDK 使用手册](../user/java-sdk/usage.md#13-升级兼容性) |
+| Beta/Tag 灰度配置兼容 | Nacos 3.3 起不再自动迁移旧 `config_info_beta`、`config_info_tag` 表，升级前需迁移到 `config_info_gray` 当前灰度模型。当前 beta/tag API 仍由 `config_info_gray` 和 `GrayRule` 支撑。 | [升级手册](./upgrading.mdx)、[配置灰度发布](../user/config/gray-release.md) |
+| 默认命名空间迁移 | Nacos 3.3 起不再自动在空 tenant 与 `public` 之间做存储迁移或双写。空或省略 namespace 请求仍会归一为默认 namespace `public`。 | [升级手册](./upgrading.mdx)、[Java SDK 使用手册](../user/java-sdk/usage.md#13-升级兼容性) |
 | 旧控制台 | 仅用于兼容存量使用习惯。新部署使用新控制台。 | [控制台手册](./console.md#旧控制台) |
 | Java SDK 已废弃配置项 | 不在新系统中继续使用。 | [Java SDK 属性配置](../user/java-sdk/properties.md) |
 | CLI 已废弃命令 | 使用显式生命周期命令替代快捷 publish 命令。 | [Nacos CLI 使用指南](./nacos-cli.md) |
 | 实验性功能 | 只在明确接受变更风险后使用。 | [实验性功能概览](../../experimental/overview.md) |
+
+## Nacos 3.3 配置兼容迁移移除
+
+Nacos 3.3 移除了 Config 3.0 之前的运行时兼容迁移逻辑，包括默认 namespace 在 legacy 空 tenant 与 `public` 之间的存储迁移、旧 `config_info_beta`/`config_info_tag` 到 `config_info_gray` 的迁移，以及相关双写和混部同步逻辑。
+
+从 3.0 之前版本升级到 3.3 时，如果旧部署未使用默认 namespace，且未使用 beta 灰度发布，则本次兼容迁移移除不影响该兼容领域的平滑升级。若使用过默认 namespace 或 beta 灰度发布，则升级到 3.3 前需要自行完成数据迁移：将默认 namespace 数据从空 tenant 迁移到 `public`，并将旧 beta/tag 灰度数据迁移到 `config_info_gray` 当前灰度模型。
+
+这不是移除当前默认 namespace 语义，也不是移除当前 beta/tag 灰度 API。空或省略 namespace 请求仍归一为 `public`；当前 beta/tag 灰度行为仍由 `config_info_gray` 和 `GrayRule` 支撑。
 
 ## 使用兼容能力时要确认什么
 

--- a/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
@@ -8,7 +8,7 @@ sidebar:
 
 # 系统参数
 
-本文整理 Nacos 3.2.x 常用服务端参数。主要来源是发行包中的 `${nacos.home}/conf/application.properties`，并结合当前代码中的配置读取逻辑补充说明。
+本文整理 Nacos 3.3.x 常用服务端参数。主要来源是发行包中的 `${nacos.home}/conf/application.properties`，并结合当前代码中的配置读取逻辑补充说明。
 
 如果你正在部署生产集群，建议先阅读[部署最佳实践](./deployment/deployment-best-practices.md)，再回到本文确认具体参数。
 
@@ -344,14 +344,13 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 | `nacos.core.api.compatibility.client.enabled` | 是否开启客户端 API 兼容能力。 | `true` |
 | `nacos.core.api.compatibility.admin.enabled` | 是否开启 Admin API 兼容能力。 | `false` |
 | `nacos.core.api.compatibility.console.enabled` | 是否开启 Console API 兼容能力。 | `false` |
-| `nacos.config.gray.compatible.model` | 是否开启 Beta/Tag 灰度配置向新版灰度模型的兼容与迁移。 | `true` |
-| `nacos.gray.migrate.executor.multi` | 灰度配置迁移线程数。 | `8` |
-| `nacos.config.namespace.compatible.mode` | 是否开启空命名空间到 `public` 命名空间的兼容迁移。 | `true` |
-| `nacos.namespace.migrate.retry.times` | 命名空间迁移失败重试次数。 | `3` |
-| `nacos.namespace.migrate.batch.size` | 命名空间迁移批大小。 | `100` |
 
 :::note
 鉴权开关和 API 兼容开关不是同一类参数。`nacos.core.auth.admin.enabled` 控制 Admin API 是否鉴权；`nacos.core.api.compatibility.admin.enabled` 控制 Admin API 兼容行为是否接受请求。旧版 v1/v2 HTTP API 从 Nacos 3.2.0 起已从主发行包移除，需要迁移到 v3 API 或临时使用 legacy adapter。
+:::
+
+:::caution[Nacos 3.3 配置迁移开关移除]
+`nacos.config.gray.compatible.model`、`nacos.gray.migrate.executor.multi`、`nacos.config.namespace.compatible.mode`、`nacos.namespace.migrate.retry.times` 和 `nacos.namespace.migrate.batch.size` 已不再是 Nacos 3.3 服务端参数。3.3 不再自动迁移 3.0 之前的空 tenant/default namespace 存储，也不再自动迁移旧 beta/tag 灰度表。受影响部署需要在升级前自行完成数据迁移，详见[升级手册](./upgrading.mdx#217-配置中心兼容迁移移除-nacos-330)。
 :::
 
 ## 启动脚本和镜像变量

--- a/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
@@ -12,12 +12,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## 1. 升级版本兼容性
 
-当前文档所对应的版本为 3.2.x，所有 Nacos 版本升级到 3.2.x 的兼容性如下：
+当前文档所对应的版本为 3.3.x，所有 Nacos 版本升级到 3.3.x 的兼容性如下：
 
 | Nacos版本 | 是否支持升级到当前版本 | 备注 |
 |----------|--------------------|------|
 | 0.X ～ 1.X | 不支持 | 0.X ~ 1.X 版本需要先升级到2.0以上的版本，请参考[Nacos2.0升级文档](https://nacos.io/docs/v2/upgrading/200-upgrading/) 先升级到2.0或2.1版本后再进行升级 |
-| 2.0.X ~ 3.2.X | 支持 | 3.2.X 版本支持从 2.0.X 及以上版本升级到 3.2.X，但数据库表结构有发生变化，请升级前对比目标版本对应数据库的 schema 文件，并应用新的表结构后进行升级 |
+| 2.0.X ~ 2.5.X | 有条件支持 | 3.0 之前版本升级到 3.3.x 时，请先阅读[配置中心兼容迁移移除](#217-配置中心兼容迁移移除-nacos-330)并完成前置检查。若旧部署未使用默认 namespace，且未使用 beta 灰度发布，则本次兼容迁移移除不影响该兼容领域的平滑升级。 |
+| 3.0.X ~ 3.3.X | 支持 | 3.3.X 版本支持从 3.0.X 及以上版本升级到 3.3.X，但数据库表结构有发生变化，请升级前对比目标版本对应数据库的 schema 文件，并应用新的表结构后进行升级 |
 
 ### 1.1 客户端兼容性
 
@@ -44,14 +45,13 @@ Nacos 3.x 服务端与各版本客户端的兼容性如下：
 -- 从 2.0.X 升级时需要执行下列所有SQL, 从2.1.X之后版本升级仅需执行最后三行。
 ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
 ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `config_info_beta` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
 ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
 ALTER TABLE `his_config_info` ADD COLUMN `publish_type` varchar(50)  DEFAULT 'formal' COMMENT 'publish type gray or formal';
 ALTER TABLE `his_config_info` ADD COLUMN `gray_name` varchar(50)  DEFAULT NULL COMMENT 'gray name';
 ALTER TABLE `his_config_info` ADD COLUMN `ext_info`  longtext DEFAULT NULL COMMENT 'ext info';
 ```
 
-3.2.0 版本新增了AI相关的表，所有版本升级到 3.2.X 均需创建以下表：
+3.2.0 版本新增了AI相关的表，所有版本升级到 3.3.X 均需创建以下表：
 
 ```SQL
 CREATE TABLE IF NOT EXISTS `pipeline_execution` (
@@ -206,42 +206,28 @@ ${nacos.home}/bin/shutdown.cmd
 ${nacos.home}/bin/startup.cmd
 ```
 
-#### 2.1.7. 配置中心命名空间迁移
+#### 2.1.7. 配置中心兼容迁移移除 (Nacos 3.3.0+)
 
-Nacos 3.0 中对于配置中心的`空命名空间`和`public命名空间`进行了统一，将`namespaceId="public"`的命名空间作为默认命名空间，并将原先`namespaceId=""`的命名空间的配置数据全部统一到`namespaceId="public"`的命名空间中。 相关[ISSUE](https://github.com/alibaba/nacos/issues/9846)。
-
-为了能够完成平滑升降级，Nacos 3.0 将会开启配置中心命名空间兼容模式，将`namespaceId="public"`的命名空间和`namespaceId=""`的命名空间的配置数据进行双向同步，因此会对性能有一定影响。当集群升级并稳定运行后，可以关闭配置中心命名空间兼容模式，关闭兼容模式后将会失去平滑降级的功能。
-
-命名空间的兼容模式默认为`开启`状态，可以通过`nacos.config.namespace.compatible.mode`配置项关闭。
-
-:::note
-注意，关闭命名空间兼容模式后无法再进行平滑降级，请先确认关闭前集群正确运行。
+:::caution[3.3 升级前置检查]
+从 Nacos 3.3.0 起，服务端不再保留 Config 3.0 之前兼容迁移逻辑，不再自动在 legacy 空 tenant（`tenant_id = ''`）与默认 namespace `public` 之间做存储迁移或双写，也不再自动将旧 `config_info_beta`、`config_info_tag` 表中的灰度数据迁移到当前 `config_info_gray` 模型。
 :::
 
-##### 2.1.7.1. 如何确认配置命名空间迁移已经完成
+这项移除只影响历史存储兼容迁移，不改变当前配置中心语义：
 
-首先查看nacos目录下 `logs/startup.log`或`logs/nacos.log` 观察到nacos启动成功的日志，如 `Nacos started successfully in cluster mode. use xxx storage` 说明程序已启动成功。
+- 空或省略的 namespace 请求仍会归一化为默认 namespace，当前默认 namespace ID 为 `public`。
+- 当前 beta/tag 灰度发布 API 仍可使用，实际由 `config_info_gray` 和 `GrayRule` 模型支撑。
 
-如果观察到`[migrate] config_info namespace migrate insert failed` 日志，则说明数据库中`namespaceId="public"`的命名空间和`namespaceId=""`的命名空间下存在配置数据冲突的情况，即存在`dataId`、`group`相同，但是namespaceId分别为`空`和`public`的两份配置，请删除其中一份配置数据后再尝试启动节点。
-如果观察到`[migrate] config_info_gray namespace migrate insert failed`日志，则说明数据库中`namespaceId="public"`的命名空间和`namespaceId=""`的命名空间下存在灰度配置数据冲突的情况，即存在`dataId`、`group`、`grayName`相同，但是namespaceId分别为`空`和`public`的两份配置，请删除其中一份灰度配置数据后再尝试启动节点。
+从 3.0 之前版本升级到 3.3.x 时，如果旧部署未使用默认 namespace，且未使用 beta 灰度发布，则本次兼容迁移移除不影响该兼容领域的平滑升级。如果旧部署使用过默认 namespace 或 beta 灰度发布，则不再保证完全平滑升级，需要在升级到 3.3.x 前自行完成数据迁移和验证。
 
-如果没有观察到上述两个错误信息，而是`[migrate] finish migrate config namespacetotal time taken: xxx ms` 那么说明此时配置命名空间迁移已经完成，再进行业务配置使用验证无误后，可以关闭命名空间兼容模式。
+受影响部署至少需要完成以下操作：
 
-:::note
-注意，由于历史遗留问题，命名空间Id为`public`的配置数据只能通过Nacos 2.x客户端进行发布和删除操作，无法通过控制台和1.x客户端进行，如果需要删除对应的配置数据，请通过2.x客户端进行。
-:::
+1. 检查旧数据库中是否存在 `tenant_id = ''` 的默认 namespace 配置数据。
+2. 在升级到 3.3.x 前，将默认 namespace 数据从空 tenant 迁移到 `tenant_id = 'public'`。如果同一 `data_id`、`group_id` 下同时存在空 tenant 和 `public` 记录，请先确认保留哪一份业务数据，避免迁移后产生冲突。
+3. 检查旧数据库中是否存在 `config_info_beta` 或 `config_info_tag` 灰度数据。
+4. 在升级到 3.3.x 前，将旧 beta/tag 灰度数据迁移到当前 `config_info_gray` 模型，并按当前灰度规则保存对应 `grayName` 和 `GrayRule` 元数据。
+5. 迁移后使用当前客户端或 API 验证默认 namespace 配置读取、正式发布、beta 灰度查询、tag 灰度查询和停止灰度等关键路径。
 
-##### 2.1.7.2. 配置命名空间迁移导致首次启动较慢
-
-在升级过程中，Nacos 3.0会对配置中的`namespaceId=""`的命名空间下存在配置进行全量迁移，因此升级过程中，首次启动Nacos 3.0版本时，可能会存在较长的启动时间，具体时间由配置数据量决定。
-
-迁移过程中，您可以从`logs/nacos.log`日志中观察到如下日志`[migrate] migrating config namespace from empty to public, finished:xxx`.
-
-根据测试 配置`namespaceId=""`的命名空间下若存在 20000个左右配置时， 迁移过程会在`2分钟`左右结束， 这依赖于如下配置及数据库的处理能力大小：
-```properties
-# 迁移时，每批迁移的配置数量，默认100，增加此值可提高迁移速度，但也会随之增加对数据库的压力。
-nacos.namespace.migrate.batch.size=100
-```
+如果无法在业务侧直接确认迁移格式，可以先升级到仍包含该兼容迁移能力的 3.0.x～3.2.x 版本，完成迁移、稳定运行并验证数据后，再升级到 3.3.x。
 
 #### 2.1.8. 迁移MCP服务（可选）
 

--- a/src/content/docs/next/zh-cn/manual/user/config/gray-release.md
+++ b/src/content/docs/next/zh-cn/manual/user/config/gray-release.md
@@ -31,6 +31,14 @@ Nacos 当前内置两类常用规则：
 
 默认最多允许 `10` 个灰度版本，可通过 `nacos.config.gray.version.max.count` 调整。
 
+## 升级兼容说明
+
+当前 beta 和 tag 灰度发布行为由 `config_info_gray` 与 `GrayRule` 支撑。Nacos 3.3 起不再自动将 3.0 之前的旧 `config_info_beta`、`config_info_tag` 表迁移到 `config_info_gray`。
+
+如果从 3.0 之前版本升级到 3.3，且旧部署使用过 beta 灰度发布，需要在升级前自行将旧 beta/tag 灰度数据迁移到当前 `config_info_gray` 灰度模型。若旧部署未使用 beta 灰度发布，则本次兼容迁移移除不影响该灰度兼容领域的平滑升级。
+
+这项变化不是移除当前 beta/tag 灰度 API。携带 `betaIps` 或 `tag` 的发布、查询与停止灰度流程仍按当前灰度模型工作。
+
 ## 查询行为
 
 灰度查询遵循以下原则：

--- a/src/content/docs/next/zh-cn/plugin/config-encryption-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/config-encryption-plugin.md
@@ -41,11 +41,10 @@ cipher-aes-application-prod.yaml
 配置加密依赖 `encrypted_data_key` 字段。当前默认 schema 已包含该字段，涉及表包括：
 
 - `config_info`
-- `config_info_beta`
 - `config_info_gray`
 - `his_config_info`
 
-如果从较早版本升级，请先对比当前版本对应数据库的 schema，并在升级前补齐字段。不同数据库的字段类型可能不同，请优先使用当前版本发布包或源码中的 schema。
+如果从较早版本升级，请先对比当前版本对应数据库的 schema，并在升级前补齐字段。不同数据库的字段类型可能不同，请优先使用当前版本发布包或源码中的 schema。Nacos 3.3 当前 schema 不再包含旧 `config_info_beta`、`config_info_tag` 表；如果旧部署仍有 beta/tag 灰度数据，请在升级前迁移到 `config_info_gray` 当前灰度模型。
 
 ## AES 插件
 
@@ -67,7 +66,6 @@ nacos-encryption-plugin-ext/nacos-aes-encryption-plugin
 
 ```sql
 ALTER TABLE config_info ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE config_info_beta ADD COLUMN `encrypted_data_key` varchar(256) NOT NULL DEFAULT '' COMMENT 'encrypted_data_key';
 ALTER TABLE config_info_gray ADD COLUMN `encrypted_data_key` varchar(256) NOT NULL DEFAULT '' COMMENT 'encrypted_data_key';
 ALTER TABLE his_config_info ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
 ```

--- a/src/content/docs/next/zh-cn/plugin/datasource-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/datasource-plugin.md
@@ -136,10 +136,11 @@ db.password.1=nacos_password_1
 
 当前 mapper 覆盖范围包括：
 
-- 配置表：`config_info`、`config_info_beta`、`config_info_gray`、`config_info_tag`、`config_tags_relation`、`his_config_info`；
+- 配置表：`config_info`、`config_info_gray`、`config_tags_relation`、`his_config_info`；
 - 容量和命名空间表：`tenant_info`、`tenant_capacity`、`group_capacity`；
-- 配置迁移查询；
 - AI 资源表：`ai_resource`、`ai_resource_version`。
+
+Nacos 3.3 起当前 mapper 不再包含 Config 3.0 之前兼容迁移查询，也不再包含旧 `config_info_beta`、`config_info_tag` 表 mapper。仍保留这类旧数据的部署，应在升级到 3.3 前将 beta/tag 灰度数据迁移到 `config_info_gray` 当前灰度模型。
 
 开发时可以参考官方默认实现中的 `derby`、`mysql`、`postgresql` 和 `oracle` 模块。插件需要在 `META-INF/services` 下注册：
 


### PR DESCRIPTION
### What changed
- Add Nacos 3.3 upgrade guidance for the removed Config pre-3.0 compatibility migration logic.
- Document safe smooth-upgrade conditions and required pre-upgrade operator actions for affected default namespace and beta/tag gray data.
- Update next compatibility, gray release, system configuration, datasource plugin, and config encryption plugin docs in both Chinese and English.
- Clarify that current default namespace normalization and current beta/tag gray APIs remain supported by the current model.

### Validation
- git diff --check
- npm run build: Astro static generation completed for the changed next pages; the full build still exits in the existing Pagefind/sitemap post-build step.

Related to alibaba/nacos#15322