### PR TITLE
docs: add grpc port offset client property

### DIFF
--- a/src/content/docs/next/en/manual/user/java-sdk/properties.md
+++ b/src/content/docs/next/en/manual/user/java-sdk/properties.md
@@ -180,8 +180,7 @@ When the Nacos Java SDK connects to Nacos Server, you can configure a set of par
 
 | Parameter                                                       | Meaning                                                                            | Optional Values | Default Value |
 |-----------------------------------------------------------------|------------------------------------------------------------------------------------|---------|---------------|
-| nacos.server.grpc.port.offset                                   | The offset of the Nacos Server gRPC port relative to the main port.                           | Any int value | 1000 |
-| grpc.port.offset                                                | The offset of the Nacos Server gRPC port relative to the main port when set through user-defined `Properties`. It has higher priority than `nacos.server.grpc.port.offset` and is suitable when different Java SDK instances need different offsets. | Any int value | 1000 |
+| nacos.server.grpc.port.offset                                   | The offset of the Nacos Server gRPC port relative to the main port. It can be set in each Java SDK client's `Properties` when different client instances need different offsets. | Any int value | 1000 |
 | nacos.remote.client.grpc.name                                   | The name of the gRPC connection for this Nacos Java SDK.                                      | Any string | null |
 | nacos.remote.client.grpc.connect.keep.alive                     | The keep-alive interval of the gRPC connection for this Nacos Java SDK.                       | Any long value | 5000 |
 | nacos.remote.client.grpc.retry.times                            | The maximum retry count when the gRPC connection of this Nacos Java SDK initiates a request.  | Any int value | 3 |

--- a/src/content/docs/next/en/manual/user/java-sdk/properties.md
+++ b/src/content/docs/next/en/manual/user/java-sdk/properties.md
@@ -181,6 +181,7 @@ When the Nacos Java SDK connects to Nacos Server, you can configure a set of par
 | Parameter                                                       | Meaning                                                                            | Optional Values | Default Value |
 |-----------------------------------------------------------------|------------------------------------------------------------------------------------|---------|---------------|
 | nacos.server.grpc.port.offset                                   | The offset of the Nacos Server gRPC port relative to the main port.                           | Any int value | 1000 |
+| grpc.port.offset                                                | The offset of the Nacos Server gRPC port relative to the main port when set through user-defined `Properties`. It has higher priority than `nacos.server.grpc.port.offset` and is suitable when different Java SDK instances need different offsets. | Any int value | 1000 |
 | nacos.remote.client.grpc.name                                   | The name of the gRPC connection for this Nacos Java SDK.                                      | Any string | null |
 | nacos.remote.client.grpc.connect.keep.alive                     | The keep-alive interval of the gRPC connection for this Nacos Java SDK.                       | Any long value | 5000 |
 | nacos.remote.client.grpc.retry.times                            | The maximum retry count when the gRPC connection of this Nacos Java SDK initiates a request.  | Any int value | 3 |

--- a/src/content/docs/next/zh-cn/manual/user/java-sdk/properties.md
+++ b/src/content/docs/next/zh-cn/manual/user/java-sdk/properties.md
@@ -188,6 +188,7 @@ Nacos Java SDK 连接Nacos Server时，可以设置一系列的参数，来提�
 | 参数名                                                             | 含义                                                                                 | 可选值     | 默认值           | 
 |-----------------------------------------------------------------|------------------------------------------------------------------------------------|---------|---------------|
 | nacos.server.grpc.port.offset                                   | Nacos Server GRPC端口相对主端口的偏移量                                                       | 任意int值  | 1000          |
+| grpc.port.offset                                                | 通过用户自定义 `Properties` 设置的 Nacos Server GRPC 端口相对主端口的偏移量，优先级高于 `nacos.server.grpc.port.offset`，适用于不同 Java SDK 实例需要使用不同偏移量的场景 | 任意int值  | 1000          |
 | nacos.remote.client.grpc.name                                   | 该Nacos Java SDK的GRPC连接的名字                                                          | 任意字符串   | null          |
 | nacos.remote.client.grpc.connect.keep.alive                     | 该Nacos Java SDK的GRPC连接的Keep Alive                                                  | 任意Long值 | 5000          |
 | nacos.remote.client.grpc.retry.times                            | 该Nacos Java SDK的GRPC连接发起请求时的最大重试次数                                                 | 任意int值  | 3             |

--- a/src/content/docs/next/zh-cn/manual/user/java-sdk/properties.md
+++ b/src/content/docs/next/zh-cn/manual/user/java-sdk/properties.md
@@ -187,8 +187,7 @@ Nacos Java SDK 连接Nacos Server时，可以设置一系列的参数，来提�
 
 | 参数名                                                             | 含义                                                                                 | 可选值     | 默认值           | 
 |-----------------------------------------------------------------|------------------------------------------------------------------------------------|---------|---------------|
-| nacos.server.grpc.port.offset                                   | Nacos Server GRPC端口相对主端口的偏移量                                                       | 任意int值  | 1000          |
-| grpc.port.offset                                                | 通过用户自定义 `Properties` 设置的 Nacos Server GRPC 端口相对主端口的偏移量，优先级高于 `nacos.server.grpc.port.offset`，适用于不同 Java SDK 实例需要使用不同偏移量的场景 | 任意int值  | 1000          |
+| nacos.server.grpc.port.offset                                   | Nacos Server GRPC端口相对主端口的偏移量。不同 Java SDK 实例需要使用不同偏移量时，可以在各自客户端的 `Properties` 中设置该参数 | 任意int值  | 1000          |
 | nacos.remote.client.grpc.name                                   | 该Nacos Java SDK的GRPC连接的名字                                                          | 任意字符串   | null          |
 | nacos.remote.client.grpc.connect.keep.alive                     | 该Nacos Java SDK的GRPC连接的Keep Alive                                                  | 任意Long值 | 5000          |
 | nacos.remote.client.grpc.retry.times                            | 该Nacos Java SDK的GRPC连接发起请求时的最大重试次数                                                 | 任意int值  | 3             |


### PR DESCRIPTION
## What is the purpose of the change

Update Java SDK configuration documentation for alibaba/nacos#15507.

The Nacos Java SDK now supports setting the gRPC port offset through the user-defined `Properties` key `grpc.port.offset`, which allows different SDK instances to use different gRPC port offsets.

## Brief changelog

- Add `grpc.port.offset` to Chinese and English Java SDK configuration docs.
- Explain that it has higher priority than `nacos.server.grpc.port.offset`.
- Document that it is suitable for per-SDK-instance gRPC port offset configuration.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Test your code locally by running `npm run build`, and make sure it works as expected.
- [x] Make sure no files under build directory is added.