### PR TITLE
docs: update skill list front matter response

### DIFF
--- a/src/content/docs/next/en/manual/user/ai/skill-registry.md
+++ b/src/content/docs/next/en/manual/user/ai/skill-registry.md
@@ -187,7 +187,7 @@ The list page displays all Skills in card format with the following features:
 
 - **Search**: Search by Skill name keyword
 - **Sort**: Sort by default order or download count
-- **Card Info**: Displays name, description, business tags, online version count, draft status, download count, and update time
+- **Card Info**: Displays name, description, business tags, online version count, draft status, download count, and update time; the list API also returns `frontMatter` parsed from the display version's `SKILL.md`, which can be used to show custom metadata such as `alias`
 - **Batch Operations**: Multi-select for batch deletion
 - **Quick Actions**: Upload ZIP, create new Skill
 
@@ -258,6 +258,8 @@ Skill Registry provides three layers of REST APIs:
 | **Client API** | Client runtime query/download Skills (supports anonymous access) | [Client API - Download Skill](../open-api.md) |
 | **Console API** | Console operations (requires login authentication) | [Console API - Skills](../../admin/console-api.md) |
 | **Admin API** | Cluster internal management interface | [Admin API - AI Skills](../../admin/admin-api.md) |
+
+For Skill list queries, each response item contains a `frontMatter` field with key-value pairs parsed from the display version's `SKILL.md` YAML front matter. This field may be empty when the version is unavailable, `SKILL.md` has no front matter, or parsing fails.
 
 ### 4.3. Java SDK
 

--- a/src/content/docs/next/zh-cn/manual/user/ai/skill-registry.md
+++ b/src/content/docs/next/zh-cn/manual/user/ai/skill-registry.md
@@ -187,7 +187,7 @@ Nacos 控制台提供了完整的 Skill 管理界面，位于 **AI 注册中心 
 
 - **搜索**：按 Skill 名称关键字搜索
 - **排序**：支持按默认排序或下载量排序
-- **卡片信息**：显示名称、描述、业务标签、在线版本数、是否有草稿、下载量、更新时间
+- **卡片信息**：显示名称、描述、业务标签、在线版本数、是否有草稿、下载量、更新时间；列表接口同时返回展示版本 `SKILL.md` 中解析出的 `frontMatter`，可用于展示 `alias` 等自定义元数据
 - **批量操作**：支持多选后批量删除
 - **快捷入口**：上传 ZIP、创建新 Skill
 
@@ -258,6 +258,8 @@ Skill 管理提供三层 REST API：
 | **Client API** | 客户端运行时查询/下载 Skill（支持匿名访问） | [客户端API - 下载 Skill](../open-api.md#34-下载-skill) |
 | **Console API** | 控制台管理操作（需登录认证） | [控制台API - Skills 管理](../../admin/console-api.md#7-skills-管理) |
 | **Admin API** | 集群内部管理接口 | [运维API - AI Skills 管理](../../admin/admin-api.md#7-ai-skills-管理) |
+
+其中，Skill 列表查询的返回项包含 `frontMatter` 字段，内容为展示版本 `SKILL.md` YAML front matter 解析后的键值对；当对应版本不存在、`SKILL.md` 无 front matter 或解析失败时，该字段可能为空。
 
 ### 4.3. Java SDK
 


### PR DESCRIPTION
## What is the purpose of the change

Update Skill Registry documentation for alibaba/nacos#15345.

The Nacos Skill list response now includes `frontMatter` parsed from the display version's `SKILL.md`, so the documentation should describe this response field for users and console/API consumers.

## Brief changelog

- Document that Skill list response items include `frontMatter`.
- Explain that `frontMatter` is parsed from the display version's `SKILL.md` YAML front matter.
- Update both Chinese and English Skill Registry docs.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `npm run build`, and make sure it works as expected.
- [x] Make sure no files under build directory is added.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).