### PR TITLE
[ISSUE #15495] Document microservice function mode

### DIFF
--- a/src/content/docs/latest/en/manual/admin/deployment/deployment-overview.md
+++ b/src/content/docs/latest/en/manual/admin/deployment/deployment-overview.md
@@ -66,7 +66,33 @@ For deployment details, see [Cluster Deployment](./deployment-cluster.md).
 
 Nacos supports NameServer-based request routing. With this mode, you can design mapping rules to forward requests to the corresponding cluster, such as routing requests by namespace or tenant.
 
-## 3. Independent Nacos Console Deployment
+## 3. Select Modules by Function Mode
+
+The deployment mode determines the Nacos node topology and high-availability model. The function mode determines which business modules a node loads at runtime. These two settings can be combined.
+
+Starting with Nacos 3.2.2, use the `microservice` function mode when you need only configuration management and service discovery. This mode loads only the Config and Naming modules and does not load the AI module. As a result, AI Registry capabilities for resources such as MCP Servers, Skills, Prompts, Agents, and AgentSpecs, together with their console entries, are unavailable.
+
+For standalone mode, run:
+
+```shell
+sh startup.sh -m standalone -f microservice
+```
+
+For cluster mode, use the same function mode on every node:
+
+```shell
+sh startup.sh -f microservice
+```
+
+:::note
+The function mode controls only which modules are loaded at runtime. It still uses the standard Nacos distribution and does not remove AI-related JARs from the package. When you use `-f microservice`, you do not also need to set `nacos.extension.ai.enabled=false`.
+
+For Nacos 3.2.0, Nacos 3.2.1, or a deployment method that cannot pass the `-f` option, set `nacos.extension.ai.enabled=false` in `${nacos.home}/conf/application.properties` to disable the AI module while keeping the Config and Naming modules enabled.
+:::
+
+For the complete function-mode and property reference, see [System Parameters](../system-configurations.md#basic-startup-parameters).
+
+## 4. Independent Nacos Console Deployment
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
@@ -80,7 +106,7 @@ For independent console deployment details, see [Independent Console Deployment]
 
 Before going to production, continue with [Deployment Best Practices](./deployment-best-practices.md) to check internal network boundaries, independent console deployment, external database storage, authentication, visibility, traffic control, configuration encryption, and rollback plans.
 
-## 4. Multi-NIC IP Selection
+## 5. Multi-NIC IP Selection
 
 When the local environment is complex, Nacos needs to select the IP address or network interface card to use at startup. Nacos obtains IP addresses from multiple NICs by referring to the Spring Cloud design. You can use `nacos.inetutils` parameters to specify the NIC and IP address used by Nacos. The following configuration parameters are supported:
 

--- a/src/content/docs/latest/en/manual/admin/system-configurations.md
+++ b/src/content/docs/latest/en/manual/admin/system-configurations.md
@@ -32,7 +32,7 @@ Nacos is an internal microservice component and should not be exposed to the pub
 | --- | --- | --- |
 | `nacos.home(-D)` | Nacos home directory. | installation directory |
 | `nacos.standalone(-D)` | Whether to start in standalone mode. `startup.sh -m standalone` sets this property. | `false` |
-| `nacos.functionMode(-D)` | Function mode. `all` starts all modules. The startup script also supports `config`, `naming`, `microservice`, and `ai`. | `all` |
+| `nacos.functionMode(-D)` | Function mode. `all` starts all available modules; `config` and `naming` start only Config and Naming, respectively; `microservice` starts Config and Naming without the AI module; `ai` starts AI together with its Config and Naming dependencies. | `all` |
 | `nacos.deployment.type(-D)` | Deployment type. The startup script uses `merged` by default. | `merged` |
 | `nacos.server.main.port` | Main Nacos Server port. | `8848` |
 | `nacos.server.contextPath` | HTTP context path of Nacos Server. | `/nacos` |
@@ -305,7 +305,7 @@ For usage, see [AI Registry Overview](../user/ai/ai-registry-overview.md). The p
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `nacos.extension.ai.enabled` | Whether the AI module is enabled. The AI module requires both config and naming modules. | `true` |
+| `nacos.extension.ai.enabled` | Whether the AI module is enabled. When set to `false`, the AI module and its console entries are not loaded, while Config and Naming remain available. The `microservice` function mode does not load the AI module regardless of this value. | `true` |
 | `nacos.ai.mcp.registry.enabled` | Whether the official MCP Registry protocol adapter is enabled. When enabled, it exposes an independent port through `nacos.ai.registry.port`. | `false` |
 | `nacos.ai.skill.registry.enabled` | Whether the Skill Registry protocol adapter is enabled. When enabled, it exposes an independent port through `nacos.ai.registry.port`. | `false` |
 | `nacos.ai.registry.port` | AI Registry protocol adapter port. | `9080` |
@@ -364,7 +364,7 @@ The distribution `startup.sh` supports these common options:
 | `-m cluster` | Start in cluster mode. | `nacos.standalone=false` |
 | `-f config` | Start config-related modules only. | `nacos.functionMode=config` |
 | `-f naming` | Start naming-related modules only. | `nacos.functionMode=naming` |
-| `-f microservice` | Start microservice-related modules. | `nacos.functionMode=microservice` |
+| `-f microservice` | Start only the Config and Naming modules without the AI module (Nacos 3.2.2+). | `nacos.functionMode=microservice` |
 | `-f ai` | Start AI-related modules. | `nacos.functionMode=ai` |
 | `-c` | Set the cluster member list. | `nacos.member.list` |
 | `-p embedded` | Use embedded storage in cluster mode. | `embeddedStorage=true` |

--- a/src/content/docs/latest/zh-cn/manual/admin/deployment/deployment-overview.md
+++ b/src/content/docs/latest/zh-cn/manual/admin/deployment/deployment-overview.md
@@ -66,7 +66,33 @@ Nacos自3.0版本在2.X版本的基础上，对Nacos控制台和Nacos本身进�
 
 Nacos支持NameServer路由请求模式，通过它您可以设计一个有用的映射规则来控制请求转发到相应的集群，在映射规则中您可以按命名空间或租户等分片请求...
 
-## 3. Nacos控制台独立部署
+## 3. 按功能模块启动
+
+部署模式决定 Nacos 节点的拓扑和高可用方式，功能模式决定节点运行时加载哪些业务模块，两者可以组合使用。
+
+从 Nacos 3.2.2 起，如果只需要配置管理和服务发现，可以使用 `microservice` 功能模式。该模式仅加载 Config 和 Naming 模块，不加载 AI 模块，因此 AI 管理中心以及 MCP Server、Skill、Prompt、Agent、AgentSpec 等 AI 资源管理能力和对应控制台入口不可用。
+
+单机模式启动命令：
+
+```shell
+sh startup.sh -m standalone -f microservice
+```
+
+集群模式下，需要在每个节点使用相同的功能模式：
+
+```shell
+sh startup.sh -f microservice
+```
+
+:::note
+功能模式只控制运行时加载的模块，仍然使用标准 Nacos 发行包，不会从发行包中移除 AI 相关 JAR。使用 `-f microservice` 后，无需再设置 `nacos.extension.ai.enabled=false`。
+
+Nacos 3.2.0、3.2.1，或无法传递 `-f` 参数的部署方式，可以在 `${nacos.home}/conf/application.properties` 中设置 `nacos.extension.ai.enabled=false`，关闭 AI 模块并保留 Config 和 Naming 模块。
+:::
+
+完整的功能模式和配置参数说明见[系统参数](../system-configurations.md#基础启动参数)。
+
+## 4. Nacos控制台独立部署
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
@@ -80,7 +106,7 @@ Nacos控制台独立部署参考文档: [控制台独立部署](./deployment-ind
 
 生产环境正式上线前，建议继续阅读[部署最佳实践](./deployment-best-practices.md)，统一检查内网边界、控制台独立部署、外置数据库、鉴权、可见性、流量防护、配置加密和升级回滚方案。
 
-## 4. 多网卡IP选择
+## 5. 多网卡IP选择
 
 当本地环境比较复杂的时候，Nacos服务在启动的时候需要选择运行时使用的IP或者网卡。Nacos从多网卡获取IP参考Spring
 Cloud设计，通过nacos.inetutils参数，可以指定Nacos使用的网卡和IP地址。目前支持的配置参数有:

--- a/src/content/docs/latest/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/latest/zh-cn/manual/admin/system-configurations.md
@@ -32,7 +32,7 @@ Nacos 是内部微服务组件，不应暴露在公网。开启控制台、鉴�
 | --- | --- | --- |
 | `nacos.home(-D)` | Nacos 根目录。 | 安装目录 |
 | `nacos.standalone(-D)` | 是否以单机模式启动。`startup.sh -m standalone` 会设置该参数。 | `false` |
-| `nacos.functionMode(-D)` | 启动功能模式。`all` 表示全部模块；也可通过启动脚本设置为 `config`、`naming`、`microservice`、`ai`。 | `all` |
+| `nacos.functionMode(-D)` | 启动功能模式。`all` 表示启动全部可用模块；`config`、`naming` 分别只启动配置中心、服务发现；`microservice` 仅启动 Config 和 Naming，不加载 AI 模块；`ai` 启动 AI 及其依赖的 Config 和 Naming。 | `all` |
 | `nacos.deployment.type(-D)` | 部署形态。启动脚本默认设置为 `merged`；独立控制台部署时会使用控制台相关配置。 | `merged` |
 | `nacos.server.main.port` | Nacos Server 主端口。 | `8848` |
 | `nacos.server.contextPath` | Nacos Server HTTP 上下文路径。 | `/nacos` |
@@ -305,7 +305,7 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
-| `nacos.extension.ai.enabled` | 是否启用 AI 模块。AI 模块需要配置中心和服务发现模块同时启用。 | `true` |
+| `nacos.extension.ai.enabled` | 是否启用 AI 模块。设为 `false` 时不加载 AI 模块及其控制台入口，Config 和 Naming 不受影响；`microservice` 功能模式下无论该值为何都不会加载 AI 模块。 | `true` |
 | `nacos.ai.mcp.registry.enabled` | 是否启用官方 MCP Registry 协议适配。开启后会使用 `nacos.ai.registry.port` 暴露独立端口。 | `false` |
 | `nacos.ai.skill.registry.enabled` | 是否启用 Skill Registry 协议适配。开启后会使用 `nacos.ai.registry.port` 暴露独立端口。 | `false` |
 | `nacos.ai.registry.port` | AI Registry 协议适配端口。 | `9080` |
@@ -364,7 +364,7 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 | `-m cluster` | 集群模式启动。 | `nacos.standalone=false` |
 | `-f config` | 只启动配置中心相关模块。 | `nacos.functionMode=config` |
 | `-f naming` | 只启动服务发现相关模块。 | `nacos.functionMode=naming` |
-| `-f microservice` | 启动微服务相关模块。 | `nacos.functionMode=microservice` |
+| `-f microservice` | 仅启动配置中心和服务发现模块，不加载 AI 模块（Nacos 3.2.2+）。 | `nacos.functionMode=microservice` |
 | `-f ai` | 启动 AI 相关模块。 | `nacos.functionMode=ai` |
 | `-c` | 设置集群成员列表。 | `nacos.member.list` |
 | `-p embedded` | 集群模式下使用嵌入式存储。 | `embeddedStorage=true` |

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-overview.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-overview.md
@@ -66,7 +66,33 @@ For deployment details, see [Cluster Deployment](./deployment-cluster.md).
 
 Nacos supports NameServer-based request routing. With this mode, you can design mapping rules to forward requests to the corresponding cluster, such as routing requests by namespace or tenant.
 
-## 3. Independent Nacos Console Deployment
+## 3. Select Modules by Function Mode
+
+The deployment mode determines the Nacos node topology and high-availability model. The function mode determines which business modules a node loads at runtime. These two settings can be combined.
+
+Starting with Nacos 3.2.2, use the `microservice` function mode when you need only configuration management and service discovery. This mode loads only the Config and Naming modules and does not load the AI module. As a result, AI Registry capabilities for resources such as MCP Servers, Skills, Prompts, Agents, and AgentSpecs, together with their console entries, are unavailable.
+
+For standalone mode, run:
+
+```shell
+sh startup.sh -m standalone -f microservice
+```
+
+For cluster mode, use the same function mode on every node:
+
+```shell
+sh startup.sh -f microservice
+```
+
+:::note
+The function mode controls only which modules are loaded at runtime. It still uses the standard Nacos distribution and does not remove AI-related JARs from the package. When you use `-f microservice`, you do not also need to set `nacos.extension.ai.enabled=false`.
+
+For Nacos 3.2.0, Nacos 3.2.1, or a deployment method that cannot pass the `-f` option, set `nacos.extension.ai.enabled=false` in `${nacos.home}/conf/application.properties` to disable the AI module while keeping the Config and Naming modules enabled.
+:::
+
+For the complete function-mode and property reference, see [System Parameters](../system-configurations.md#basic-startup-parameters).
+
+## 4. Independent Nacos Console Deployment
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
@@ -80,7 +106,7 @@ For independent console deployment details, see [Independent Console Deployment]
 
 Before going to production, continue with [Deployment Best Practices](./deployment-best-practices.md) to check internal network boundaries, independent console deployment, external database storage, authentication, visibility, traffic control, configuration encryption, and rollback plans.
 
-## 4. Multi-NIC IP Selection
+## 5. Multi-NIC IP Selection
 
 When the local environment is complex, Nacos needs to select the IP address or network interface card to use at startup. Nacos obtains IP addresses from multiple NICs by referring to the Spring Cloud design. You can use `nacos.inetutils` parameters to specify the NIC and IP address used by Nacos. The following configuration parameters are supported:
 

--- a/src/content/docs/next/en/manual/admin/system-configurations.md
+++ b/src/content/docs/next/en/manual/admin/system-configurations.md
@@ -32,7 +32,7 @@ Nacos is an internal microservice component and should not be exposed to the pub
 | --- | --- | --- |
 | `nacos.home(-D)` | Nacos home directory. | installation directory |
 | `nacos.standalone(-D)` | Whether to start in standalone mode. `startup.sh -m standalone` sets this property. | `false` |
-| `nacos.functionMode(-D)` | Function mode. `all` starts all modules. The startup script also supports `config`, `naming`, `microservice`, and `ai`. | `all` |
+| `nacos.functionMode(-D)` | Function mode. `all` starts all available modules; `config` and `naming` start only Config and Naming, respectively; `microservice` starts Config and Naming without the AI module; `ai` starts AI together with its Config and Naming dependencies. | `all` |
 | `nacos.deployment.type(-D)` | Deployment type. The startup script uses `merged` by default. | `merged` |
 | `nacos.server.main.port` | Main Nacos Server port. | `8848` |
 | `nacos.server.contextPath` | HTTP context path of Nacos Server. | `/nacos` |
@@ -305,7 +305,7 @@ For usage, see [AI Registry Overview](../user/ai/ai-registry-overview.md). The p
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `nacos.extension.ai.enabled` | Whether the AI module is enabled. The AI module requires both config and naming modules. | `true` |
+| `nacos.extension.ai.enabled` | Whether the AI module is enabled. When set to `false`, the AI module and its console entries are not loaded, while Config and Naming remain available. The `microservice` function mode does not load the AI module regardless of this value. | `true` |
 | `nacos.ai.mcp.registry.enabled` | Whether the official MCP Registry protocol adapter is enabled. When enabled, it exposes an independent port through `nacos.ai.registry.port`. | `false` |
 | `nacos.ai.skill.registry.enabled` | Whether the Skill Registry protocol adapter is enabled. When enabled, it exposes an independent port through `nacos.ai.registry.port`. | `false` |
 | `nacos.ai.registry.port` | AI Registry protocol adapter port. | `9080` |
@@ -363,7 +363,7 @@ The distribution `startup.sh` supports these common options:
 | `-m cluster` | Start in cluster mode. | `nacos.standalone=false` |
 | `-f config` | Start config-related modules only. | `nacos.functionMode=config` |
 | `-f naming` | Start naming-related modules only. | `nacos.functionMode=naming` |
-| `-f microservice` | Start microservice-related modules. | `nacos.functionMode=microservice` |
+| `-f microservice` | Start only the Config and Naming modules without the AI module (Nacos 3.2.2+). | `nacos.functionMode=microservice` |
 | `-f ai` | Start AI-related modules. | `nacos.functionMode=ai` |
 | `-c` | Set the cluster member list. | `nacos.member.list` |
 | `-p embedded` | Use embedded storage in cluster mode. | `embeddedStorage=true` |

--- a/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-overview.md
+++ b/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-overview.md
@@ -66,7 +66,33 @@ Nacos自3.0版本在2.X版本的基础上，对Nacos控制台和Nacos本身进�
 
 Nacos支持NameServer路由请求模式，通过它您可以设计一个有用的映射规则来控制请求转发到相应的集群，在映射规则中您可以按命名空间或租户等分片请求...
 
-## 3. Nacos控制台独立部署
+## 3. 按功能模块启动
+
+部署模式决定 Nacos 节点的拓扑和高可用方式，功能模式决定节点运行时加载哪些业务模块，两者可以组合使用。
+
+从 Nacos 3.2.2 起，如果只需要配置管理和服务发现，可以使用 `microservice` 功能模式。该模式仅加载 Config 和 Naming 模块，不加载 AI 模块，因此 AI 管理中心以及 MCP Server、Skill、Prompt、Agent、AgentSpec 等 AI 资源管理能力和对应控制台入口不可用。
+
+单机模式启动命令：
+
+```shell
+sh startup.sh -m standalone -f microservice
+```
+
+集群模式下，需要在每个节点使用相同的功能模式：
+
+```shell
+sh startup.sh -f microservice
+```
+
+:::note
+功能模式只控制运行时加载的模块，仍然使用标准 Nacos 发行包，不会从发行包中移除 AI 相关 JAR。使用 `-f microservice` 后，无需再设置 `nacos.extension.ai.enabled=false`。
+
+Nacos 3.2.0、3.2.1，或无法传递 `-f` 参数的部署方式，可以在 `${nacos.home}/conf/application.properties` 中设置 `nacos.extension.ai.enabled=false`，关闭 AI 模块并保留 Config 和 Naming 模块。
+:::
+
+完整的功能模式和配置参数说明见[系统参数](../system-configurations.md#基础启动参数)。
+
+## 4. Nacos控制台独立部署
 
 ![nacos_console_deploy.png](/img/blog/3_0_0-release/3.0_deploy.svg)
 
@@ -80,7 +106,7 @@ Nacos控制台独立部署参考文档: [控制台独立部署](./deployment-ind
 
 生产环境正式上线前，建议继续阅读[部署最佳实践](./deployment-best-practices.md)，统一检查内网边界、控制台独立部署、外置数据库、鉴权、可见性、流量防护、配置加密和升级回滚方案。
 
-## 4. 多网卡IP选择
+## 5. 多网卡IP选择
 
 当本地环境比较复杂的时候，Nacos服务在启动的时候需要选择运行时使用的IP或者网卡。Nacos从多网卡获取IP参考Spring
 Cloud设计，通过nacos.inetutils参数，可以指定Nacos使用的网卡和IP地址。目前支持的配置参数有:

--- a/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
@@ -32,7 +32,7 @@ Nacos 是内部微服务组件，不应暴露在公网。开启控制台、鉴�
 | --- | --- | --- |
 | `nacos.home(-D)` | Nacos 根目录。 | 安装目录 |
 | `nacos.standalone(-D)` | 是否以单机模式启动。`startup.sh -m standalone` 会设置该参数。 | `false` |
-| `nacos.functionMode(-D)` | 启动功能模式。`all` 表示全部模块；也可通过启动脚本设置为 `config`、`naming`、`microservice`、`ai`。 | `all` |
+| `nacos.functionMode(-D)` | 启动功能模式。`all` 表示启动全部可用模块；`config`、`naming` 分别只启动配置中心、服务发现；`microservice` 仅启动 Config 和 Naming，不加载 AI 模块；`ai` 启动 AI 及其依赖的 Config 和 Naming。 | `all` |
 | `nacos.deployment.type(-D)` | 部署形态。启动脚本默认设置为 `merged`；独立控制台部署时会使用控制台相关配置。 | `merged` |
 | `nacos.server.main.port` | Nacos Server 主端口。 | `8848` |
 | `nacos.server.contextPath` | Nacos Server HTTP 上下文路径。 | `/nacos` |
@@ -305,7 +305,7 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
-| `nacos.extension.ai.enabled` | 是否启用 AI 模块。AI 模块需要配置中心和服务发现模块同时启用。 | `true` |
+| `nacos.extension.ai.enabled` | 是否启用 AI 模块。设为 `false` 时不加载 AI 模块及其控制台入口，Config 和 Naming 不受影响；`microservice` 功能模式下无论该值为何都不会加载 AI 模块。 | `true` |
 | `nacos.ai.mcp.registry.enabled` | 是否启用官方 MCP Registry 协议适配。开启后会使用 `nacos.ai.registry.port` 暴露独立端口。 | `false` |
 | `nacos.ai.skill.registry.enabled` | 是否启用 Skill Registry 协议适配。开启后会使用 `nacos.ai.registry.port` 暴露独立端口。 | `false` |
 | `nacos.ai.registry.port` | AI Registry 协议适配端口。 | `9080` |
@@ -363,7 +363,7 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 | `-m cluster` | 集群模式启动。 | `nacos.standalone=false` |
 | `-f config` | 只启动配置中心相关模块。 | `nacos.functionMode=config` |
 | `-f naming` | 只启动服务发现相关模块。 | `nacos.functionMode=naming` |
-| `-f microservice` | 启动微服务相关模块。 | `nacos.functionMode=microservice` |
+| `-f microservice` | 仅启动配置中心和服务发现模块，不加载 AI 模块（Nacos 3.2.2+）。 | `nacos.functionMode=microservice` |
 | `-f ai` | 启动 AI 相关模块。 | `nacos.functionMode=ai` |
 | `-c` | 设置集群成员列表。 | `nacos.member.list` |
 | `-p embedded` | 集群模式下使用嵌入式存储。 | `embeddedStorage=true` |


### PR DESCRIPTION
## What is the purpose of the change

For alibaba/nacos#15495.

Users who only need configuration management and service discovery need clear guidance on how to run Nacos without loading the AI module.

## Brief changelog

- Document the Nacos 3.2.2+ `microservice` function mode, which loads Config and Naming without the AI module.
- Add standalone and cluster startup examples and clarify that the standard distribution is still used.
- Document `nacos.extension.ai.enabled=false` as the compatible option for Nacos 3.2.0/3.2.1 or deployment methods that cannot pass `-f`.
- Keep the `latest` and `next` Chinese and English deployment and system-parameter pages aligned.

## Verifying this change

- `git diff --check`
- Astro compiled and generated the four updated deployment pages.
- Pagefind indexed 1,485 generated pages in Chinese and English.
