### PR TITLE
[ISSUE #15475] Update next plugin management documentation

### DIFF
--- a/src/content/docs/next/en/contribution/source-code-run-and-start.md
+++ b/src/content/docs/next/en/contribution/source-code-run-and-start.md
@@ -62,11 +62,11 @@ After packaging, the `distribution/target` directory will contain the nacos-serv
 Add the following configuration to the `Nacos/distribution/target/nacos-server-${version}/nacos/conf/application.properties` file:
 
 ```properties
-spring.sql.init.platform=mysql
-db.num=1
-db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-db.user=${MYSQL_USERNAME}
-db.password=${MYSQL_PASSWORD}
+nacos.plugin.datasource-dialect.type=mysql
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.user=${MYSQL_USERNAME}
+nacos.plugin.datasource.db.password=${MYSQL_PASSWORD}
 ```
 
 Start `Nacos-bootstrap` and specify the `nacos.deployment.type` parameter as `merged`. The startup command is as follows:
@@ -75,7 +75,7 @@ Start `Nacos-bootstrap` and specify the `nacos.deployment.type` parameter as `me
 distribution/target/nacos-server-${version}/nacos/bin/startup.sh -m standalone -d merged
 ```
 
-> On first launch, the system will prompt you to configure authentication parameters such as `nacos.core.auth.plugin.nacos.token.secret.key`, `nacos.core.auth.server.identity.key`, and `nacos.core.auth.server.identity.value`. Follow the instructions to complete them.
+> On first launch, the system prompts for authentication settings such as `nacos.plugin.auth.nacos.token.secret.key`, `nacos.core.auth.server.identity.key`, and `nacos.core.auth.server.identity.value`. Follow the prompt to complete them.
 
 ### Step 5: Verify Whether Nacos-Bootstrap Has Started Successfully
 

--- a/src/content/docs/next/en/guide/admin/cluster-mode-quick-start.md
+++ b/src/content/docs/next/en/guide/admin/cluster-mode-quick-start.md
@@ -78,8 +78,8 @@ Setting
 
 ```properties
 nacos.core.auth.enabled=true
-nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${custom, make sure same in all nodes}
+nacos.plugin.auth.type=nacos
+nacos.plugin.auth.nacos.token.secret.key=${custom, make sure same in all nodes}
 nacos.core.auth.server.identity.key=${custom, make sure same in all nodes}
 nacos.core.auth.server.identity.value=${custom, make sure same in all nodes}
 ```

--- a/src/content/docs/next/en/guide/admin/deployment.md
+++ b/src/content/docs/next/en/guide/admin/deployment.md
@@ -50,12 +50,12 @@ cmd startup.cmd -m standalone
 add mysql datasource and configure url, user and password 
 
 ```
-spring.datasource.platform=mysql
+nacos.plugin.datasource-dialect.type=mysql
 
-db.num=1
-db.url.0=jdbc:mysql://11.162.196.16:3306/nacos_devtest?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-db.user=nacos_devtest
-db.password=youdontknow
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:mysql://11.162.196.16:3306/nacos_devtest?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+nacos.plugin.datasource.db.user=nacos_devtest
+nacos.plugin.datasource.db.password=youdontknow
 ```
 
 ## Running Nacos in Multi-Node Cluster Mode

--- a/src/content/docs/next/en/guide/admin/nginx-cluster-load-balance-guide.md
+++ b/src/content/docs/next/en/guide/admin/nginx-cluster-load-balance-guide.md
@@ -52,10 +52,10 @@ Ensure each Nacos node is configured for cluster mode:
 **application.properties** (database configuration):
 
 ```properties
-spring.datasource.platform=mysql
-db.url.0=jdbc:mysql://192.168.190.1:3306/config?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-db.user.0=root
-db.password.0=your_password
+nacos.plugin.datasource-dialect.type=mysql
+nacos.plugin.datasource.db.url.0=jdbc:mysql://192.168.190.1:3306/config?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.user.0=root
+nacos.plugin.datasource.db.password.0=your_password
 ```
 
 ## Nginx Configuration

--- a/src/content/docs/next/en/guide/admin/system-configurations.md
+++ b/src/content/docs/next/en/guide/admin/system-configurations.md
@@ -45,12 +45,12 @@ In addition to the above listed to in `application.properties`configuration prop
 
 |Parameter names	|Meaning	 |     Optional value	 |     Default value| Support version |
 |------|------|-----------|-----------------|-------|
-|nacos.plugin.datasource-dialect.type|Database dialect selector|derby/mysql/postgresql/oracle/custom|By running mode|next|
-|nacos.plugin.datasource.db.num|Number of external databases|positive integer|0|next|
-|nacos.plugin.datasource.db.url.{index}|Indexed database URL|string|empty|next|
-|nacos.plugin.datasource.db.user[.{index}]|Shared or indexed username|string|empty|next|
-|nacos.plugin.datasource.db.password[.{index}]|Shared or indexed password|string|empty|next|
-|nacos.plugin.datasource.db.pool.config.xxx|HikariCP setting; stable items use kebab-case|string|See plugin page|next|
+|nacos.plugin.datasource-dialect.type|Database dialect selector|derby/mysql/postgresql/oracle/custom|By running mode|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.num|Number of external databases|positive integer|0|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.url.{index}|Indexed database URL|string|empty|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.user[.{index}]|Shared or indexed username|string|empty|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.password[.{index}]|Shared or indexed password|string|empty|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.pool.config.xxx|HikariCP setting; stable items use kebab-case|string|See plugin page|3.3.0 ~ latest|
 
 `spring.sql.init.platform` and `db.*` remain historical aliases, and canonical keys win. `spring.datasource.platform` is removed. See [Datasource Plugin](../../plugin/datasource-plugin.md) for stable keys, defaults, and migration rules.
 

--- a/src/content/docs/next/en/guide/admin/system-configurations.md
+++ b/src/content/docs/next/en/guide/admin/system-configurations.md
@@ -45,19 +45,14 @@ In addition to the above listed to in `application.properties`configuration prop
 
 |Parameter names	|Meaning	 |     Optional value	 |     Default value| Support version |
 |------|------|-----------|-----------------|-------|
-|db.num| Number of database | positive integer  | 0 | >= 0.1.0 |
-|db.url.0| The first database URL | string | null | >= 0.1.0 |
-|db.url.1| The second database URL | string | null | >= 0.1.0 |
-|db.user| User name of the database connection | string | null | >= 0.1.0 |
-|db.password| Database connection password | string | null | >= 0.1.0 |
-|spring.datasource.platform|Database type|string|mysql｜>=1.3.0|
-|db.pool.config.xxx| Database connection pool parameters, using hikari connection pool, the parameters are the same as hikari connection pool, such as `db.pool.config.connectionTimeout` or `db.pool.config.maximumPoolSize` |string| same as hikariCp |>=1.4.1|
+|nacos.plugin.datasource-dialect.type|Database dialect selector|derby/mysql/postgresql/oracle/custom|By running mode|next|
+|nacos.plugin.datasource.db.num|Number of external databases|positive integer|0|next|
+|nacos.plugin.datasource.db.url.{index}|Indexed database URL|string|empty|next|
+|nacos.plugin.datasource.db.user[.{index}]|Shared or indexed username|string|empty|next|
+|nacos.plugin.datasource.db.password[.{index}]|Shared or indexed password|string|empty|next|
+|nacos.plugin.datasource.db.pool.config.xxx|HikariCP setting; stable items use kebab-case|string|See plugin page|next|
 
-Now the db config support multi data source. It can set data source num by `db.num`, and `db.url.index` as the corresponding connection's url. When `db.user` and `db.password` are set without `index`, all db connection use `db.user` and `db.password` to auth. If the username or password is different with different data source, can split by symbol `,`, or use `db.user.index`,`db.user.password` to set corresponding db connection's username or password. It is important to note that, when `db.user` or `db.password` are set without index, and the mechanism which split `db.user`,`db.password` by `,` exist, so if username or password contains `,`, it will split the value by `,`, and use split[0] to auth, failed to auth finally.      
-
-Nacos started to use HikariCP connection pool from version 1.3, but before version 1.4.1, the connection pool configuration is system default value, and the configuration could not be customized. After 1.4.1, Nacos provide a method to configure the HikariCP connection pool.
-`db.pool.config` is the configuration prefix, `xxx` is the actual hikariCP configuration, such as `db.pool.config.connectionTimeout` or `db.pool.config.maximumPoolSize` and so on. For more configuration of hikariCP, please check [HikariCP](https://github.com/brettwooldridge/HikariCP)
-It should be noted that `url`, `user`, `password` will be rewrite by `db.url.n`, `db.user`, `db.password`, and driverClassName is the default MySQL8 driver which supports mysql5.x.
+`spring.sql.init.platform` and `db.*` remain historical aliases, and canonical keys win. `spring.datasource.platform` is removed. See [Datasource Plugin](../../plugin/datasource-plugin.md) for stable keys, defaults, and migration rules.
 
 ### CMDB module
 

--- a/src/content/docs/next/en/guide/user/auth.md
+++ b/src/content/docs/next/en/guide/user/auth.md
@@ -21,12 +21,15 @@ sidebar:
 |Parameter|Default|Versions|Description|
 |-----|------|------|----|
 |nacos.core.auth.enabled|false|1.2.0 ~ latest|Whether to enable the authentication|
-|nacos.plugin.auth.type|nacos|3.3.0 ~ latest|Auth implementation selector; old `nacos.core.auth.system.type` is an alias|
+|nacos.plugin.auth.type|nacos|3.3.0 ~ latest|Auth implementation selector|
 |nacos.plugin.auth.nacos.token.secret.key|No default|3.3.0 ~ latest|Default auth access-token signing key; sensitive and RESTART|
 |nacos.plugin.auth.nacos.token.expire.seconds|18000|3.3.0 ~ latest|Login access-token lifetime; RUNTIME|
 |nacos.core.auth.enable.userAgentAuthWhite|false|1.4.1 ~ latest|Whether to use the useragent whitelist, mainly used to adapt to the upgrade of the old version, **Setting `true` is a security risk**|
 |nacos.core.auth.server.identity.key|serverIdentity(No default since 2.2.1)|1.4.1 ~ latest|Used to replace the identification key of the useragent whitelist, **Using the default value is a security risk**|
 |nacos.core.auth.server.identity.value|security(No default since 2.2.1)|1.4.1 ~ latest|It is used to replace the identification value of the useragent whitelist, **Using the default value is a security risk**|
+|~~nacos.core.auth.system.type~~|nacos|1.2.0 ~ latest|Deprecated legacy auth selector; it will be removed. Use `nacos.plugin.auth.type`|
+|~~nacos.core.auth.plugin.nacos.token.secret.key~~|No default|2.1.0 ~ latest|Deprecated signing-key alias; it will be removed. Use `nacos.plugin.auth.nacos.token.secret.key`|
+|~~nacos.core.auth.plugin.nacos.token.expire.seconds~~|18000|2.1.0 ~ latest|Deprecated token-expiration alias; it will be removed. Use `nacos.plugin.auth.nacos.token.expire.seconds`|
 
 
 ## Use Authentication in Servers

--- a/src/content/docs/next/en/guide/user/auth.md
+++ b/src/content/docs/next/en/guide/user/auth.md
@@ -21,14 +21,12 @@ sidebar:
 |Parameter|Default|Versions|Description|
 |-----|------|------|----|
 |nacos.core.auth.enabled|false|1.2.0 ~ latest|Whether to enable the authentication|
-|nacos.plugin.auth.type|nacos|next|Auth implementation selector; old `nacos.core.auth.system.type` is an alias|
-|nacos.plugin.auth.nacos.token.secret.key|No default|next|Default auth access-token signing key; sensitive and RESTART|
-|nacos.plugin.auth.nacos.token.expire.seconds|18000|next|Login access-token lifetime; RUNTIME|
+|nacos.plugin.auth.type|nacos|3.3.0 ~ latest|Auth implementation selector; old `nacos.core.auth.system.type` is an alias|
+|nacos.plugin.auth.nacos.token.secret.key|No default|3.3.0 ~ latest|Default auth access-token signing key; sensitive and RESTART|
+|nacos.plugin.auth.nacos.token.expire.seconds|18000|3.3.0 ~ latest|Login access-token lifetime; RUNTIME|
 |nacos.core.auth.enable.userAgentAuthWhite|false|1.4.1 ~ latest|Whether to use the useragent whitelist, mainly used to adapt to the upgrade of the old version, **Setting `true` is a security risk**|
 |nacos.core.auth.server.identity.key|serverIdentity(No default since 2.2.1)|1.4.1 ~ latest|Used to replace the identification key of the useragent whitelist, **Using the default value is a security risk**|
 |nacos.core.auth.server.identity.value|security(No default since 2.2.1)|1.4.1 ~ latest|It is used to replace the identification value of the useragent whitelist, **Using the default value is a security risk**|
-|~~nacos.core.auth.default.token.secret.key~~|SecretKey012345678901234567890123456789012345678901234567890123456789|1.2.0 ~ 2.0.4|Same as `nacos.core.auth.plugin.nacos.token.secret.key`|
-|~~nacos.core.auth.default.token.expire.seconds~~|18000|1.2.0 ~ 2.0.4|Same as `nacos.core.auth.plugin.nacos.token.expire.seconds`|
 
 
 ## Use Authentication in Servers
@@ -55,29 +53,23 @@ After enabling authentication, you can customize the key used to generate JWT to
 
 > Attention：
 > 1. The secret key provided in the document is a public key. Please replace it with other secret key content during actual deployment to prevent security risks caused by secret key leakage.
-> 2. After version 2.2.0.1, the community release version will remove the following value as the default value in the document, which needs to be filled in by yourself, otherwise the node cannot be started.
+> 2. The signing key has no default. When the canonical value is empty, the distribution startup script first migrates a valid `nacos.core.auth.plugin.nacos.token.secret.key` value from `application.properties`; it prompts for a value only when neither key provides one.
 > 3. The secret key needs to be consistent between nodes, and if it is inconsistent for a long time, it may cause 403 invalid token error.
 
 ```properties
-### The default token(Base64 String):
-nacos.core.auth.default.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
-
-### Since 2.1.0
 nacos.plugin.auth.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
 ```
 
 When customizing the key, it is recommended to set the configuration item to a **Base64 encoded** string,
-and **the length of the original key must not be less than 32 characters**. For example the following example:
+and **the decoded key must not be less than 32 bytes**. For example:
 
 ```properties
-### The default token(Base64 String):
-nacos.core.auth.default.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
-
-### Since 2.1.0
 nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
-> Attention: the authentication switch takes effect immediately after the modification, and there is no need to restart the server. When dynamic modifing `token.secret.key`, Please make sure the new value is valid, otherwise the login and request will fail.
+The historical `nacos.core.auth.plugin.nacos.token.secret.key` remains an alias; use the standard key for new configuration.
+
+> Attention: the authentication switch takes effect immediately after modification. `token.secret.key` is a `RESTART` item: change it in static configuration, keep it consistent on every node, and restart the servers.
 
 ### With Docker
 

--- a/src/content/docs/next/en/guide/user/auth.md
+++ b/src/content/docs/next/en/guide/user/auth.md
@@ -21,9 +21,9 @@ sidebar:
 |Parameter|Default|Versions|Description|
 |-----|------|------|----|
 |nacos.core.auth.enabled|false|1.2.0 ~ latest|Whether to enable the authentication|
-|nacos.core.auth.system.type|nacos|1.2.0 ~ latest|Type of authentication|
-|nacos.core.auth.plugin.nacos.token.secret.key|SecretKey012345678901234567890123456789012345678901234567890123456789(No default since 2.2.0.1)|2.1.0 ~ latest|Used to generate the key used by the user to login to the temporary accessToken in the default authentication plugin. **Using the default value is a security risk**.|
-|nacos.core.auth.plugin.nacos.token.expire.seconds|18000|2.1.0 ~ latest|Expiration time of user login temporary accessToken|
+|nacos.plugin.auth.type|nacos|next|Auth implementation selector; old `nacos.core.auth.system.type` is an alias|
+|nacos.plugin.auth.nacos.token.secret.key|No default|next|Default auth access-token signing key; sensitive and RESTART|
+|nacos.plugin.auth.nacos.token.expire.seconds|18000|next|Login access-token lifetime; RUNTIME|
 |nacos.core.auth.enable.userAgentAuthWhite|false|1.4.1 ~ latest|Whether to use the useragent whitelist, mainly used to adapt to the upgrade of the old version, **Setting `true` is a security risk**|
 |nacos.core.auth.server.identity.key|serverIdentity(No default since 2.2.1)|1.4.1 ~ latest|Used to replace the identification key of the useragent whitelist, **Using the default value is a security risk**|
 |nacos.core.auth.server.identity.value|security(No default since 2.2.1)|1.4.1 ~ latest|It is used to replace the identification value of the useragent whitelist, **Using the default value is a security risk**|
@@ -45,7 +45,7 @@ nacos.core.auth.enabled=false
 After enabling authentication, the configuration in application.properties is as follow:
 ```java
 ### If turn on auth system:
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 ```
 
@@ -63,7 +63,7 @@ After enabling authentication, you can customize the key used to generate JWT to
 nacos.core.auth.default.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
 
 ### Since 2.1.0
-nacos.core.auth.plugin.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
+nacos.plugin.auth.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
 ```
 
 When customizing the key, it is recommended to set the configuration item to a **Base64 encoded** string,
@@ -74,7 +74,7 @@ and **the length of the original key must not be less than 32 characters**. For 
 nacos.core.auth.default.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 
 ### Since 2.1.0
-nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
 > Attention: the authentication switch takes effect immediately after the modification, and there is no need to restart the server. When dynamic modifing `token.secret.key`, Please make sure the new value is valid, otherwise the login and request will fail.
@@ -121,7 +121,7 @@ nacos.core.auth.enabled=false
 ```
 into
 ```
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 ```
 
@@ -190,13 +190,13 @@ Regardless of the client SDK or OpenAPI, after calling the `login` interface to 
 
 #### Way to open
 ```
-nacos.core.auth.plugin.nacos.token.cache.enable=true
+nacos.plugin.auth.nacos.token.cache.enable=true
 ```
 
 #### Attention
 Before enabling the feature of token cache, the server will generate a new token for each request carrying a username and password to access the `login` interface. The `tokenTtl` field in the return value of `login` interface is equal to the value set in the server configuration file. The configuration is as follows:
 ```
-nacos.core.auth.plugin.nacos.token.expire.seconds=18000
+nacos.plugin.auth.nacos.token.expire.seconds=18000
 ```
 After enabling the feature of token cache, the server will first check whether the token corresponding to the username exists in cache for each request to access the `login` interface with username and password. If it does not exist, generate a new token, insert it into the cache and return it to requester; if it exists, return the token to requester, and the value of the `tokenTtl` field is the value set in the configuration file minus the duration of the token stored in the cache. 
 If the token stays in the cache for more than 90% of the value set in the configuration file, when the `login` interface receives a request, although the token corresponding to the username exists in the cache, the server will regenerate the token and return it to the requester, and update cache. Therefore, in the worst case, the `tokenTtl` received by the requester is only 10% of the value set in the configuration file.

--- a/src/content/docs/next/en/manual/admin/admin-api.md
+++ b/src/content/docs/next/en/manual/admin/admin-api.md
@@ -1496,7 +1496,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 #### Description
 
-Use this API to update plugin configuration. Provide the plugin type, name, and configuration content. `localOnly` is supported to apply the change only to the current node.
+Replace the complete configuration map for the target source. `localOnly=false` writes the persisted runtime source; `localOnly=true` writes the higher-priority local source for this node only. An empty map clears the target source. Only definition items with `effectMode=RUNTIME` can be changed; adding, changing, or removing a `RESTART` item is rejected.
 
 #### Since
 
@@ -1524,8 +1524,8 @@ The request body is JSON and contains the following fields:
 |-------------|----------|----|----------------|
 | `pluginType` | `string` | **Yes** | Plugin type, such as auth. |
 | `pluginName` | `string` | **Yes** | Plugin name. |
-| `config` | `string` | **Yes** | Plugin configuration item. |
-| `localOnly` | `boolean` | No | Whether to write only locally without persistence. |
+| `config` | `object` | **Yes** | Complete configuration map keyed by definition item key. |
+| `localOnly` | `boolean` | No | `true` writes `LOCAL_ONLY`; otherwise writes cluster-persisted `RUNTIME_PERSISTED`. |
 
 #### Response Data
 
@@ -1537,7 +1537,8 @@ The response body follows the [Nacos open API unified response format](../user/o
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
-  -H 'Content-Type: application/json' -d '{}'
+  -H 'Content-Type: application/json' \
+  -d '{"pluginType":"auth","pluginName":"ldap","config":{"connect-timeout":"6000"},"localOnly":false}'
 ```
 
 * Response example
@@ -1590,16 +1591,20 @@ The response body follows the [Nacos open API unified response format](../user/o
 | pluginName | `string` | Plugin name. |
 | enabled | `boolean` | Whether the plugin is enabled. |
 | critical | `boolean` | Whether the plugin is critical. |
+| typeCritical | `boolean` | Whether the plugin type is declared critical. |
+| executionMode | `string` | `EXCLUSIVE`, `CHAIN`, `ROUTED`, or `BROADCAST`. |
+| exclusive | `boolean` | Whether the type uses exclusive selection. |
 | configurable | `boolean` | Whether the plugin is configurable. |
-| config | `object` | Configuration content. |
-| configDefinitions | `array` | Configuration definition list. |
+| config | `object` | Effective item map with sensitive values masked. |
+| configDefinitions | `array` | Definitions including key, aliases, type, defaultValue, required, sensitive, and effectMode. |
+| configValueMetas | `object` | Effective source and `overridden` metadata for each item. |
 
 #### Examples
 
 * Request example
 
 ```shell
-curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=auth&pluginName=nacos-default-auth-plugin'
+curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=auth&pluginName=nacos'
 ```
 
 * Response example
@@ -1609,14 +1614,18 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=
   "code": 0,
   "message": "success",
   "data": {
-    "pluginId": "auth:nacos-default-auth-plugin",
+    "pluginId": "auth:nacos",
     "pluginType": "auth",
-    "pluginName": "nacos-default-auth-plugin",
+    "pluginName": "nacos",
     "enabled": true,
     "critical": true,
-    "configurable": true,
+    "typeCritical": true,
+    "executionMode": "EXCLUSIVE",
+    "exclusive": true,
+    "configurable": false,
     "config": {},
-    "configDefinitions": []
+    "configDefinitions": [],
+    "configValueMetas": {}
   }
 }
 ```
@@ -1669,12 +1678,14 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
   "message": "success",
   "data": [
     {
-      "pluginId": "auth:nacos-default-auth-plugin",
+      "pluginId": "auth:nacos",
       "pluginType": "auth",
-      "pluginName": "nacos-default-auth-plugin",
+      "pluginName": "nacos",
       "enabled": true,
       "critical": true,
-      "configurable": true,
+      "configurable": false,
+      "typeCritical": true,
+      "executionMode": "EXCLUSIVE",
       "exclusive": true
     }
   ]
@@ -1685,7 +1696,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 #### Description
 
-Use this API to update the plugin status (enabled or disabled). `localOnly` is supported to apply the change only to the current node.
+Update implementation state. `localOnly=false` persists to `${nacos.home}/data/plugin/plugin-states.json` for cluster operations; `localOnly=true` affects only this node and has higher priority. Exclusive selection, PRE_CONTEXT state, and active critical providers cannot be changed illegally at runtime.
 
 #### Since
 
@@ -1726,7 +1737,8 @@ The response body follows the [Nacos open API unified response format](../user/o
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
-  -H 'Content-Type: application/json' -d '{}'
+  -H 'Content-Type: application/json' \
+  -d '{"pluginType":"trace","pluginName":"ai-resource-trace-log","enabled":false,"localOnly":false}'
 ```
 
 * Response example
@@ -9727,11 +9739,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/detail?pipelineId
 
 ## 10. AI Resource Import
 
+These APIs use only enabled fixed sources from unified plugin management. Request and response `sourceId` equals the managed plugin name: `mcp-official`, `mcp-registry-protocol`, `skills-sh`, or `skills-well-known`. The historical source descriptor field named `pluginName` still means importerType, such as `mcp-registry`; it is not the source ID. One implementation can no longer be cloned to multiple endpoints through configuration.
+
 ### 10.1. List AI Resource Import Sources
 
 #### Description
 
-This API lists the currently configured AI resource import sources.
+This API lists fixed AI resource import sources that are currently loaded and enabled. Source detail and canonical definitions are managed by `ai-resource-import:{sourceId}`.
 
 #### Since
 

--- a/src/content/docs/next/en/manual/admin/auth.mdx
+++ b/src/content/docs/next/en/manual/admin/auth.mdx
@@ -32,16 +32,16 @@ For plugin boundaries and development details, see [Auth Plugin](../../plugin/au
 
 | Property | Default configuration | Description |
 | --- | --- | --- |
-| `nacos.core.auth.system.type` | `nacos` | Selected auth plugin type. Supports `nacos`, `ldap`, `oidc`, or a custom type. |
+| `nacos.plugin.auth.type` | `nacos` | Selects the auth plugin at startup; `nacos.core.auth.system.type` is a legacy alias. |
 | `nacos.core.auth.enabled` | `true` | Enables auth for Open API, SDK, and gRPC requests. |
 | `nacos.core.auth.admin.enabled` | `true` | Enables auth for Admin API requests. |
 | `nacos.core.auth.console.enabled` | `true` | Enables auth for Console API and default console login. |
 | `nacos.core.auth.server.identity.key` | Empty | Server-to-server identity key. Required for auth-enabled clusters. |
 | `nacos.core.auth.server.identity.value` | Empty | Server-to-server identity value. Required for auth-enabled clusters. |
 | `nacos.core.auth.caching.enabled` | `true` | Caches users, roles, and permissions. Permission changes may have about 15 seconds of delay. |
-| `nacos.core.auth.plugin.nacos.token.secret.key` | Empty | Signing key for default Nacos tokens. Use a Base64 string generated from at least 32 raw characters. |
-| `nacos.core.auth.plugin.nacos.token.expire.seconds` | `18000` | Default Nacos token lifetime, in seconds. |
-| `nacos.core.auth.plugin.nacos.token.cache.enable` | `false` | Caches issued token parsing and validation results. |
+| `nacos.plugin.auth.nacos.token.secret.key` | Empty | Default token signing key; sensitive and RESTART. The old core key is an alias. |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | Token lifetime; RUNTIME. The old core key is an alias. |
+| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | Token cache switch; RUNTIME. The old core key is an alias. |
 
 :::note
 After an upgrade, your cluster may keep old values. Always check the actual `application.properties`, environment variables, and startup parameters of the running cluster.
@@ -57,14 +57,14 @@ Default Nacos auth uses local users, roles, permissions, and tokens. It provides
     Edit `${nacos.home}/conf/application.properties`:
 
     ```properties
-    nacos.core.auth.system.type=nacos
+    nacos.plugin.auth.type=nacos
     nacos.core.auth.enabled=true
     nacos.core.auth.admin.enabled=true
     nacos.core.auth.console.enabled=true
 
     nacos.core.auth.server.identity.key=${custom_server_identity_key}
     nacos.core.auth.server.identity.value=${custom_server_identity_value}
-    nacos.core.auth.plugin.nacos.token.secret.key=${custom_base64_token_secret_key}
+    nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
     ```
 
     In cluster mode, every node must use the same `server.identity` and `token.secret.key`.
@@ -146,19 +146,18 @@ LDAP boundaries:
 Example:
 
 ```properties
-nacos.core.auth.system.type=ldap
+nacos.plugin.auth.type=ldap
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
-nacos.core.auth.ldap.url=ldap://localhost:389
-nacos.core.auth.ldap.basedc=dc=example,dc=org
-nacos.core.auth.ldap.userDn=cn=admin,${nacos.core.auth.ldap.basedc}
-nacos.core.auth.ldap.password=admin
-nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
-nacos.core.auth.ldap.filter.prefix=uid
-nacos.core.auth.ldap.case.sensitive=true
-nacos.core.auth.ldap.ignore.partial.result.exception=false
+nacos.plugin.auth.ldap.url=ldap://localhost:389
+nacos.plugin.auth.ldap.base-dn=dc=example,dc=org
+nacos.plugin.auth.ldap.user-dn=cn=admin,dc=example,dc=org
+nacos.plugin.auth.ldap.password=${ldap_bind_password}
+nacos.plugin.auth.ldap.filter-prefix=uid
+nacos.plugin.auth.ldap.case-sensitive=true
+nacos.plugin.auth.ldap.ignore-partial-result-exception=false
 ```
 
 Before enabling LDAP, check that:
@@ -175,25 +174,25 @@ The OIDC/OAuth2 plugin type is `oidc`. It delegates authentication to an externa
 Basic example:
 
 ```properties
-nacos.core.auth.system.type=oidc
+nacos.plugin.auth.type=oidc
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
 nacos.core.auth.server.identity.key=${custom_server_identity_key}
 nacos.core.auth.server.identity.value=${custom_server_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${custom_base64_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
 
-nacos.core.auth.plugin.oidc.issuer-uri=https://idp.example.com/realms/nacos
-nacos.core.auth.plugin.oidc.client-id=nacos-server
-nacos.core.auth.plugin.oidc.client-secret=${client_secret}
-nacos.core.auth.plugin.oidc.scope=openid profile email
+nacos.plugin.auth.oidc.issuer-uri=https://idp.example.com/realms/nacos
+nacos.plugin.auth.oidc.client-id=nacos-server
+nacos.plugin.auth.oidc.client-secret=${client_secret}
+nacos.plugin.auth.oidc.scope=openid profile email
 ```
 
 In OIDC/OAuth2 mode, console login uses compatibility endpoints under `/v1/auth/oidc/*`. The Java SDK can use the OAuth2 Client Credentials flow to obtain bearer tokens.
 
 :::caution
-If production needs resource-level permission isolation, configure the OIDC plugin external authorization endpoint. In the current implementation, when `nacos.core.auth.plugin.oidc.authorization-endpoint` is empty, non-admin authorization decisions are allowed by default.
+If production needs resource-level permission isolation, configure `nacos.plugin.auth.oidc.authorization-endpoint`. In the current implementation, an empty value allows non-admin authorization decisions by default.
 :::
 
 For detailed configuration, Keycloak examples, external authorization, and troubleshooting, see [OIDC/OAuth2 Authentication](./oidc-auth.md).
@@ -241,7 +240,7 @@ For SDK configuration, see [User Manual - Authorization](../user/auth.mdx).
 The default Nacos auth plugin supports token caching. When enabled, the server caches token parsing and validation results to reduce JWT parsing overhead.
 
 ```properties
-nacos.core.auth.plugin.nacos.token.cache.enable=true
+nacos.plugin.auth.nacos.token.cache.enable=true
 ```
 
 Notes:

--- a/src/content/docs/next/en/manual/admin/auth.mdx
+++ b/src/content/docs/next/en/manual/admin/auth.mdx
@@ -33,15 +33,15 @@ For plugin boundaries and development details, see [Auth Plugin](../../plugin/au
 | Property | Default configuration | Description |
 | --- | --- | --- |
 | `nacos.plugin.auth.type` | `nacos` | Selects the auth plugin at startup; `nacos.core.auth.system.type` is a legacy alias. |
-| `nacos.core.auth.enabled` | `true` | Enables auth for Open API, SDK, and gRPC requests. |
+| `nacos.core.auth.enabled` | `false` | Enables auth for Open API, SDK, and gRPC requests. |
 | `nacos.core.auth.admin.enabled` | `true` | Enables auth for Admin API requests. |
 | `nacos.core.auth.console.enabled` | `true` | Enables auth for Console API and default console login. |
 | `nacos.core.auth.server.identity.key` | Empty | Server-to-server identity key. Required for auth-enabled clusters. |
 | `nacos.core.auth.server.identity.value` | Empty | Server-to-server identity value. Required for auth-enabled clusters. |
-| `nacos.core.auth.caching.enabled` | `true` | Caches users, roles, and permissions. Permission changes may have about 15 seconds of delay. |
-| `nacos.plugin.auth.nacos.token.secret.key` | Empty | Default token signing key; sensitive and RESTART. The old core key is an alias. |
-| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | Token lifetime; RUNTIME. The old core key is an alias. |
-| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | Token cache switch; RUNTIME. The old core key is an alias. |
+| `nacos.plugin.auth.nacos.caching.enabled` | `true` | Caches users, roles, and permissions; `nacos.core.auth.caching.enabled` is a historical alias. Permission changes may have about 15 seconds of delay. |
+| `nacos.plugin.auth.nacos.token.secret.key` | Empty | Default token signing key; sensitive and RESTART. `nacos.core.auth.plugin.nacos.token.secret.key` is a historical alias. |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | Token lifetime; RUNTIME. `nacos.core.auth.plugin.nacos.token.expire.seconds` is a historical alias. |
+| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | Token cache switch; RUNTIME. `nacos.core.auth.plugin.nacos.token.cache.enable` is a historical alias. |
 
 :::note
 After an upgrade, your cluster may keep old values. Always check the actual `application.properties`, environment variables, and startup parameters of the running cluster.

--- a/src/content/docs/next/en/manual/admin/compatibility-and-deprecation.md
+++ b/src/content/docs/next/en/manual/admin/compatibility-and-deprecation.md
@@ -28,6 +28,7 @@ As Nacos evolves, some compatibility capabilities remain available to help users
 | Compatibility switches | Enable them only during upgrade or migration windows. Disable them after the system becomes stable. | [System Configurations](./system-configurations.md) |
 | Beta/Tag gray release compatibility | Starting with Nacos 3.3, legacy `config_info_beta` and `config_info_tag` tables are no longer migrated automatically. Migrate them to the current `config_info_gray` gray model before upgrade. Current beta/tag APIs remain backed by `config_info_gray` and `GrayRule`. | [Upgrading Manual](./upgrading.mdx), [Configuration Gray Release](../user/config/gray-release.md) |
 | Default namespace migration | Starting with Nacos 3.3, storage migration or double-write between empty tenant values and `public` is no longer automatic. Blank or omitted namespace requests are still normalized to the default namespace `public`. | [Upgrading Manual](./upgrading.mdx), [Java SDK Usage](../user/java-sdk/usage.md#13-upgrade-compatibility) |
+| Plugin management refactor | Migrate to `pluginType:pluginName`, canonical definition keys, and unified state. The old AI Resource Import two-level SPI/source/preset model is removed. | [Plugin Migration](../../plugin/migration.md), [AI Resource Import Plugin](../../plugin/ai-resource-import-plugin.md) |
 | Legacy console | Use only for compatibility with existing habits. New deployments should use the new console. | [Console Manual](./console.md#legacy-console) |
 | Deprecated Java SDK properties | Do not use them in new systems. | [Java SDK Properties](../user/java-sdk/properties.md) |
 | Deprecated CLI commands | Use explicit lifecycle commands instead of shortcut publish commands. | [Nacos CLI User Guide](./nacos-cli.md) |
@@ -40,6 +41,12 @@ Nacos 3.3 removes runtime compatibility migration logic for Config data from ver
 When upgrading from versions before 3.0 to 3.3, if the old deployment did not use the default namespace and did not use beta gray release, this compatibility removal does not affect smooth upgrade for this compatibility area. If the old deployment used the default namespace or beta gray release, operators must complete data migration before upgrading to 3.3: migrate default-namespace data from the empty tenant to `public`, and migrate legacy beta/tag gray data to the current `config_info_gray` gray model.
 
 This does not remove current default namespace semantics or current beta/tag gray APIs. Blank or omitted namespace requests are still normalized to `public`; current beta/tag gray behavior remains backed by `config_info_gray` and `GrayRule`.
+
+## Plugin Management and AI Resource Import Breaking Change
+
+The next line uses unified plugin identity, state, configuration sources, and lifecycle. A historical implementation without `PluginConfigSpec` still loads but is automatically reported as `configurable=false`. Config Change's `ConfigChangeConfigs` is deprecated but remains in its compatibility window.
+
+AI Resource Import requires an incompatible migration: `AiResourceImportSource`, the Source Provider SPI, presets, `nacos.ai.resource.import.sources[N].*`, and cloning one implementation to multiple endpoints through configuration are removed. One `pluginName` now identifies one fixed source, and `sourceId` equals the managed pluginName. The existing API field named `pluginName` continues to mean importerType. New deployments use `nacos.plugin.ai-resource-import.*`; see [Plugin Migration](../../plugin/migration.md).
 
 ## What to confirm before using compatibility capabilities
 

--- a/src/content/docs/next/en/manual/admin/console-api.md
+++ b/src/content/docs/next/en/manual/admin/console-api.md
@@ -844,8 +844,8 @@ A user identity with the corresponding `namespace read` permission is required.
 
 | Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **Yes** | Plugin type, such as `auth` (authentication), `control`, or `datasource`. |
-| `pluginName` | `string` | **Yes** | Plugin name, such as `nacos-default-auth-plugin`. |
+| `pluginType` | `string` | **Yes** | Plugin type, such as `auth`, `control`, or `datasource-dialect`. |
+| `pluginName` | `string` | **Yes** | Plugin name, such as `nacos`; the full identity is `pluginType:pluginName`. |
 
 #### Response Data
 
@@ -856,16 +856,20 @@ A user identity with the corresponding `namespace read` permission is required.
 | data.pluginName | `string` | plugin name. |
 | data.enabled | `boolean` | whether it is currently enabled. |
 | data.critical | `boolean` | whether it is a critical plugin (critical plugins cannot be disabled). |
+| data.typeCritical | `boolean` | whether the plugin type is declared critical. |
+| data.executionMode | `string` | `EXCLUSIVE`, `CHAIN`, `ROUTED`, or `BROADCAST`. |
+| data.exclusive | `boolean` | whether the type uses exclusive selection. |
 | data.configurable | `boolean` | whether dynamic configuration in the console is supported. |
-| data.config | `object` | current plugin configuration items. |
-| data.configDefinitions | `array` | plugin configuration item definition list, used to render the configuration form. |
+| data.config | `object` | effective configuration with sensitive items masked. |
+| data.configDefinitions | `array` | definitions including aliases, type, default, required, sensitivity, and effectMode. |
+| data.configValueMetas | `object` | effective source and `overridden` metadata per item. |
 
 #### Examples
 
 * Request example
 
 ```shell
-curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=nacos-default-auth-plugin'
+curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=nacos'
 ```
 
 * Response example
@@ -875,10 +879,12 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=
   "code": 0,
   "message": "success",
   "data": {
-    "name": "nacos-default-auth-plugin",
+    "name": "nacos",
     "type": "auth",
     "enabled": true,
-    "config": {}
+    "config": {},
+    "configDefinitions": [],
+    "configValueMetas": {}
   }
 }
 ```
@@ -909,7 +915,7 @@ A user identity with the corresponding `namespace read` permission is required.
 
 | Name | Type | Required | Description |
 |--------|------|------|----------|
-| `pluginType` | `string` | **Yes** | Plugin type, such as `auth`, `control`, or `datasource`. |
+| `pluginType` | `string` | **Yes** | Plugin type, such as `auth`, `control`, or `datasource-dialect`. |
 | `pluginName` | `string` | **Yes** | plugin name. |
 
 #### Response Data
@@ -921,7 +927,7 @@ The returned `data` is a Map&lt;node address, availability&gt;. The key is the N
 * Request example
 
 ```shell
-curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=auth&pluginName=nacos-default-auth-plugin'
+curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=auth&pluginName=nacos'
 ```
 
 * Response example
@@ -940,7 +946,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=aut
 
 #### Description
 
-You can use this API to update plugin configuration. You must provide the plugin type, name, and configuration content.
+Replace the complete configuration map for the target runtime source. Only `RUNTIME` definitions can be submitted. `RESTART` items are read-only in Next Console, and adding, changing, or removing them is rejected. For a sensitive item returned as a masked marker, submitting the marker unchanged preserves the value already present in the target source.
 
 #### Since
 
@@ -964,7 +970,8 @@ A user identity with the corresponding `namespace write` permission is required.
 |--------|------|------|----------|
 | `pluginType` | `string` | **Yes** | plugin type. |
 | `pluginName` | `string` | **Yes** | plugin name. |
-| `config` | `string` | No | Plugin configuration content as a JSON object. Specific fields are defined by the plugin. |
+| `config` | `string` | No | Complete JSON item map whose fields come from plugin definitions. |
+| `localOnly` | `boolean` | No | `true` writes this node's `LOCAL_ONLY`; otherwise writes `RUNTIME_PERSISTED`. |
 
 #### Response Data
 
@@ -979,8 +986,9 @@ A user identity with the corresponding `namespace write` permission is required.
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
   -d 'pluginType=auth' \
-  -d 'pluginName=nacos-default-auth-plugin' \
-  -d 'config={}'
+  -d 'pluginName=ldap' \
+  -d 'config={"connect-timeout":"6000"}' \
+  -d 'localOnly=false'
 ```
 
 * Response example
@@ -1023,7 +1031,7 @@ A user identity with the corresponding `namespace read` permission is required.
 
 #### Response Data
 
-The returned `data` is an array of plugin information. Each item contains the plugin name, type, enabled status, and other fields.
+The returned `data` is an array including name, type, state, critical, executionMode, configurable, and related metadata.
 
 #### Examples
 
@@ -1041,7 +1049,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
   "message": "success",
   "data": [
     {
-      "name": "nacos-default-auth-plugin",
+      "name": "nacos",
       "type": "auth",
       "enabled": true
     }
@@ -1053,7 +1061,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 
 #### Description
 
-You can use this API to update whether a plugin is enabled or disabled.
+Update plugin state. Persisted cluster state overrides static initialization, and local state overrides persisted state. Illegal runtime changes to exclusive selection, PRE_CONTEXT implementations, or active critical providers are rejected.
 
 #### Since
 
@@ -1093,8 +1101,9 @@ A user identity with the corresponding `namespace write` permission is required.
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
   -d 'pluginType=auth' \
-  -d 'pluginName=nacos-default-auth-plugin' \
-  -d 'enabled=True'
+  -d 'pluginName=ldap' \
+  -d 'enabled=true' \
+  -d 'localOnly=false'
 ```
 
 * Response example
@@ -7823,6 +7832,8 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/{pipelineId}'
 ## 10. AI Resource Import
 
 AI Resource Import APIs provide query, search, validation, and execution capabilities for external AI resource import sources.
+
+API `sourceId` equals the managed plugin name and is one of `mcp-official`, `mcp-registry-protocol`, `skills-sh`, or `skills-well-known`. The source descriptor field named `pluginName` continues to mean importerType, not sourceId. Next Console retains the existing display names and search-select-validate-import experience for `mcp-official` and `skills-sh`, but presets and cloned endpoints are no longer supported.
 
 ### 10.1. Execute AI Resource Import
 #### Description

--- a/src/content/docs/next/en/manual/admin/console.md
+++ b/src/content/docs/next/en/manual/admin/console.md
@@ -104,12 +104,25 @@ Platform management usually serves administrators. Menus may differ under differ
 | --- | --- |
 | Namespace | Create, edit, and delete namespaces. |
 | Cluster Management | View cluster nodes and basic status. |
-| Plugin Management | View loaded plugins and plugin state. |
+| Plugin Management | View unified inventory, state, effective configuration and sources, and safely update runtime definitions. |
 | User List | Manage console users. |
 | Role Management | Manage roles and user relationships. |
 | Privilege Management | Manage resource permissions. |
 
 If a menu is missing, the common causes are that the current user is not an administrator, the function mode hides the module, or the related capability is not enabled.
+
+### Next Console Plugin Management
+
+The plugin list uses `pluginType:pluginName` identities and shows execution mode, critical, and configurable metadata. Detail shows:
+
+- enabled state and whether it comes from persisted cluster state or a current-node `localOnly` override;
+- definition type, default, aliases, required, sensitivity, and `effectMode`;
+- each effective value's `source` and `overridden` flag, with `LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT`;
+- a masked marker instead of plaintext for sensitive values.
+
+Only `RUNTIME` definitions are editable online. `RESTART` items are read-only and direct operators to change static configuration and restart. A configuration submission replaces the complete map for the selected source; an empty map clears it. Clear current-node `localOnly` overrides before a cluster operation, or they continue to win over persisted values. Illegal runtime state changes to active critical providers, exclusive selection, and PRE_CONTEXT plugins are rejected.
+
+These capabilities apply only to Next Console. Legacy Console does not implement the unified plugin configuration workflow. See [Plugin Operations](../../plugin/operations.md) for the complete semantics.
 
 ## Legacy console
 

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-best-practices.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-best-practices.md
@@ -98,10 +98,10 @@ Basic configuration:
 
 ```properties
 nacos.core.auth.enabled=true
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.server.identity.key=${your_identity_key}
 nacos.core.auth.server.identity.value=${your_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${your_token_secret}
+nacos.plugin.auth.nacos.token.secret.key=${your_token_secret}
 ```
 
 Recommendations:
@@ -128,7 +128,7 @@ Related docs:
 When a cluster carries many client connections or sudden traffic spikes on core APIs, enable the traffic control plugin. Start with `monitor` mode, then switch to `intercept` after the threshold is validated.
 
 ```properties
-nacos.plugin.control.manager.type=nacos
+nacos.plugin.control.type=nacos
 ```
 
 Pay attention to:

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-cluster.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-cluster.md
@@ -53,12 +53,12 @@ In the `conf` directory under the Nacos decompression directory `nacos/`, config
 Then modify `${nacos.home}/conf/application.properties`, add the MySQL data source configuration, and configure the MySQL data source URL, username, and password.
 
 ```
-spring.sql.init.platform=mysql
+nacos.plugin.datasource-dialect.type=mysql
 
-db.num=1
-db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-db.user=${mysql_user}
-db.password=${mysql_password}
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+nacos.plugin.datasource.db.user=${mysql_user}
+nacos.plugin.datasource.db.password=${mysql_password}
 ```
 
 ##### 1.1.3.1. Enable the Default Authentication Plugin
@@ -74,8 +74,8 @@ Set the following items:
 nacos.core.auth.enabled=true
 ## Enable console access authentication. Enabled by default.
 nacos.core.auth.console.enabled=true
-nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${custom_value_same_on_all_nodes}
+nacos.plugin.auth.type=nacos
+nacos.plugin.auth.nacos.token.secret.key=${custom_value_same_on_all_nodes}
 nacos.core.auth.server.identity.key=${custom_value_same_on_all_nodes}
 nacos.core.auth.server.identity.value=${custom_value_same_on_all_nodes}
 ```
@@ -103,8 +103,8 @@ startup.cmd
 The startup program then prompts you to enter the following `3` authentication-related configurations:
 
 ```
-`nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
-nacos.core.auth.plugin.nacos.token.secret.key` Updated:
+`nacos.plugin.auth.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key` Updated:
 ----------------------------------
 `nacos.core.auth.server.identity.key` is missing, please set: ${your_input_server_identity_key}
 `nacos.core.auth.server.identity.key` Updated:
@@ -150,8 +150,8 @@ Set the following items:
 nacos.core.auth.enabled=true
 ## Enable console access authentication. Enabled by default.
 nacos.core.auth.console.enabled=true
-nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${custom_value_same_on_all_nodes}
+nacos.plugin.auth.type=nacos
+nacos.plugin.auth.nacos.token.secret.key=${custom_value_same_on_all_nodes}
 nacos.core.auth.server.identity.key=${custom_value_same_on_all_nodes}
 nacos.core.auth.server.identity.value=${custom_value_same_on_all_nodes}
 ```

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-independent.md
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-independent.md
@@ -76,7 +76,7 @@ You must also configure authentication-related settings to avoid startup failure
 ```properties
 nacos.core.auth.server.identity.key=${your_custom_server_identity_key}
 nacos.core.auth.server.identity.value=${your_custom_server_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${your_custom_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key=${your_custom_token_secret_key}
 ```
 
 :::note
@@ -102,8 +102,8 @@ startup.cmd -d console
 The startup program then prompts you to enter the following `3` authentication-related configurations:
 
 ```
-`nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
-nacos.core.auth.plugin.nacos.token.secret.key` Updated:
+`nacos.plugin.auth.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key` Updated:
 ----------------------------------
 `nacos.core.auth.server.identity.key` is missing, please set: ${your_input_server_identity_key}
 `nacos.core.auth.server.identity.key` Updated:

--- a/src/content/docs/next/en/manual/admin/deployment/deployment-standalone.mdx
+++ b/src/content/docs/next/en/manual/admin/deployment/deployment-standalone.mdx
@@ -28,12 +28,12 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     Then modify `${nacos.home}/conf/application.properties`, add the MySQL data source configuration, and configure the MySQL data source URL, username, and password.
 
     ```
-    spring.sql.init.platform=mysql
+    nacos.plugin.datasource-dialect.type=mysql
 
-    db.num=1
-    db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-    db.user=${mysql_user}
-    db.password=${mysql_password}
+    nacos.plugin.datasource.db.num=1
+    nacos.plugin.datasource.db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+    nacos.plugin.datasource.db.user=${mysql_user}
+    nacos.plugin.datasource.db.password=${mysql_password}
     ```
 
     Then follow [Quick Start - Start Server](../../../quickstart/quick-start/#4-modify-authentication-configuration) to modify the Nacos authentication configuration.

--- a/src/content/docs/next/en/manual/admin/maintainer-sdk.md
+++ b/src/content/docs/next/en/manual/admin/maintainer-sdk.md
@@ -3412,7 +3412,7 @@ A `NacosException` is thrown when reading the config times out or a network exce
 
 #### Description
 
-List loaded plugins, optionally filtered by plugin type.
+List unified plugins loaded by Nacos, optionally filtered by type. Returned identities use `pluginType:pluginName` and include state, critical, executionMode, configurable, and related metadata.
 
 ```java
 List<Map<String, Object>> listPlugins(String pluginType) throws NacosException;
@@ -3450,7 +3450,7 @@ A `NacosException` is thrown when the operation fails.
 
 #### Description
 
-Get plugin detail by type and name.
+Get plugin detail by type and name, including definitions, masked effective configuration, and per-item source/overridden metadata.
 
 ```java
 Map<String, Object> getPluginDetail(String pluginType, String pluginName) throws NacosException;
@@ -3473,7 +3473,7 @@ Map<String, Object> getPluginDetail(String pluginType, String pluginName) throws
 
 ```java
 try {
-    Map<String, Object> detail = coreMaintainerService.getPluginDetail("auth", "nacos-ldap-auth");
+    Map<String, Object> detail = coreMaintainerService.getPluginDetail("auth", "ldap");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -3487,7 +3487,7 @@ A `NacosException` is thrown when the operation fails.
 
 #### Description
 
-Enable or disable a plugin.
+Enable or disable a plugin. Exclusive selection, PRE_CONTEXT implementations, and active critical providers cannot be changed illegally at runtime. `localOnly=true` affects this node only and overrides persisted state.
 
 ```java
 void updatePluginStatus(String pluginType, String pluginName, boolean enabled) throws NacosException;
@@ -3512,8 +3512,8 @@ None (void).
 
 ```java
 try {
-    coreMaintainerService.updatePluginStatus("auth", "nacos-ldap-auth", false);
-    coreMaintainerService.updatePluginStatus("auth", "nacos-ldap-auth", false, true);
+    coreMaintainerService.updatePluginStatus("auth", "ldap", false);
+    coreMaintainerService.updatePluginStatus("auth", "ldap", false, true);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -3527,7 +3527,7 @@ A `NacosException` is thrown when the operation fails.
 
 #### Description
 
-Update plugin configuration.
+Replace the complete configuration map for the target source. Only definitions with `effectMode=RUNTIME` can be changed. Adding, changing, or removing a `RESTART` item is rejected. `localOnly=true` writes higher-priority `LOCAL_ONLY`; otherwise the method writes `RUNTIME_PERSISTED`.
 
 ```java
 void updatePluginConfig(String pluginType, String pluginName, Map<String, String> config) throws NacosException;
@@ -3541,7 +3541,7 @@ void updatePluginConfig(String pluginType, String pluginName, Map<String, String
 |:-----------|:--------------------|:-------|
 | pluginType | string              | Plugin type.  |
 | pluginName | string              | Plugin name.  |
-| config     | Map\<String, String> | Config key-value pairs. |
+| config     | Map\<String, String> | Complete target-source map keyed by definition item key. |
 | localOnly  | boolean             | Whether to apply only to the current node. |
 
 #### Response Parameters
@@ -3553,9 +3553,9 @@ None (void).
 ```java
 try {
     Map<String, String> config = new HashMap<>();
-    config.put("serverAddr", "ldap://localhost:389");
-    coreMaintainerService.updatePluginConfig("auth", "nacos-ldap-auth", config);
-    coreMaintainerService.updatePluginConfig("auth", "nacos-ldap-auth", config, true);
+    config.put("connect-timeout", "6000");
+    coreMaintainerService.updatePluginConfig("auth", "ldap", config);
+    coreMaintainerService.updatePluginConfig("auth", "ldap", config, true);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -3592,7 +3592,7 @@ Map<String, Boolean> getPluginAvailability(String pluginType, String pluginName)
 
 ```java
 try {
-    Map<String, Boolean> availability = coreMaintainerService.getPluginAvailability("auth", "nacos-ldap-auth");
+    Map<String, Boolean> availability = coreMaintainerService.getPluginAvailability("auth", "ldap");
 } catch (NacosException e) {
     e.printStackTrace();
 }

--- a/src/content/docs/next/en/manual/admin/oidc-auth.md
+++ b/src/content/docs/next/en/manual/admin/oidc-auth.md
@@ -141,7 +141,7 @@ nacos.core.auth.server.identity.value=security
 nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
-> **Important**: If `nacos.plugin.auth.nacos.token.secret.key` is not set, the startup script enters interactive mode. The old core key is only an alias. Generate a key with `openssl rand -base64 32`.
+> **Important**: If the canonical value is empty, the startup script first migrates a valid `nacos.core.auth.plugin.nacos.token.secret.key` value found in `application.properties`; it prompts only when neither a valid canonical nor legacy value is available. Generate a key with `openssl rand -base64 32`.
 
 ### 3.3 OIDC Plugin Configuration (Required)
 

--- a/src/content/docs/next/en/manual/admin/oidc-auth.md
+++ b/src/content/docs/next/en/manual/admin/oidc-auth.md
@@ -122,7 +122,7 @@ Edit `<NACOS_HOME>/conf/application.properties`.
 
 ```properties
 ### Enable OIDC/OAuth2 auth
-nacos.core.auth.system.type=oidc
+nacos.plugin.auth.type=oidc
 
 ### Enable authentication
 nacos.core.auth.enabled=true
@@ -138,48 +138,48 @@ nacos.core.auth.server.identity.key=serverIdentity
 nacos.core.auth.server.identity.value=security
 
 ### Internal JWT signing key (Base64 encoded, original string >= 32 chars)
-nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
-> **Important**: If `nacos.core.auth.plugin.nacos.token.secret.key` is not set, the startup script will enter interactive mode prompting for input. Generate a key with `openssl rand -base64 32`.
+> **Important**: If `nacos.plugin.auth.nacos.token.secret.key` is not set, the startup script enters interactive mode. The old core key is only an alias. Generate a key with `openssl rand -base64 32`.
 
 ### 3.3 OIDC Plugin Configuration (Required)
 
 ```properties
 ### IdP Issuer URI (for OIDC auto-discovery)
-nacos.core.auth.plugin.oidc.issuer-uri=http://localhost:8081/realms/nacos
+nacos.plugin.auth.oidc.issuer-uri=http://localhost:8081/realms/nacos
 
 ### OAuth2 Client credentials
-nacos.core.auth.plugin.oidc.client-id=nacos-server
-nacos.core.auth.plugin.oidc.client-secret=nacos-client-secret
+nacos.plugin.auth.oidc.client-id=nacos-server
+nacos.plugin.auth.oidc.client-secret=nacos-client-secret
 
 ### OAuth2 scopes
-nacos.core.auth.plugin.oidc.scope=openid profile email
+nacos.plugin.auth.oidc.scope=openid profile email
 
 ### Claim field for username extraction from ID Token
-nacos.core.auth.plugin.oidc.username-claim=preferred_username
+nacos.plugin.auth.oidc.username-claim=preferred_username
 ```
 
 ### 3.4 OIDC Optional Configuration
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `nacos.core.auth.plugin.oidc.token-validation-method` | `jwt` | Token validation method. The current implementation validates JWTs through JWKS. `introspection` is reserved and should not be documented as a supported runtime path yet |
-| `nacos.core.auth.plugin.oidc.jwks-cache-ttl-seconds` | `3600` | JWKS public key cache TTL (seconds) |
-| `nacos.core.auth.plugin.oidc.roles-claim` | `roles` | Claim name for roles in ID Token |
-| `nacos.core.auth.plugin.oidc.admin-role` | `nacos-admin` | Admin role name |
-| `nacos.core.auth.plugin.oidc.auto-create-user` | `true` | Auto-create user on first login |
-| `nacos.core.auth.plugin.oidc.authorization-endpoint` | (empty) | External authorization decision endpoint. When empty, the current implementation allows non-admin authorization decisions |
-| `nacos.core.auth.plugin.oidc.authorization-timeout-ms` | `5000` | Authorization request timeout (ms) |
-| `nacos.core.auth.plugin.oidc.strict-nonce-validation` | `true` | Enable strict nonce validation |
-| `nacos.core.auth.plugin.oidc.strict-audience-validation` | `true` | Enable strict audience validation |
+| `nacos.plugin.auth.oidc.token-validation-method` | `jwt` | Only JWT/JWKS is implemented; `introspection` is not supported |
+| `nacos.plugin.auth.oidc.jwks-cache-ttl-seconds` | `3600` | JWKS public key cache TTL (seconds) |
+| `nacos.plugin.auth.oidc.roles-claim` | `roles` | Claim name for roles in ID Token |
+| `nacos.plugin.auth.oidc.admin-role` | `nacos-admin` | Admin role name |
+| `nacos.plugin.auth.oidc.auto-create-user` | `true` | Reserved compatibility item; it does not change current runtime behavior |
+| `nacos.plugin.auth.oidc.authorization-endpoint` | (empty) | External authorization decision endpoint. When empty, the current implementation allows non-admin authorization decisions |
+| `nacos.plugin.auth.oidc.authorization-timeout-ms` | `5000` | Authorization request timeout (ms) |
+| `nacos.plugin.auth.oidc.strict-nonce-validation` | `true` | Enable strict nonce validation |
+| `nacos.plugin.auth.oidc.strict-audience-validation` | `true` | Enable strict audience validation |
 
 :::note
 `strict-nonce-validation` and `strict-audience-validation` are enabled by default when not explicitly configured. Disable them only temporarily during development or IdP integration debugging, and turn them back on before production.
 :::
 
 :::caution
-If production needs permission isolation by namespace, config, service, or AI resource, configure `nacos.core.auth.plugin.oidc.authorization-endpoint`, or provide a stricter authorization implementation. In the current implementation, an empty endpoint allows non-admin authorization decisions by default.
+If production needs permission isolation by namespace, config, service, or AI resource, configure `nacos.plugin.auth.oidc.authorization-endpoint`, or provide a stricter authorization implementation. In the current implementation, an empty endpoint allows non-admin authorization decisions by default.
 :::
 
 ### 3.5 Java SDK OAuth2 Client Credentials
@@ -293,12 +293,12 @@ Browser              Nacos                    IdP (Keycloak)
 
 ### 7.1 Startup hangs at "Please input the JWT token secret key"
 
-**Cause**: `nacos.core.auth.plugin.nacos.token.secret.key` is not set.
+**Cause**: `nacos.plugin.auth.nacos.token.secret.key` is not set.
 
 **Fix**: Set a Base64-encoded key in `application.properties`:
 
 ```properties
-nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
 ### 7.2 Startup fails: Empty identity
@@ -325,7 +325,7 @@ nacos.core.auth.server.identity.value=security
 **Steps**:
 1. Verify `issuer-uri` matches the IdP's actual issuer (no trailing slash)
 2. Check `logs/nacos.log` for detailed errors
-3. During development, temporarily disable strict audience validation: `nacos.core.auth.plugin.oidc.strict-audience-validation=false`
+3. During development, temporarily disable strict audience validation: `nacos.plugin.auth.oidc.strict-audience-validation=false`
 4. Verify the IdP's JWKS endpoint is accessible
 
 ### 7.5 Auto-login after logout

--- a/src/content/docs/next/en/manual/admin/system-configurations.md
+++ b/src/content/docs/next/en/manual/admin/system-configurations.md
@@ -228,14 +228,14 @@ For auth setup, read [Authorization](./auth.mdx) and [OIDC/OAuth2 Authentication
 | `nacos.core.auth.enabled` | Whether SDK/gRPC request authentication is enabled. | `false` |
 | `nacos.core.auth.admin.enabled` | Whether `/v3/admin/*` Admin API authentication is enabled. | `true` |
 | `nacos.core.auth.console.enabled` | Whether `/v3/console/*` Console API and login authentication are enabled. | `true` |
-| `nacos.core.auth.caching.enabled` | Whether auth information is cached. Permission updates may have a short delay when enabled. | `true` |
+| `nacos.plugin.auth.nacos.caching.enabled` | Whether auth information is cached; `nacos.core.auth.caching.enabled` is a historical alias. Permission updates may have a short delay when enabled. | `true` |
 | `nacos.core.auth.server.identity.key` | Server-to-server identity key. Required when auth is enabled. | empty |
 | `nacos.core.auth.server.identity.value` | Server-to-server identity value. Required when auth is enabled. | empty |
 | `nacos.security.ignore.urls` | Auth ignored URLs. This is a legacy compatibility property and may be deprecated in the future. | distribution default |
-| `nacos.plugin.auth.nacos.token.cache.enable` | Default auth token cache; the old core key is an alias. | `false` |
-| `nacos.plugin.auth.nacos.token.expire.seconds` | Default auth token expiration in seconds; the old core key is an alias. | `18000` |
-| `nacos.plugin.auth.nacos.token.secret.key` | JWT signing secret; sensitive and RESTART. The old core key is an alias. | empty |
-| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | Whether anonymous AI resource reads are allowed; the old core key is an alias. | `false` |
+| `nacos.plugin.auth.nacos.token.cache.enable` | Default auth token cache; `nacos.core.auth.plugin.nacos.token.cache.enable` is a historical alias. | `false` |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | Default auth token expiration in seconds; `nacos.core.auth.plugin.nacos.token.expire.seconds` is a historical alias. | `18000` |
+| `nacos.plugin.auth.nacos.token.secret.key` | JWT signing secret; sensitive and RESTART. `nacos.core.auth.plugin.nacos.token.secret.key` is a historical alias. | empty |
+| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | Whether anonymous AI resource reads are allowed; `nacos.core.auth.nacos.anonymous.ai.enabled` is a historical alias. | `false` |
 | `nacos.plugin.visibility.enabled` | Whether the visibility plugin is enabled. | `true` |
 | `nacos.plugin.visibility.type` | Visibility plugin type. The default `nacos` implementation reuses default auth plugin user information. | `nacos` |
 
@@ -245,8 +245,8 @@ LDAP and OIDC/OAuth2 are optional plugins. The table lists canonical prefixes; s
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `nacos.plugin.auth.ldap.{itemKey}` | LDAP definitions: `url`, `base-dn`, `timeout`, `user-dn`, `password`, `filter-prefix`, `case-sensitive`, and `ignore-partial-result-exception`. | See the auth plugin page |
-| `nacos.plugin.auth.oidc.{itemKey}` | OIDC definitions for issuer/client, JWT/JWKS, claims, external authorization, and strict validation. Only JWT/JWKS is currently implemented; introspection is not supported. | See the auth plugin page |
+| `nacos.plugin.auth.ldap.{itemKey}` | LDAP definitions: `url`, `base-dn`, `timeout`, `user-dn`, `password`, `filter-prefix`, `case-sensitive`, and `ignore-partial-result-exception`. | See the [Auth Plugin](../../plugin/auth-plugin.md) page |
+| `nacos.plugin.auth.oidc.{itemKey}` | OIDC definitions for issuer/client, JWT/JWKS, claims, external authorization, and strict validation. Only JWT/JWKS is currently implemented; introspection is not supported. | See the [Auth Plugin](../../plugin/auth-plugin.md) page |
 
 ## Plugin Parameters
 
@@ -291,12 +291,12 @@ For usage, see [AI Registry Overview](../user/ai/ai-registry-overview.md). The p
 | `nacos.ai.mcp.registry.port` | Legacy property name. Deprecated. Use `nacos.ai.registry.port` instead. | `9080` |
 | `nacos.plugin.ai-pipeline.enabled` | Dynamic AI Pipeline family gate; when false, type loading is deferred. | `false` |
 | `nacos.plugin.ai-pipeline.type` | Legacy startup chain used only to initialize node state when no persisted state exists. | empty |
-| `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions; only `order` is RUNTIME. | See the Pipeline plugin page |
-| `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions; only `order` is RUNTIME. | See the Pipeline plugin page |
+| `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions; only `order` is RUNTIME. | See the [AI Pipeline Plugin](../../plugin/ai-pipeline-plugin.md) page |
+| `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions; only `order` is RUNTIME. | See the [AI Pipeline Plugin](../../plugin/ai-pipeline-plugin.md) page |
 | `nacos.ai.skill.auto-publish-after-review.enabled` | Whether Skill versions are automatically published after approval. | `false` |
-| `nacos.plugin.ai-resource-import.enabled` | AI Resource Import family gate. The distribution `application.properties` explicitly enables it. | `true` in the distribution |
+| `nacos.plugin.ai-resource-import.enabled` | AI Resource Import family gate. It is enabled when neither the standard key nor its alias is configured; only an explicit `false` disables it. The distribution also sets the standard key to `true`. | `true` |
 | `nacos.plugin.ai-resource-import.{pluginName}.enabled` | Startup state for each fixed source. | `mcp-official`/`skills-sh` enabled; others disabled |
-| `nacos.plugin.ai-resource-import.{pluginName}.{itemKey}` | Source definitions. Endpoint/network items are RESTART; display and limit items are RUNTIME. | See the import plugin page |
+| `nacos.plugin.ai-resource-import.{pluginName}.{itemKey}` | Source definitions. Endpoint/network items are RESTART; display and limit items are RUNTIME. | See the [AI Resource Import Plugin](../../plugin/ai-resource-import-plugin.md) page |
 | `nacos.ai.resource.import.legacy-mcp-api-enabled` | Whether deprecated MCP import APIs are temporarily reopened. | `false` |
 | `nacos.ai.resource.import.allow-user-url` | Whether deprecated MCP import APIs can fetch user-provided URLs after being reopened. | `false` |
 

--- a/src/content/docs/next/en/manual/admin/system-configurations.md
+++ b/src/content/docs/next/en/manual/admin/system-configurations.md
@@ -55,16 +55,17 @@ Nacos supports Derby, MySQL, PostgreSQL, Oracle, and custom database types throu
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `spring.sql.init.platform` | Database type. Supported values include `derby`, `mysql`, `postgresql`, `oracle`, or a custom dialect plugin type. `oracle` requires Oracle 12c or later. | empty |
-| `db.num` | Number of database URLs. | `0` |
-| `db.url.0`, `db.url.1` | JDBC URLs. Use indexes for multiple URLs. | empty |
-| `db.user`, `db.password` | Shared database credentials for all URLs. | empty |
-| `db.user.0`, `db.password.0` | Credentials for a specific indexed URL. Use them when different URLs need different credentials. | empty |
-| `db.pool.config.*` | HikariCP properties, such as `db.pool.config.connectionTimeout`. | HikariCP defaults |
+| `nacos.plugin.datasource-dialect.type` | Select `derby`, `mysql`, `postgresql`, `oracle`, or a custom dialect at startup. | `derby` for standalone/embedded; `mysql` for ordinary cluster |
+| `nacos.plugin.datasource.db.num` | Number of external database URLs. | `0` |
+| `nacos.plugin.datasource.db.url.{index}` | JDBC URL for each index. | empty |
+| `nacos.plugin.datasource.db.user[.{index}]` | Shared or per-connection username. | empty |
+| `nacos.plugin.datasource.db.password[.{index}]` | Shared or per-connection password. | empty |
+| `nacos.plugin.datasource.db.pool.config.*` | HikariCP settings; stable keys use kebab-case, such as `maximum-pool-size`. | See the datasource plugin page |
+| `nacos.plugin.datasource.db.query-timeout` | JDBC query timeout in seconds. | `3` |
 | `nacos.plugin.datasource.log.enabled` | Whether to print datasource plugin logs. | `true` |
 
 :::note
-`spring.datasource.platform` is a legacy compatibility property. New deployments should use `spring.sql.init.platform`.
+`spring.sql.init.platform` is the historical dialect selector alias, and `db.*` contains connection aliases. Canonical keys win. `spring.datasource.platform` has been removed.
 :::
 
 ## Web and Console
@@ -223,7 +224,7 @@ For auth setup, read [Authorization](./auth.mdx) and [OIDC/OAuth2 Authentication
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `nacos.core.auth.system.type` | Auth plugin type. The default implementation is `nacos`. LDAP, OIDC/OAuth2, and custom plugins can also be used. | `nacos` |
+| `nacos.plugin.auth.type` | Select the auth implementation at startup; `nacos.core.auth.system.type` is a legacy alias. | `nacos` |
 | `nacos.core.auth.enabled` | Whether SDK/gRPC request authentication is enabled. | `false` |
 | `nacos.core.auth.admin.enabled` | Whether `/v3/admin/*` Admin API authentication is enabled. | `true` |
 | `nacos.core.auth.console.enabled` | Whether `/v3/console/*` Console API and login authentication are enabled. | `true` |
@@ -231,41 +232,21 @@ For auth setup, read [Authorization](./auth.mdx) and [OIDC/OAuth2 Authentication
 | `nacos.core.auth.server.identity.key` | Server-to-server identity key. Required when auth is enabled. | empty |
 | `nacos.core.auth.server.identity.value` | Server-to-server identity value. Required when auth is enabled. | empty |
 | `nacos.security.ignore.urls` | Auth ignored URLs. This is a legacy compatibility property and may be deprecated in the future. | distribution default |
-| `nacos.core.auth.plugin.nacos.token.cache.enable` | Whether the default auth plugin caches tokens. | `false` |
-| `nacos.core.auth.plugin.nacos.token.expire.seconds` | Token expiration time for the default auth plugin, in seconds. | `18000` |
-| `nacos.core.auth.plugin.nacos.token.secret.key` | JWT signing secret for the default auth plugin. Use a Base64 string from an original secret of at least 32 characters. | empty |
-| `nacos.core.auth.nacos.anonymous.ai.enabled` | Whether anonymous AI resource reads are allowed. Currently mainly applies to Skill and AgentSpec. | `false` |
+| `nacos.plugin.auth.nacos.token.cache.enable` | Default auth token cache; the old core key is an alias. | `false` |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | Default auth token expiration in seconds; the old core key is an alias. | `18000` |
+| `nacos.plugin.auth.nacos.token.secret.key` | JWT signing secret; sensitive and RESTART. The old core key is an alias. | empty |
+| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | Whether anonymous AI resource reads are allowed; the old core key is an alias. | `false` |
 | `nacos.plugin.visibility.enabled` | Whether the visibility plugin is enabled. | `true` |
 | `nacos.plugin.visibility.type` | Visibility plugin type. The default `nacos` implementation reuses default auth plugin user information. | `nacos` |
 
 ### LDAP, OIDC, and OAuth2
 
-LDAP is maintained as an optional plugin starting from Nacos 3.2. OIDC/OAuth2 is also plugin based. Before using these properties, confirm that the corresponding plugin is included in the distribution or placed in the plugin directory.
+LDAP and OIDC/OAuth2 are optional plugins. The table lists canonical prefixes; see [Auth Plugin](../../plugin/auth-plugin.md) for exact definitions, aliases, defaults, and effect modes.
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `nacos.core.auth.ldap.url` | LDAP server URL. | empty |
-| `nacos.core.auth.ldap.basedc` | LDAP base DN. | empty |
-| `nacos.core.auth.ldap.userDn` | LDAP admin user DN. | empty |
-| `nacos.core.auth.ldap.password` | LDAP admin password. | empty |
-| `nacos.core.auth.ldap.userdn` | Login user DN template. `{0}` is replaced with the username. | empty |
-| `nacos.core.auth.ldap.filter.prefix` | User filter prefix. | `uid` |
-| `nacos.core.auth.ldap.case.sensitive` | Whether usernames are case-sensitive. | `true` |
-| `nacos.core.auth.ldap.ignore.partial.result.exception` | Whether LDAP partial result exceptions are ignored. | `false` |
-| `nacos.core.auth.plugin.oidc.issuer-uri` | OIDC issuer URI for auto-discovery. | empty |
-| `nacos.core.auth.plugin.oidc.client-id` | OIDC client id. | empty |
-| `nacos.core.auth.plugin.oidc.client-secret` | OIDC client secret. | empty |
-| `nacos.core.auth.plugin.oidc.scope` | OIDC scopes. | `openid` |
-| `nacos.core.auth.plugin.oidc.token-validation-method` | Token validation method. Valid values include `jwt` and `introspection`. | empty |
-| `nacos.core.auth.plugin.oidc.jwks-cache-ttl-seconds` | JWKS cache TTL in seconds. | empty |
-| `nacos.core.auth.plugin.oidc.username-claim` | Username claim. | `sub` |
-| `nacos.core.auth.plugin.oidc.roles-claim` | Roles claim. | empty |
-| `nacos.core.auth.plugin.oidc.admin-role` | Admin role name. | empty |
-| `nacos.core.auth.plugin.oidc.auto-create-user` | Whether to auto-create users on first login. | `true` |
-| `nacos.core.auth.plugin.oidc.authorization-endpoint` | External authorization endpoint. | empty |
-| `nacos.core.auth.plugin.authorization-timeout-ms` | External authorization request timeout in milliseconds. | empty |
-| `nacos.core.auth.plugin.oidc.strict-nonce-validation` | Whether strict nonce validation is enforced. | `false` |
-| `nacos.core.auth.plugin.oidc.strict-audience-validation` | Whether strict audience validation is enforced. | `false` |
+| `nacos.plugin.auth.ldap.{itemKey}` | LDAP definitions: `url`, `base-dn`, `timeout`, `user-dn`, `password`, `filter-prefix`, `case-sensitive`, and `ignore-partial-result-exception`. | See the auth plugin page |
+| `nacos.plugin.auth.oidc.{itemKey}` | OIDC definitions for issuer/client, JWT/JWKS, claims, external authorization, and strict validation. Only JWT/JWKS is currently implemented; introspection is not supported. | See the auth plugin page |
 
 ## Plugin Parameters
 
@@ -274,15 +255,13 @@ For the plugin system, see [Plugin Overview](../../plugin/overview.md).
 | Property | Description | Default |
 | --- | --- | --- |
 | `nacos.custom.environment.enabled` | Whether the custom environment plugin is enabled. | `false` |
-| `nacos.plugin.control.manager.type` | Traffic control plugin type. Set to `nacos` to use the default implementation. | empty |
+| `nacos.plugin.control.type` | Select the control implementation at startup; `nacos.plugin.control.manager.type` is a legacy alias. | empty (no-limit) |
 | `nacos.plugin.control.rule.local.basedir` | Local directory for traffic control rules. | `${nacos.home}` |
 | `nacos.plugin.control.rule.external.storage` | External rule storage type. Requires a custom implementation. | empty |
-| `nacos.core.config.plugin.webhook.enabled` | Whether the config change webhook plugin is enabled. | `false` |
-| `nacos.core.config.plugin.webhook.url` | Webhook URL. | empty |
-| `nacos.core.config.plugin.webhook.contentMaxCapacity` | Maximum webhook payload size in bytes. | `102400` |
-| `nacos.core.config.plugin.whitelist.enabled` | Whether the config import suffix whitelist plugin is enabled. | `false` |
-| `nacos.core.config.plugin.whitelist.suffixs` | Allowed config import file suffixes. | `xml,text,properties,yaml,html` |
-| `nacos.core.config.plugin.fileformatcheck.enabled` | Whether the imported file format check plugin is enabled. | `false` |
+| `nacos.plugin.{pluginType}.{pluginName}.enabled` | Implementation startup state; persisted or local state can override it. | Defined by implementation and type policy |
+| `nacos.plugin.{pluginType}.{pluginName}.{itemKey}` | Canonical key for an implementation definition. | Defined by the definition |
+
+Historical `nacos.core.config.plugin.{pluginName}.*` properties exist only for old config-change binaries. Nacos Server does not bundle webhook, whitelist, or fileformatcheck implementations. New implementations use `nacos.plugin.config-change.{pluginName}.{itemKey}`.
 
 ## Istio and Prometheus Service Discovery
 
@@ -310,20 +289,18 @@ For usage, see [AI Registry Overview](../user/ai/ai-registry-overview.md). The p
 | `nacos.ai.skill.registry.enabled` | Whether the Skill Registry protocol adapter is enabled. When enabled, it exposes an independent port through `nacos.ai.registry.port`. | `false` |
 | `nacos.ai.registry.port` | AI Registry protocol adapter port. | `9080` |
 | `nacos.ai.mcp.registry.port` | Legacy property name. Deprecated. Use `nacos.ai.registry.port` instead. | `9080` |
-| `nacos.plugin.ai-pipeline.enabled` | Whether AI publish pipeline is enabled. If unset, it does not actively disable the pipeline, but no pipeline runs when `type` is empty. | empty |
-| `nacos.plugin.ai-pipeline.type` | Pipeline node type, such as `skill-scanner`. Separate multiple types with commas. | empty |
-| `nacos.plugin.ai-pipeline.skill-scanner.enabled` | Enablement property passed to the built-in `skill-scanner` node. | empty |
-| `nacos.plugin.ai-pipeline.skill-scanner.command` | External Skill scanner command path. | empty |
+| `nacos.plugin.ai-pipeline.enabled` | Dynamic AI Pipeline family gate; when false, type loading is deferred. | `false` |
+| `nacos.plugin.ai-pipeline.type` | Legacy startup chain used only to initialize node state when no persisted state exists. | empty |
+| `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions; only `order` is RUNTIME. | See the Pipeline plugin page |
+| `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions; only `order` is RUNTIME. | See the Pipeline plugin page |
 | `nacos.ai.skill.auto-publish-after-review.enabled` | Whether Skill versions are automatically published after approval. | `false` |
-| `nacos.ai.resource.import.enabled` | Whether explicitly configured AI resource import sources are enabled. | `false` |
+| `nacos.plugin.ai-resource-import.enabled` | AI Resource Import family gate. The distribution `application.properties` explicitly enables it. | `true` in the distribution |
+| `nacos.plugin.ai-resource-import.{pluginName}.enabled` | Startup state for each fixed source. | `mcp-official`/`skills-sh` enabled; others disabled |
+| `nacos.plugin.ai-resource-import.{pluginName}.{itemKey}` | Source definitions. Endpoint/network items are RESTART; display and limit items are RUNTIME. | See the import plugin page |
 | `nacos.ai.resource.import.legacy-mcp-api-enabled` | Whether deprecated MCP import APIs are temporarily reopened. | `false` |
 | `nacos.ai.resource.import.allow-user-url` | Whether deprecated MCP import APIs can fetch user-provided URLs after being reopened. | `false` |
-| `nacos.plugin.ai.importer.mcp.official.enabled` | Whether the built-in official MCP Registry import source is enabled. | `true` |
-| `nacos.plugin.ai.importer.skills.well-known.enabled` | Whether the Skill well-known import source is enabled. | `false` |
-| `nacos.plugin.ai.importer.skills.well-known.url` | Skill well-known registry root URL. | empty |
-| `nacos.plugin.ai.importer.skills.skills-sh.enabled` | Whether the `skills.sh` import source is enabled. | `true` |
-| `nacos.plugin.ai.importer.<preset>.allow-http` | Whether non-HTTPS endpoints are allowed for a source. Enable only in controlled environments. | `false` |
-| `nacos.plugin.ai.importer.<preset>.allow-private-network` | Whether private-network or localhost endpoints are allowed for a source. Enable only in controlled environments. | `false` |
+
+Old `nacos.plugin.ai.importer.*`, `nacos.ai.resource.import.sources[N].*`, presets, and cloned-endpoint models are removed or retained only as explicitly documented migration aliases. Do not use them for new deployments. See [AI Resource Import Plugin](../../plugin/ai-resource-import-plugin.md).
 
 ## Experimental Features
 

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -239,17 +239,11 @@ If you are upgrading from version 3.0.0 and your cluster has MCP services, note 
 java -jar ./mcp-migration-tool.jar localhost:8848 nacos ${your_password}
 ```
 
-#### 2.1.9. Migrate Unified Plugin Configuration
+#### 2.1.9. Migrate Unified Plugin Configuration (Nacos 3.3.0+)
 
-Before upgrading to a next build containing the unified plugin management refactor, inventory `${nacos.home}/plugins`, `application.properties`, and configuration automation:
+If the deployment does not use custom server plugins, compare its current `application.properties` with the target distribution, then migrate retained legacy properties to the canonical keys documented in [System Configurations](./system-configurations.md). AI Resource Import now defaults to enabled when its gate is absent, so set `nacos.plugin.ai-resource-import.enabled=false` before rollout if it must remain disabled. A deployment that used the old Source/preset/list configuration must also follow the [AI Resource Import migration](../../plugin/migration.md#ai-resource-import-breaking-change).
 
-1. Use `pluginType:pluginName` identities and migrate selectors and implementation settings to canonical `nacos.plugin.*` keys.
-2. Back up `${nacos.home}/data/plugin/plugin-states.json` and `plugin-configs.json`. Do not blindly copy runtime files that do not match the target plugin inventory.
-3. Use Next Console or Admin API to verify definitions, effective sources, and sensitive masking. Put `RESTART` items in static configuration and restart; the PUT API cannot change them.
-4. For AI Resource Import, remove source/preset/list configuration and old SPI JARs, then configure the four fixed plugin names. The old two-level Importer/Source SPI no longer loads.
-5. For external Config Change plugins, migrate to `PluginConfigSpec`; `ConfigChangeConfigs` and the old core prefix are compatibility-only.
-
-See [Plugin Migration](../../plugin/migration.md) for the complete key/SPI map and rollback guidance.
+If the deployment uses self-developed or third-party server plugins, complete the same configuration comparison and review the plugin compatibility changes before rollout. In particular, the legacy Importer/Source SPI for AI Resource Import has been removed, while Config Change's `ConfigChangeConfigs` is deprecated and retained only for compatibility. Follow the [Plugin Migration Guide](../../plugin/migration.md), then check the relevant [AI Resource Import](../../plugin/ai-resource-import-plugin.md), [Config Change](../../plugin/config-change-plugin.md), and [Plugin Development](../../plugin/development.md) pages.
 
 ### 2.2. Docker/Kubernetes Upgrade
 

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -239,6 +239,18 @@ If you are upgrading from version 3.0.0 and your cluster has MCP services, note 
 java -jar ./mcp-migration-tool.jar localhost:8848 nacos ${your_password}
 ```
 
+#### 2.1.9. Migrate Unified Plugin Configuration
+
+Before upgrading to a next build containing the unified plugin management refactor, inventory `${nacos.home}/plugins`, `application.properties`, and configuration automation:
+
+1. Use `pluginType:pluginName` identities and migrate selectors and implementation settings to canonical `nacos.plugin.*` keys.
+2. Back up `${nacos.home}/data/plugin/plugin-states.json` and `plugin-configs.json`. Do not blindly copy runtime files that do not match the target plugin inventory.
+3. Use Next Console or Admin API to verify definitions, effective sources, and sensitive masking. Put `RESTART` items in static configuration and restart; the PUT API cannot change them.
+4. For AI Resource Import, remove source/preset/list configuration and old SPI JARs, then configure the four fixed plugin names. The old two-level Importer/Source SPI no longer loads.
+5. For external Config Change plugins, migrate to `PluginConfigSpec`; `ConfigChangeConfigs` and the old core prefix are compatibility-only.
+
+See [Plugin Migration](../../plugin/migration.md) for the complete key/SPI map and rollback guidance.
+
 ### 2.2. Docker/Kubernetes Upgrade
 
 #### 2.2.1 Verify Database Schema

--- a/src/content/docs/next/en/manual/user/ai/skill-registry.md
+++ b/src/content/docs/next/en/manual/user/ai/skill-registry.md
@@ -98,21 +98,25 @@ Submit a draft version for review. After submission, the version state changes t
 
 The Pipeline is a configurable review process that performs automated checks before Skill publication. **The Pipeline is disabled by default**; when disabled, submitting for review will directly publish to online state.
 
-The Pipeline uses a plugin-based architecture, loading check nodes via Java SPI. A built-in **skill-scanner** plugin is provided (based on [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)). Users can also implement the `PublishPipelineServiceBuilder` interface to develop custom plugins and register them via SPI. Multiple plugins are executed serially in order of `getPreferOrder()`, with each plugin proceeding only after the previous one passes.
+The Pipeline loads nodes that directly implement `PublishPipelineService` through Java SPI. It bundles `ai-pipeline:skill-scanner` (based on [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)) and `ai-pipeline:skill-spector`; both support Skill, AgentSpec, and Prompt. Enabled nodes run serially by `getPreferOrder()` in ascending order. The old `PublishPipelineServiceBuilder` SPI has been removed.
 
 To enable the Pipeline, configure in `application.properties`:
 
 ```properties
-# Enable Pipeline and specify check nodes
+# Enable Pipeline; type only initializes chain state during first migration
 nacos.plugin.ai-pipeline.enabled=true
-nacos.plugin.ai-pipeline.type=skill-scanner
+nacos.plugin.ai-pipeline.type=skill-scanner,skill-spector
 
-# Check node configuration (skill-scanner example)
+# Implementation startup state and configuration
 nacos.plugin.ai-pipeline.skill-scanner.enabled=true
 nacos.plugin.ai-pipeline.skill-scanner.command=/path/to/skill-scanner
+nacos.plugin.ai-pipeline.skill-spector.enabled=true
+nacos.plugin.ai-pipeline.skill-spector.command=/path/to/skill-spector
 ```
 
-The skill-scanner plugin detects the following risks:
+Persisted or runtime unified state is authoritative for current chain membership. Only each node's `order` definition can be changed at runtime; command, LLM, and scan settings are `RESTART`. See [AI Publish Pipeline Plugin](../../../plugin/ai-pipeline-plugin.md) for complete definitions.
+
+The scanner nodes can detect risks such as:
 
 - Prompt injection attacks
 - Data leakage risks

--- a/src/content/docs/next/en/manual/user/auth.mdx
+++ b/src/content/docs/next/en/manual/user/auth.mdx
@@ -135,7 +135,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v2/cs/config?accessToken=${accessToken}
 
 ### OIDC/OAuth2 Auth
 
-When the server uses `nacos.core.auth.system.type=oidc`, do not use `/v3/auth/user/login` to obtain a token. Obtain an OAuth2/OIDC token from the enterprise IdP, then call Nacos with it:
+When the server uses `nacos.plugin.auth.type=oidc`, do not use `/v3/auth/user/login` to obtain a token. Obtain an OAuth2/OIDC token from the enterprise IdP, then call Nacos with it:
 
 ```powershell
 curl -X GET 'http://127.0.0.1:8848/nacos/v2/cs/config?dataId=example.properties&group=DEFAULT_GROUP' \
@@ -155,7 +155,7 @@ For server-side OIDC/OAuth2 setup, see [Admin Manual - OIDC/OAuth2 Authenticatio
 Common causes:
 
 - The token expired.
-- `nacos.core.auth.plugin.nacos.token.secret.key` is inconsistent across cluster nodes.
+- `nacos.plugin.auth.nacos.token.secret.key` is inconsistent across cluster nodes.
 - The server switched to another auth plugin type.
 - Permissions changed while the client still uses an old token.
 

--- a/src/content/docs/next/en/plugin/address-plugin.md
+++ b/src/content/docs/next/en/plugin/address-plugin.md
@@ -3,7 +3,7 @@ title: Cluster Addressing
 keywords: [Addressing, cluster members, address-server, cluster.conf]
 description: Learn how Nacos Server discovers cluster members with file and address-server modes.
 sidebar:
-    order: 10
+    order: 13
 ---
 
 # Cluster Addressing

--- a/src/content/docs/next/en/plugin/ai-pipeline-plugin.md
+++ b/src/content/docs/next/en/plugin/ai-pipeline-plugin.md
@@ -1,74 +1,86 @@
 ---
 title: AI Publish Pipeline
-keywords: [AI Pipeline, AI Registry, Skill, Prompt, MCP, AgentSpec]
-description: Learn how the Nacos AI publish pipeline plugin works, how to enable it, and how to develop custom release checks.
+keywords: [AI Pipeline, AI Registry, Skill, Prompt, AgentSpec]
+description: Learn the execution model, built-in implementations, configuration, and development contract of Nacos AI publish pipeline plugins.
 sidebar:
-    order: 11
+    order: 14
 ---
 
 # AI Publish Pipeline Plugin
 
-The AI publish pipeline plugin runs review, scanning, or blocking logic before an AI resource is published. It is useful for production release governance of Skills, Prompts, MCP Servers, AgentSpecs, and future AI resource types.
+The AI publish pipeline runs review, scanning, or interception before an AI resource is published. It may approve or reject publication, but it cannot change the resource's canonical identity, version, or visibility.
 
-Pipeline belongs to AI resource governance. It can approve or reject a publish operation, but it does not change the namespace, resource name, version, or visibility model of the AI resource.
+Its unified type is `ai-pipeline`, execution mode is `CHAIN`, load phase is `STANDARD`, and the type is non-critical. For each publication, Nacos selects enabled nodes supporting the resource type and runs them serially by `getPreferOrder()` in ascending order. A rejection stops the remaining nodes and persists the result.
 
-## When To Use It
+## Gate, State, and Loading
 
-Enable a pipeline when:
+These controls have separate owners:
 
-- Skill packages need security scanning before production use.
-- Prompts, AgentSpecs, or MCP Servers need format, compliance, or custom checks.
-- Production release should be separated from draft editing.
-- Administrators need a visible result and reason for every publish review.
+| Configuration or state | Responsibility |
+| --- | --- |
+| `nacos.plugin.ai-pipeline.enabled` | Dynamic family gate owned by the AI module. When false, type loading is deferred; enabling discovers services, restores state, and applies configuration. |
+| `nacos.plugin.ai-pipeline.type` | Legacy startup chain composition, used only to initialize implementation state when no persisted state exists. |
+| `ai-pipeline:{pipelineId}` state | Authoritative current chain membership. A disabled node remains in inventory but does not run. |
+| `nacos.plugin.ai-pipeline.{pipelineId}.{itemKey}` | Private configuration declared and consumed by the node through `PluginConfigSpec`. |
 
-If no pipeline is enabled, submitting a resource may publish it directly or move it to a publishable state. The exact behavior depends on the resource type and console flow.
+When the family gate is off or no node matches, publication proceeds without interception. Service instances must remain lightweight and defer CLI, connection, or thread initialization until their first `applyConfig`.
 
-## Execution Model
+## Built-in Nodes
 
-Pipeline is an ordered chain of plugins. For each publish operation, Nacos selects nodes that support the target resource type and runs them by `getPreferOrder()` in ascending order.
+Nacos bundles two nodes. Both support `SKILL`, `AGENTSPEC`, and `PROMPT`:
 
-```text
-submit publish
-  -> create pipeline execution record
-  -> run selected nodes in order
-  -> all passed: continue publish
-  -> any rejected: stop publish and keep the version unpublished
-```
+| pluginId | Default state | Purpose |
+| --- | --- | --- |
+| `ai-pipeline:skill-scanner` | Enabled | Invokes the `skill-scanner` CLI. |
+| `ai-pipeline:skill-spector` | Enabled | Invokes the `skill-spector` CLI for static and optional LLM risk analysis. |
 
-Notes:
+### skill-scanner definitions
 
-- Only configured nodes that support the target resource type are selected.
-- When one node rejects the publish, later nodes do not run.
-- If pipeline is disabled or no node matches, the publish flow is not blocked by pipeline.
-- Force publish bypasses pipeline validation. Use it for emergencies, not as the normal release path.
+The canonical prefix is `nacos.plugin.ai-pipeline.skill-scanner.`:
 
-Unified plugin management can list loaded `ai-pipeline` plugins. Until the execution chain is fully wired to unified plugin enablement, the pipeline feature is controlled by its own configuration.
+| key | aliases | type | default | sensitive | effectMode |
+| --- | --- | --- | --- | --- | --- |
+| `order` | None | NUMBER | `100` | No | RUNTIME |
+| `command` | `executable`, `path` | STRING | `skill-scanner` | No | RESTART |
+| `use-llm` | `useLlm` | BOOLEAN | `false` | No | RESTART |
+| `llm-api-key` | `llmApiKey` | STRING | empty | Yes | RESTART |
+| `llm-model` | `llmModel` | STRING | empty | No | RESTART |
+| `llm-provider` | `llmProvider` | STRING | empty | No | RESTART |
+| `enable-meta` | `enableMeta` | BOOLEAN | `false` | No | RESTART |
 
-## Enable the Built-in skill-scanner
-
-The default Nacos plugin set provides a `skill-scanner` pipeline node. It can process scannable content in Skills, Prompts, and AgentSpecs. A common use case is calling an external Skill scanning tool.
-
-Enable it in `${nacos.home}/conf/application.properties`:
+Example:
 
 ```properties
 nacos.plugin.ai-pipeline.enabled=true
-nacos.plugin.ai-pipeline.type=skill-scanner
-nacos.plugin.ai-pipeline.skill-scanner.enabled=true
-nacos.plugin.ai-pipeline.skill-scanner.command=/path/to/skill-scanner
+nacos.plugin.ai-pipeline.skill-scanner.command=/opt/scanners/skill-scanner
+nacos.plugin.ai-pipeline.skill-scanner.use-llm=true
+nacos.plugin.ai-pipeline.skill-scanner.llm-api-key=${SKILL_SCANNER_API_KEY}
 ```
 
-| Property | Description |
-| --- | --- |
-| `nacos.plugin.ai-pipeline.enabled` | Enables AI Pipeline. |
-| `nacos.plugin.ai-pipeline.type` | Pipeline node type to run. |
-| `nacos.plugin.ai-pipeline.skill-scanner.enabled` | Enables the `skill-scanner` node. |
-| `nacos.plugin.ai-pipeline.skill-scanner.command` | Path of the external Skill scanner command. |
+### skill-spector definitions
 
-In production, keep the same plugin versions and configuration on all Nacos Server nodes. If the scanner depends on an external executable, make sure every node can access it.
+The canonical prefix is `nacos.plugin.ai-pipeline.skill-spector.`:
+
+| key | aliases | type | default | sensitive | effectMode |
+| --- | --- | --- | --- | --- | --- |
+| `order` | None | NUMBER | `90` | No | RUNTIME |
+| `command` | `executable`, `path` | STRING | `skill-spector` | No | RESTART |
+| `use-llm` | `useLlm` | BOOLEAN | `false` | No | RESTART |
+| `provider` | None | STRING | empty | No | RESTART |
+| `model` | None | STRING | empty | No | RESTART |
+| `api-key` | `apiKey` | STRING | empty | Yes | RESTART |
+| `base-url` | `baseUrl` | STRING | empty | No | RESTART |
+| `log-level` | `logLevel` | STRING | `WARNING` | No | RESTART |
+| `risk-score-threshold` | `riskScoreThreshold` | NUMBER | `50` | No | RESTART |
+| `max-findings` | `maxFindings` | NUMBER | `20` | No | RESTART |
+
+`risk-score-threshold` is clamped to `0..100`. `max-findings` is capped at `100`, and zero, negative, or invalid values use the default. Existing process environment variables take precedence over values copied from SkillSpector plugin configuration.
+
+Except for `order`, both built-in nodes resolve their command and create immutable scan options on first configuration application, so these fields require restart. Sensitive API keys are masked in detail responses. If the command cannot be found, the node remains queryable, but an attempted scan rejects publication with an installation hint.
 
 ## Develop a Custom Pipeline
 
-Add the dependency:
+Dependency:
 
 ```xml
 <dependency>
@@ -78,43 +90,29 @@ Add the dependency:
 </dependency>
 ```
 
-Implement `com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder` and declare it with Java SPI:
+Directly implement `com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService`, provide a public no-argument constructor, and register it through:
 
 ```text
-META-INF/services/com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder
+META-INF/services/com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService
 ```
 
-Builder methods:
-
-| Method | Description |
+| Method | Requirement |
 | --- | --- |
-| `pipelineId()` | Stable node ID used by configuration, logs, and execution records. |
-| `build(properties)` | Builds a `PublishPipelineService` from configuration. |
+| `pipelineId()` | Stable node name used in `ai-pipeline:{pipelineId}`. |
+| `execute(context)` | Run review and return approval or rejection. |
+| `getPreferOrder()` | Chain order; lower values run first. |
+| `pipelineResourceTypes()` | Supported resource types. |
+| `getConfigDefinitions()` | Declare definitions. |
+| `applyConfig(config)` | Atomically accept the complete effective item map. |
+| `getCurrentConfig()` | Return the accepted snapshot. |
 
-Service methods:
+The former `PublishPipelineServiceBuilder` SPI and arbitrary `Properties` construction path have been removed. Existing plugins must migrate so the service itself implements `PluginConfigSpec`; replacing only the SPI registration while retaining a builder is insufficient.
 
-| Method | Description |
-| --- | --- |
-| `pipelineId()` | Runtime node ID. |
-| `execute(context)` | Runs the check and returns pass or reject. |
-| `getPreferOrder()` | Execution order. Lower values run earlier. |
-| `pipelineResourceTypes()` | Supported resource types, such as Skill, Prompt, MCP, or AgentSpec. |
+## Operations Guidance
 
-## Development Advice
+- Keep plugin JARs, CLIs, and RESTART configuration identical on all nodes. `order` can be changed through the unified PUT configuration API at runtime.
+- Set timeouts for external commands and return readable rejection reasons. Do not log full resources or credentials.
+- Use plugin detail to verify `effectiveConfig`, sources, and the accepted snapshot. Restart every node after changing RESTART fields.
+- Pipeline results are publication governance records; they do not replace authorization, visibility, or content storage.
 
-- Return deterministic results for the same resource version and input.
-- Set timeouts when calling external systems.
-- Return clear rejection reasons so resource authors can fix the problem.
-- Do not modify resource content in pipeline. Use the draft editing flow for content changes.
-- Do not write full Skill packages, Prompt content, keys, or credentials to logs.
-
-## Troubleshooting
-
-| Symptom | What to check |
-| --- | --- |
-| Submit does not enter review | Check `nacos.plugin.ai-pipeline.enabled` and `nacos.plugin.ai-pipeline.type`. |
-| `skill-scanner` does not run | Check `skill-scanner.enabled`, the scanner command path, and whether the plugin JAR is on the classpath. |
-| Publish keeps failing | Check the pipeline execution record and the node rejection reason. |
-| Unified plugin management shows disabled but the node still runs | Follow the pipeline configuration in the current version. Unified enablement is not fully wired into the execution chain yet. |
-
-Related reading: [AI Resource Lifecycle](../manual/user/ai/ai-resource-lifecycle.md) and [AI Resource Import Plugin](./ai-resource-import-plugin.md).
+Related reading: [Plugin Operations](./operations.md), [Plugin Development](./development.md), and [AI Resource Lifecycle](../manual/user/ai/ai-resource-lifecycle.md).

--- a/src/content/docs/next/en/plugin/ai-resource-import-plugin.md
+++ b/src/content/docs/next/en/plugin/ai-resource-import-plugin.md
@@ -38,7 +38,7 @@ When AI function mode and the AI module permit it, the family switch controls im
 nacos.plugin.ai-resource-import.enabled=true
 ```
 
-`nacos.ai.resource.import.enabled` is a historical alias, and the standard key wins. The official distribution `application.properties` sets the standard key to `true`, so AI Resource Import is enabled by default. Set it to `false` explicitly only when the deployment must disable this capability.
+`nacos.ai.resource.import.enabled` is a historical alias. The standard key is authoritative whenever it is present, including when its value is blank. The family gate defaults to enabled even when neither key is configured; only an explicit `false` disables AI Resource Import. The distribution also sets the standard key to `true`.
 
 Initial source state uses:
 
@@ -50,7 +50,7 @@ Persisted unified state takes precedence. Runtime routing also checks Builder st
 
 ## Four built-in sources
 
-| pluginId | API importer type | Resource | Endpoint | Distribution initial state |
+| pluginId | API importer type | Resource | Endpoint | Default implementation state |
 | --- | --- | --- | --- | --- |
 | `ai-resource-import:mcp-official` | `mcp-registry` | `mcp` | Fixed official MCP Registry | enabled |
 | `ai-resource-import:mcp-registry-protocol` | `mcp-registry` | `mcp` | Operator configuration required | disabled |

--- a/src/content/docs/next/en/plugin/ai-resource-import-plugin.md
+++ b/src/content/docs/next/en/plugin/ai-resource-import-plugin.md
@@ -1,184 +1,195 @@
 ---
 title: AI Resource Import
-keywords: [AI Resource Import, MCP Registry, Skill Registry, AI Registry]
-description: Learn how Nacos imports AI resources from external registries, how sources are configured, and how to extend importers.
+keywords: [AI Resource Import, MCP Registry, Skill Registry, PluginConfigSpec]
+description: Learn the unified AI Resource Import plugins, four built-in sources, definitions, security boundaries, and old SPI migration.
 sidebar:
-    order: 12
+    order: 15
 ---
 
 # AI Resource Import Plugin
 
-The AI resource import plugin brings AI resources from external registries, marketplaces, or internal catalogs into Nacos AI Registry. After import, the resource enters the Nacos namespace, version, visibility, and lifecycle model.
+AI Resource Import plugins convert MCP Servers, Skills, and future AI resources from external registries, marketplaces, or enterprise catalogs into artifacts that Nacos can validate and write. They own only the external protocol and conversion. Namespace, identity, auth, visibility, versioning, publish Pipeline, and storage remain AI Registry responsibilities.
 
-The importer only owns external source discovery and conversion into import artifacts. Nacos resource identity, auth, visibility, lifecycle, and storage still belong to AI Registry.
+## Unified source model
 
-## Use Cases
-
-Typical use cases:
-
-- Import MCP Servers from the official MCP registry.
-- Import Skills from a Skill well-known endpoint.
-- Import Skills from skills.sh or an internal Skill marketplace.
-- Connect an internal tool catalog, private Git index, or model platform as an AI Registry source.
-
-Import is for resource onboarding and governance. It should not bypass Nacos publish, review, or permission flows.
-
-## Import Flow
-
-The unified flow is:
+`ai-resource-import` is a `ROUTED` plugin type. One Builder represents one fixed external source:
 
 ```text
-list sources -> search candidates -> select candidates -> validate conflicts and dependencies -> execute import
+pluginId = ai-resource-import:{pluginName}
+sourceId = managed pluginName
 ```
 
-Each source is configured by operators and exposed as a `sourceId`. Users select a `sourceId` during import. Requests must not submit arbitrary endpoints, IPs, credentials, or registry roots.
+A request `sourceId` routes directly to one enabled Builder. The existing API field `pluginName` remains importer/protocol metadata for Console compatibility; it is not the managed plugin name.
 
-| Step | Description |
-| --- | --- |
-| List sources | Returns import sources available for a resource type. |
-| Search candidates | Searches summaries from the selected source. Full payloads are not downloaded. |
-| Validate | Fetches required artifacts and checks type, size, conflicts, and dependencies. |
-| Execute | Passes valid artifacts to the resource operator and writes Nacos AI resources. |
+```text
+sourceId
+  -> AiResourceImportServiceBuilder(accepted snapshot)
+  -> request-scoped AiResourceImportService
+  -> AiResourceOperator(resourceType)
+```
 
-Browsers and consoles should not receive full artifacts. MCP specifications, Skill ZIP files, and similar payloads should only flow inside the server-side import path.
+One `pluginName` represents exactly one source. Configuration can no longer clone one implementation to multiple endpoints. Ship another Builder with a distinct `pluginName` for another fixed source.
 
-## Source Configuration
+## Gates, state, and defaults
 
-A source usually contains:
-
-| Field | Description |
-| --- | --- |
-| `sourceId` | Stable source ID selected by users. |
-| `pluginName` | Importer implementation name under `ai-resource-import`. |
-| `resourceTypes` | Supported resource types, such as `mcp` or `skill`. |
-| `endpoint` | Source endpoint configured by operators. |
-| `enabled` | Whether the source is enabled. |
-| `authRef` | Optional server-side credential reference. Credentials are not returned to users. |
-| `connectTimeout` / `readTimeout` | Network timeouts. |
-| `maxPageCount` / `maxItemCount` | Page and item limits. |
-| `maxArtifactSize` | Maximum artifact size. |
-| `properties` | Importer-specific non-secret properties. |
-
-Explicit sources can be configured under `nacos.ai.resource.import.sources[...]` and enabled with `nacos.ai.resource.import.enabled=true`. Built-in preset sources are enabled or disabled independently with `nacos.plugin.ai.importer.*` properties.
-
-When the default importer plugin is loaded, the official MCP Registry source and skills.sh source are enabled by default. To disable them, set the corresponding preset `enabled` property to `false`.
-
-## Built-in Sources
-
-### Official MCP Registry
-
-Enable the official MCP source:
+When AI function mode and the AI module permit it, the family switch controls importer loading:
 
 ```properties
-nacos.plugin.ai.importer.mcp.official.enabled=true
+nacos.plugin.ai-resource-import.enabled=true
 ```
 
-Defaults:
+`nacos.ai.resource.import.enabled` is a historical alias, and the standard key wins. The official distribution `application.properties` sets the standard key to `true`, so AI Resource Import is enabled by default. Set it to `false` explicitly only when the deployment must disable this capability.
 
-| Item | Default |
-| --- | --- |
-| `sourceId` | `mcp-official` |
-| importer | `mcp-registry` |
-| resource type | `mcp` |
-| endpoint | `https://registry.modelcontextprotocol.io/v0/servers` |
-
-Use the `nacos.plugin.ai.importer.mcp.official.*` prefix to override source ID, display name, endpoint, auth reference, timeouts, and size limits.
-
-### Skill Well-known
-
-Enable a Skill well-known source:
+Initial source state uses:
 
 ```properties
-nacos.plugin.ai.importer.skills.well-known.enabled=true
-nacos.plugin.ai.importer.skills.well-known.url=https://developers.cloudflare.com
+nacos.plugin.ai-resource-import.{pluginName}.enabled=true
 ```
 
-Defaults:
+Persisted unified state takes precedence. Runtime routing also checks Builder state; disabled sources are neither listed nor allowed to search, validate, or execute.
 
-| Item | Default |
-| --- | --- |
-| `sourceId` | `skills-well-known` |
-| importer | `skills-well-known` |
-| resource type | `skill` |
-| endpoint | `nacos.plugin.ai.importer.skills.well-known.url` |
+## Four built-in sources
 
-The importer tries `/.well-known/agent-skills` and falls back to the legacy `/.well-known/skills` path. It supports Skill discovery v0.1.0 and v0.2.0.
+| pluginId | API importer type | Resource | Endpoint | Distribution initial state |
+| --- | --- | --- | --- | --- |
+| `ai-resource-import:mcp-official` | `mcp-registry` | `mcp` | Fixed official MCP Registry | enabled |
+| `ai-resource-import:mcp-registry-protocol` | `mcp-registry` | `mcp` | Operator configuration required | disabled |
+| `ai-resource-import:skills-sh` | `skills-sh` | `skill` | Fixed `https://skills.sh` | enabled |
+| `ai-resource-import:skills-well-known` | `skills-well-known` | `skill` | Operator configuration required | disabled |
 
-### skills.sh
+The Console still displays `Official MCP Registry` for `mcp-official` and `skills.sh` for `skills-sh`. The existing select, search, choose candidates, validate, and execute experience remains unchanged.
 
-Enable skills.sh:
+### Fixed endpoint sources
+
+`mcp-official` and `skills-sh` do not declare `endpoint`, `allow-http`, or `allow-private-network` and do not accept old endpoint overrides. The source endpoint is part of implementation identity.
 
 ```properties
-nacos.plugin.ai.importer.skills.skills-sh.enabled=true
+nacos.plugin.ai-resource-import.mcp-official.enabled=true
+nacos.plugin.ai-resource-import.skills-sh.enabled=true
 ```
 
-Defaults:
+### Operator-configured endpoint sources
 
-| Item | Default |
+Enable an MCP Registry protocol endpoint:
+
+```properties
+nacos.plugin.ai-resource-import.mcp-registry-protocol.enabled=true
+nacos.plugin.ai-resource-import.mcp-registry-protocol.endpoint=https://registry.example.com/v0/servers
+```
+
+Enable a Skill well-known registry:
+
+```properties
+nacos.plugin.ai-resource-import.skills-well-known.enabled=true
+nacos.plugin.ai-resource-import.skills-well-known.endpoint=https://skills.example.com
+```
+
+`skills-well-known` supports discovery schema v0.1.0 and v0.2.0. For a registry root, it tries `/.well-known/agent-skills/index.json` and then `/.well-known/skills/index.json`.
+
+## Configuration definitions
+
+Canonical full keys use:
+
+```text
+nacos.plugin.ai-resource-import.{pluginName}.{itemKey}
+```
+
+Common items:
+
+| Item key | Type | Default | effectMode | Implementations | Meaning |
+| --- | --- | --- | --- | --- | --- |
+| `endpoint` | `STRING` | empty | `RESTART` | Two configurable endpoint sources | Registry or marketplace root; it must be non-empty when the source builds. |
+| `allow-http` | `BOOLEAN` | `false` | `RESTART` | Two configurable endpoint sources | Permit non-HTTPS targets. |
+| `allow-private-network` | `BOOLEAN` | `false` | `RESTART` | Two configurable endpoint sources | Permit local or private targets. |
+| `display-name` | `STRING` | Per-implementation display name | `RUNTIME` | All | API and Console display name. |
+| `description` | `STRING` | Per-implementation description | `RUNTIME` | All | API and Console description. |
+| `max-item-count` | `NUMBER` | `500` | `RUNTIME` | All | Maximum result/file count per request. |
+| `max-artifact-size` | `NUMBER` | `10485760` | `RUNTIME` | All | Maximum HTTP response or artifact bytes. |
+
+All current definitions are `required=false` and `sensitive=false`. `mcp-official` and `skills-sh` expose only the four `RUNTIME` display/limit fields. The two configurable endpoint implementations expose all seven.
+
+Runtime PUT cannot add, change, or remove `endpoint`, `allow-http`, or `allow-private-network`. Change static configuration and restart. The other four fields are runtime-effective, and a new immutable Builder snapshot is used by subsequent requests.
+
+## Effective config and aliases
+
+Effective values use:
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+Old `nacos.plugin.ai.importer.*` keys remain aliases for one migration window:
+
+| New pluginName | Old prefix/alias scope |
 | --- | --- |
-| `sourceId` | `skills-sh` |
-| importer | `skills-sh` |
-| resource type | `skill` |
-| endpoint | `https://skills.sh` |
+| `mcp-official` | Display, description, limits, and historical state under `nacos.plugin.ai.importer.mcp.official.` |
+| `skills-sh` | Display, description, limits, and historical state under `nacos.plugin.ai.importer.skills.skills-sh.` |
+| `skills-well-known` | Old `url`/`endpoint`, network flags, display, description, limits, and state under `nacos.plugin.ai.importer.skills.well-known.` |
+| `mcp-registry-protocol` | No old aliases. |
 
-## Security Boundaries
+Fixed-source endpoint overrides, `auth-ref`, source/global timeouts, `max-page-count`, `block-private-network`, global defaults, and arbitrary `properties.*` are removed.
 
-Built-in sources require HTTPS by default and reject localhost, loopback, link-local, multicast, and private network endpoints. Only enable the following options in a controlled private deployment:
+## Flow and lifecycle
 
-| Suffix | Meaning | Default |
+```text
+list sources -> search -> explicit user selection -> validate -> execute
+```
+
+- Search builds one service and returns only candidate summaries, not MCP tools, Skill packages, or secrets.
+- Validate and execute each build one service, reuse it for all selected items in that operation, and close it in `finally`.
+- Fetch returns an artifact but never writes Nacos directly. A resource Operator validates and persists it.
+- The browser must not select search results by default. Select-all must still allow individual deselection.
+
+Unified APIs:
+
+| Operation | Admin | Console |
 | --- | --- | --- |
-| `allow-http` / `allowHttp` | Allow non-HTTPS endpoints. | `false` |
-| `allow-private-network` / `allowPrivateNetwork` | Allow private, localhost, and similar endpoints. | `false` |
+| Sources | `GET /v3/admin/ai/import/sources` | `GET /v3/console/ai/import/sources` |
+| Search | `POST /v3/admin/ai/import/search` | `POST /v3/console/ai/import/search` |
+| Validate | `POST /v3/admin/ai/import/validate` | `POST /v3/console/ai/import/validate` |
+| Execute | `POST /v3/admin/ai/import/execute` | `POST /v3/console/ai/import/execute` |
 
-Do not treat an external registry as trusted input. Validate file paths, archive size, digest, content type, and conflict policy before import.
+## Security boundary
 
-## API Entry Points
+- Requests cannot submit arbitrary URLs, IPs, registry roots, or credentials.
+- HTTPS is required by default, and loopback, link-local, multicast, and private DNS results are blocked.
+- Only operator-owned configurable sources can opt in to `allow-http` or `allow-private-network`.
+- Derived URLs and redirects must reapply the same network policy.
+- HTTP responses and artifacts are capped by `max-artifact-size`; result/file counts are capped by `max-item-count`.
+- Skill import must not execute scripts and must validate paths, digests, and aggregate archive size.
 
-Unified import provides Admin API and Console API:
+## Develop a source
 
-| Surface | Paths |
+Implement `com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder` and register it through Java SPI. The Builder itself is the managed plugin and implements `PluginConfigSpec`:
+
+| Builder method | Requirement |
 | --- | --- |
-| Admin API | `/v3/admin/ai/import/sources`, `/search`, `/validate`, `/execute` |
-| Console API | `/v3/console/ai/import/sources`, `/search`, `/validate`, `/execute` |
+| `pluginName()` | Stable managed name and API `sourceId`. |
+| `importerType()` | Importer/protocol metadata returned in the API `pluginName` field. |
+| `displayName()` / `description()` | Read from the accepted config snapshot. |
+| `supportedResourceTypes()` | Resource types produced by this fixed source. |
+| `getConfigDefinitions()` | Declare every item owned by the source. |
+| `applyConfig(config)` | Atomically replace the immutable effective snapshot. |
+| `getCurrentConfig()` | Return the last accepted canonical item-key snapshot. |
+| `build()` | Build a request-scoped service from one snapshot without extra properties. |
 
-For parameters, see [Admin API](../manual/admin/admin-api.md) and [Console API](../manual/admin/console-api.md).
-
-## Develop a Custom Importer
-
-Add the dependency:
-
-```xml
-<dependency>
-    <groupId>com.alibaba.nacos</groupId>
-    <artifactId>nacos-ai-plugin</artifactId>
-    <version>${project.version}</version>
-</dependency>
-```
-
-Implement `com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder` and declare it with Java SPI:
+SPI file:
 
 ```text
 META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder
 ```
 
-Core methods:
+Duplicate names use first-wins with a WARN.
 
-| Method | Description |
-| --- | --- |
-| `importerType()` | Stable importer name. |
-| `build(properties)` | Builds the import service from importer configuration. |
-| `supportedResourceTypes()` | Resource types this importer can produce. |
-| `search(context)` | Returns candidate summaries, not full payloads. |
-| `fetch(context, item)` | Fetches the selected artifact, but does not write to Nacos. |
+## Breaking change and migration
 
-To provide preset sources, implement `AiResourceImportSourceProvider` and declare the corresponding SPI file.
+The old Importer/Source dual SPI is removed with no compatibility adapter. External plugins must be migrated and recompiled:
 
-## Troubleshooting
+- Remove `AiResourceImportSource` and the Source Provider SPI.
+- Remove `nacos.ai.resource.import.sources[N].*`, presets, and cloned endpoints.
+- Make the Builder `pluginName()` the fixed source ID, implement `PluginConfigSpec`, and use no-argument `build()`.
+- Move effective properties to canonical full keys.
 
-| Symptom | What to check |
-| --- | --- |
-| Source list is empty | Check `nacos.ai.resource.import.enabled`, source `enabled`, and whether the importer plugin is loaded. |
-| Search fails | Check endpoint, network, timeout, auth reference, and HTTPS/private-network restrictions. |
-| Validation reports conflicts | Check resource name, version, and whether an editing or reviewing version already exists. |
-| Imported resource is not visible | Check namespace, visibility, auth, and resource status. |
-| Private source cannot be reached | Enable `allow-private-network` only after confirming the risk. |
+Old MCP import compatibility APIs are disabled by default. A temporary migration can set `nacos.ai.resource.import.legacy-mcp-api-enabled=true`. Fetching a user URL also requires the explicit `nacos.ai.resource.import.allow-user-url=true` opt-in and is not a long-term solution.
+
+See [Plugin Migration Guide](./migration.md) and [Compatibility and Deprecation](../manual/admin/compatibility-and-deprecation.md).

--- a/src/content/docs/next/en/plugin/ai-storage-plugin.md
+++ b/src/content/docs/next/en/plugin/ai-storage-plugin.md
@@ -3,7 +3,7 @@ title: AI Storage
 keywords: [AI Storage, AI Registry, Plugin]
 description: Learn the responsibility, default provider, routing model, and extension boundary of the Nacos AI storage plugin.
 sidebar:
-    order: 13
+    order: 16
 ---
 
 # AI Storage Plugin
@@ -11,6 +11,8 @@ sidebar:
 The AI storage plugin stores binary or text content associated with AI resource versions. It only reads, writes, and deletes content by storage key. AI resource metadata, versions, labels, visibility, and lifecycle are still owned by AI Registry.
 
 This boundary matters. A storage plugin is not a new AI resource model. It is only a content backend.
+
+Its unified type is `ai-storage`, execution mode is `ROUTED`, load phase is `STANDARD`, and the type is critical. A plugin identity is `ai-storage:{provider}`. The router checks unified state before every operation; a disabled provider fails explicitly instead of falling back to another discovered implementation.
 
 ## When To Care
 
@@ -44,11 +46,24 @@ provider -> opaque key
 
 The default provider is `nacos_config`. It stores AI resource content through Nacos config storage and is suitable for default deployments and small to medium content.
 
+Its built-in identity is `ai-storage:nacos_config`. It is enabled by default, declares no definitions, and is reported as `configurable=false`. When the AI module is active, it is normally an active critical provider and cannot be disabled while any resource domain still selects it.
+
 Notes:
 
 - From the user perspective, the AI resource is still a Skill, Prompt, MCP Server, or AgentSpec. It is not a normal config item.
 - Configuration encryption, database, backup, and capacity settings may indirectly affect the default storage.
 - For large content or high-frequency downloads, validate the deployment with real load tests.
+
+Prompt, Skill, AgentSpec, and Agent select providers independently through module routing keys:
+
+```properties
+nacos.ai.prompt.storage.provider=nacos_config
+nacos.ai.skill.storage.provider=nacos_config
+nacos.ai.agentspec.storage.provider=nacos_config
+nacos.ai.agent.storage.provider=nacos_config
+```
+
+These are AI domain routing policy, not definitions owned by `ai-storage:nacos_config`. When the AI module is active, every distinct selected provider must be discovered and enabled; another available provider is not a fallback. When AI function mode is off or `nacos.extension.ai.enabled=false`, this type does not impose a startup requirement.
 
 ## Develop Custom Storage
 
@@ -84,6 +99,8 @@ Builder methods:
 | `get(storageKey)` | Reads content. Missing content returns empty result. |
 | `delete(storageKey)` | Deletes content. |
 
+`AiResourceStorage` inherits `PluginConfigSpec`. An implementation with private settings declares definitions under `nacos.plugin.ai-storage.{provider}.{itemKey}`. The builder only creates the service; definitions, `applyConfig`, and the current snapshot belong to the built service instance. An older binary service without definitions still loads but is automatically reported as not configurable.
+
 ## Implementation Requirements
 
 A custom provider should document:
@@ -97,15 +114,15 @@ A custom provider should document:
 
 The storage plugin must not modify resource metadata, version status, labels, visibility, or auth results. Publish review is still handled by the [AI Publish Pipeline Plugin](./ai-pipeline-plugin.md).
 
-## Current Integration Note
+## State and Startup Validation
 
-Unified plugin management can list loaded `ai-storage` plugins. In the current version, unified enablement is not fully wired into `AiResourceStorageRouter`. Until that is completed, routing is controlled by registered storage providers.
+Unified state is wired into `AiResourceStorageRouter`. A disabled non-critical provider remains loaded and visible, but new operations fail. AI storage instances are registered by builders during Spring context refresh, so critical validation of selected providers runs after registration and before Nacos reports startup success.
 
 ## Troubleshooting
 
 | Symptom | What to check |
 | --- | --- |
-| Resource content cannot be read | Check whether the provider in metadata exists and whether the target storage plugin is loaded. |
+| Resource content cannot be read | Check the provider in metadata, the domain selector, plugin loading, and unified enabled state. |
 | Upload succeeds but download fails | Check post-save consistency, object storage permission, network, and key generation. |
 | Content is still downloadable after deletion | Check delete consistency and cache policy in the provider. |
 | Old resources cannot be read after provider migration | Check the migration plan. Existing versions still use the old provider and storage key. |

--- a/src/content/docs/next/en/plugin/auth-plugin.md
+++ b/src/content/docs/next/en/plugin/auth-plugin.md
@@ -3,12 +3,12 @@ title: Auth Plugin
 keywords: [Auth, Plugin, RBAC, LDAP, OIDC, OAuth2]
 description: Learn how Nacos auth plugins work, what built-in implementations are available, which v3 Auth APIs belong to the default auth plugin, and how to build custom plugins.
 sidebar:
-    order: 2
+    order: 5
 ---
 
 # Auth Plugin
 
-Since 2.1.0, Nacos can load auth implementations through [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html). The server selects one auth plugin through `nacos.core.auth.system.type` in `application.properties`.
+Since 2.1.0, Nacos can load auth implementations through [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html). The server selects one auth plugin at startup through `nacos.plugin.auth.type`; `nacos.core.auth.system.type` is a historical alias.
 
 An auth plugin answers one question: **who is calling, and can that caller perform this action on this resource**.
 
@@ -17,6 +17,22 @@ IdentityContext + Resource + Action -> allow or reject
 ```
 
 If you only need to enable the built-in auth capability, start with [Admin Manual - Authorization](../manual/admin/auth.mdx). If you need enterprise SSO or an external identity provider, see [OIDC/OAuth2 Authentication](../manual/admin/oidc-auth.md). This page focuses on the plugin model, built-in implementation boundaries, and custom extension.
+
+## Unified Management Contract
+
+`auth` is an `EXCLUSIVE`, `STANDARD` type with type-level `critical=true`. When any auth entry gate is enabled, or an auth type is explicitly configured, the selected provider becomes the active critical implementation. A missing or disabled provider fails startup; Nacos does not fall back to another implementation.
+
+| Implementation | pluginId | Configurable | Selection and lifecycle |
+| --- | --- | --- | --- |
+| Default Nacos | `auth:nacos` | Yes | Default selection. Token secret is `RESTART`; other private fields support runtime apply. |
+| LDAP | `auth:ldap` | Yes | All private fields are `RESTART`. |
+| OIDC | `auth:oidc` | Yes | All private fields are `RESTART`; active selection performs additional config validation. |
+
+```properties
+nacos.plugin.auth.type=nacos
+```
+
+Selection is snapshotted at startup and cannot be changed through runtime plugin state. `nacos.core.auth.enabled`, `nacos.core.auth.admin.enabled`, and `nacos.core.auth.console.enabled` are request-entry gates, not `auth:nacos` definitions.
 
 ## Concepts
 
@@ -74,19 +90,31 @@ The default `nacos` auth implementation is designed for trusted internal network
 
 ### Default Nacos Auth Implementation
 
-The default Nacos auth implementation uses plugin type `nacos`. It provides username/password login, JWT tokens, user management, role management, permission management, and the default AI resource visibility integration.
+The default Nacos auth implementation has plugin ID `auth:nacos`. It provides username/password login, JWT tokens, user management, role management, permission management, and the default AI resource visibility integration.
 
 Typical configuration:
 
 ```properties
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 nacos.core.auth.server.identity.key=${custom_server_identity_key}
 nacos.core.auth.server.identity.value=${custom_server_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${custom_base64_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
 ```
+
+`auth:nacos` definitions:
+
+| Item key | Historical alias | Type / default | Sensitive | effectMode |
+| --- | --- | --- | --- | --- |
+| `token.secret.key` | `nacos.core.auth.plugin.nacos.token.secret.key` | `STRING` / empty | Yes | `RESTART` |
+| `token.expire.seconds` | `nacos.core.auth.plugin.nacos.token.expire.seconds` | `NUMBER` / `18000` | No | `RUNTIME` |
+| `token.cache.enable` | `nacos.core.auth.plugin.nacos.token.cache.enable` | `BOOLEAN` / `false` | No | `RUNTIME` |
+| `caching.enabled` | `nacos.core.auth.caching.enabled` | `BOOLEAN` / `true` | No | `RUNTIME` |
+| `anonymous.ai.enabled` | `nacos.core.auth.nacos.anonymous.ai.enabled` | `BOOLEAN` / `false` | No | `RUNTIME` |
+
+All definitions are `required=false`. When an auth entry needs tokens, `token.secret.key` must in practice be valid Base64 that decodes to at least 32 bytes. Plugin detail masks it.
 
 The default implementation uses an RBAC model:
 
@@ -143,7 +171,7 @@ In OIDC/OAuth2 mode, users, roles, passwords, and permissions are usually manage
 
 ### LDAP Auth Plugin
 
-The LDAP plugin type is `ldap`. Since Nacos 3.2, LDAP is separated from the default auth implementation and provided as a standalone optional plugin.
+The LDAP plugin ID is `auth:ldap`. Since Nacos 3.2, LDAP is separated from the default auth implementation and provided as a standalone optional plugin.
 
 LDAP plugin boundaries:
 
@@ -155,18 +183,32 @@ LDAP plugin boundaries:
 Example:
 
 ```properties
-nacos.core.auth.system.type=ldap
+nacos.plugin.auth.type=ldap
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
-nacos.core.auth.ldap.url=ldap://localhost:389
-nacos.core.auth.ldap.basedc=dc=example,dc=org
-nacos.core.auth.ldap.userDn=cn=admin,${nacos.core.auth.ldap.basedc}
-nacos.core.auth.ldap.password=admin
-nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
-nacos.core.auth.ldap.filter.prefix=uid
+nacos.plugin.auth.ldap.url=ldap://localhost:389
+nacos.plugin.auth.ldap.base-dn=dc=example,dc=org
+nacos.plugin.auth.ldap.user-dn=cn=admin,dc=example,dc=org
+nacos.plugin.auth.ldap.password=${ldap_bind_password}
+nacos.plugin.auth.ldap.filter-prefix=uid
 ```
+
+All `auth:ldap` definitions are `RESTART` and `required=false`:
+
+| Item key | Historical alias | Type / default | Sensitive |
+| --- | --- | --- | --- |
+| `url` | `nacos.core.auth.ldap.url` | `STRING` / `ldap://localhost:389` | No |
+| `base-dn` | `nacos.core.auth.ldap.basedc` | `STRING` / `dc=example,dc=org` | No |
+| `timeout` | `nacos.core.auth.ldap.timeout` | `NUMBER` / `3000` | No |
+| `user-dn` | `nacos.core.auth.ldap.userDn` | `STRING` / `cn=admin,dc=example,dc=org` | No |
+| `password` | `nacos.core.auth.ldap.password` | `STRING` / `password` | Yes |
+| `filter-prefix` | `nacos.core.auth.ldap.filter.prefix` | `STRING` / `uid` | No |
+| `case-sensitive` | `nacos.core.auth.ldap.case.sensitive` | `BOOLEAN` / `true` | No |
+| `ignore-partial-result-exception` | `nacos.core.auth.ldap.ignore.partial.result.exception` | `BOOLEAN` / `false` | No |
+
+The historical `nacos.core.auth.ldap.userdn` template was not consumed by production code and is not a supported alias.
 
 Before enabling LDAP, check that:
 
@@ -175,7 +217,7 @@ Before enabling LDAP, check that:
 
 ### OIDC/OAuth2 Auth Plugin
 
-The OIDC/OAuth2 plugin type is `oidc`. It is designed for enterprise SSO and external identity providers. It supports Keycloak, Okta, Auth0, Microsoft Entra ID, and similar providers through OIDC Discovery.
+The OIDC/OAuth2 plugin ID is `auth:oidc`. It is designed for enterprise SSO and external identity providers. It supports Keycloak, Okta, Auth0, Microsoft Entra ID, and similar providers through OIDC Discovery.
 
 Differences from the default Nacos auth implementation:
 
@@ -189,16 +231,35 @@ Differences from the default Nacos auth implementation:
 Example:
 
 ```properties
-nacos.core.auth.system.type=oidc
+nacos.plugin.auth.type=oidc
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
-nacos.core.auth.plugin.oidc.issuer-uri=https://idp.example.com/realms/nacos
-nacos.core.auth.plugin.oidc.client-id=nacos-server
-nacos.core.auth.plugin.oidc.client-secret=${client_secret}
-nacos.core.auth.plugin.oidc.scope=openid profile email
+nacos.plugin.auth.oidc.issuer-uri=https://idp.example.com/realms/nacos
+nacos.plugin.auth.oidc.client-id=nacos-server
+nacos.plugin.auth.oidc.client-secret=${client_secret}
+nacos.plugin.auth.oidc.scope=openid profile email
 ```
+
+All `auth:oidc` fields are `RESTART` and `required=false`; historical aliases use `nacos.core.auth.plugin.oidc.{itemKey}`:
+
+| Item key | Type / default | Sensitive | Notes |
+| --- | --- | --- | --- |
+| `issuer-uri` | `STRING` / empty | No | Conditionally required when OIDC is selected. |
+| `client-id` | `STRING` / empty | No | Conditionally required when OIDC is selected. |
+| `client-secret` | `STRING` / empty | Yes | Browser login also requires it. |
+| `scope` | `STRING` / `openid profile email` | No | Login scopes. |
+| `token-validation-method` | `STRING` / `jwt` | No | Current code implements JWT/JWKS only. |
+| `jwks-cache-ttl-seconds` | `NUMBER` / `3600` | No | Must be positive. |
+| `username-claim` | `STRING` / `preferred_username` | No | Username claim. |
+| `roles-claim` | `STRING` / `roles` | No | Role claim. |
+| `admin-role` | `STRING` / `nacos-admin` | No | Global admin mapping. |
+| `auto-create-user` | `BOOLEAN` / `true` | No | Reserved compatibility field with no current runtime effect. |
+| `authorization-endpoint` | `STRING` / empty | No | External non-admin authorization endpoint. |
+| `authorization-timeout-ms` | `NUMBER` / `5000` | No | External authorization timeout. |
+| `strict-nonce-validation` | `BOOLEAN` / `true` | No | Strict nonce validation. |
+| `strict-audience-validation` | `BOOLEAN` / `true` | No | Strict audience/azp validation. |
 
 For detailed setup, Keycloak examples, and troubleshooting, see [Admin Manual - OIDC/OAuth2 Authentication](../manual/admin/oidc-auth.md).
 
@@ -218,7 +279,7 @@ Then implement `com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService` and 
 
 | Method | Description |
 | --- | --- |
-| `getAuthServiceName()` | Return the plugin name selected by `nacos.core.auth.system.type`. |
+| `getAuthServiceName()` | Return the stable pluginName selected by `nacos.plugin.auth.type`. |
 | `identityNames()` | Declare identity fields that should be extracted from requests. |
 | `enableAuth(action, type)` | Decide whether the action and resource type require auth. |
 | `validateIdentity(identityContext, resource)` | Authenticate the caller and enrich `IdentityContext`. |
@@ -229,11 +290,13 @@ Then implement `com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService` and 
 Package the plugin and place it under `${nacos-server.path}/plugins`, then configure:
 
 ```properties
-nacos.core.auth.system.type=${authServiceName}
+nacos.plugin.auth.type=${authServiceName}
 nacos.core.auth.enabled=true
 ```
 
 After restart, check `${nacos-server.path}/logs/nacos.log` for plugin loading logs.
+
+`AuthPluginService` inherits `PluginConfigSpec`. An old binary implementation with no definitions still loads but appears as `configurable=false`. A new implementation should declare definitions, implement atomic `applyConfig`, and return its accepted snapshot. Do not declare module gates, `type` selection, or `enabled` as private config.
 
 ## Client Auth Plugins
 

--- a/src/content/docs/next/en/plugin/config-change-plugin.md
+++ b/src/content/docs/next/en/plugin/config-change-plugin.md
@@ -3,12 +3,14 @@ title: Config Change Plugin
 keywords: [Config Change, config audit, config format check, webhook]
 description: Learn how the Nacos config change plugin works, how to enable it, and how to develop custom config governance logic.
 sidebar:
-    order: 6
+    order: 9
 ---
 
 # Config Change Plugin
 
 The config change plugin inserts custom logic before or after configuration publish, update, delete, import, and related operations. It is designed for config governance. It does not redefine the Nacos config storage model.
+
+In unified plugin management, the type is `config-change`, its execution mode is `CHAIN`, its load phase is `STANDARD`, and the type is non-critical. A plugin identity is `config-change:{getServiceType()}`. The Nacos Server repository defines the SPI and execution aspect, but does not bundle production `webhook`, `whitelist`, or `fileformatcheck` implementations; those examples exist only when an external plugin JAR is on the classpath.
 
 Typical use cases:
 
@@ -45,39 +47,27 @@ The current SPI defines these pointcuts:
 Before plugins affect the main config change path. Avoid slow calls or uncontrolled external systems in Before plugins. After plugin failures do not roll back already committed config changes.
 :::
 
-## Enable a Plugin
+## Enable and Configure a Plugin
 
 Put the plugin JAR under `${nacos.home}/plugins`, or add it to the Nacos Server startup classpath. The plugin must declare its implementation in `META-INF/services/com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService`.
 
-Then enable the plugin in `${nacos.home}/conf/application.properties`:
+Participation in the candidate chain is controlled only by unified state for `config-change:{pluginName}`. The historical property only initializes state when no persisted state exists; its historical default remains `false`:
 
 ```properties
 nacos.core.config.plugin.${configChangePluginName}.enabled=true
 ```
 
-`${configChangePluginName}` must match the value returned by `getServiceType()`. Nacos 3.2 also has unified plugin state management, but the config change execution path still reads the `enabled` property above. For production use, follow the plugin document and configure both loading and feature enabling correctly.
+`${configChangePluginName}` must match `getServiceType()`. Persisted state wins. After startup, use the plugin status API or Next Console instead of maintaining a second execution gate.
 
-Plugin-specific configuration uses this prefix:
-
-```properties
-nacos.core.config.plugin.${configChangePluginName}.${propertyKey}=${propertyValue}
-```
-
-Example settings for webhook, whitelist, and file format check plugins:
+New plugins declare configuration through `PluginConfigSpec` with this canonical prefix:
 
 ```properties
-# webhook
-nacos.core.config.plugin.webhook.enabled=true
-nacos.core.config.plugin.webhook.url=http://localhost:8080/webhook/send?token=***
-nacos.core.config.plugin.webhook.contentMaxCapacity=102400
-
-# whitelist
-nacos.core.config.plugin.whitelist.enabled=true
-nacos.core.config.plugin.whitelist.suffixs=xml,text,properties,yaml,html
-
-# file format check
-nacos.core.config.plugin.fileformatcheck.enabled=true
+nacos.plugin.config-change.${configChangePluginName}.${itemKey}=${propertyValue}
 ```
+
+The implementation declares each definition's key, legacy aliases, type, default, required flag, sensitivity, and effect mode, then accepts effective values through `applyConfig`. Nacos also places the current effective item map in `ConfigChangeConstants.PLUGIN_PROPERTIES` to preserve the existing request contract.
+
+An older binary plugin without definitions continues through the deprecated compatibility adapter and reads `nacos.core.config.plugin.{pluginName}.{propertyKey}`. It still loads and receives static properties, but the management APIs report `configurable=false` and log a migration warning on first use. `ConfigChangeConfigs` is deprecated but remains in its compatibility window; new code must not depend on it.
 
 ## Develop a Plugin
 
@@ -117,6 +107,8 @@ Implement `com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService`:
 | `args` | Replacement arguments provided by a Before plugin. The order and types must match the original arguments. |
 | `retVal` | Reserved return value. |
 
+A new implementation should also implement the definition, apply, and current-snapshot methods inherited from `PluginConfigSpec`. Validate the complete runtime map before switching it atomically. Older binaries can continue using the compatibility defaults.
+
 ## Production Advice
 
 - Keep Before plugins lightweight and define a clear failure policy.
@@ -129,7 +121,8 @@ Implement `com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService`:
 
 | Symptom | What to check |
 |---------|---------------|
-| Plugin does not run | Check whether the JAR is on the classpath, `META-INF/services` is correct, and `enabled` is `true`. |
+| Plugin does not run | Check the JAR, `META-INF/services`, and unified plugin state; for first migration, also check the historical `enabled` initializer. |
 | Before plugin does not reject a change | Check `executeType()`, `pointcutMethodNames()`, and whether the plugin sets `response.setSuccess(false)`. |
-| Plugin properties are empty | Check whether the prefix is `nacos.core.config.plugin.${serviceType}.`, and whether `serviceType` matches `getServiceType()`. |
+| New plugin properties are empty | Check `nacos.plugin.config-change.${serviceType}.`, definitions, and `applyConfig`. |
+| Legacy plugin properties are empty | Check the deprecated `nacos.core.config.plugin.${serviceType}.` compatibility prefix and plan migration. |
 | Post-change notification is unstable | Check timeout, retry, and exception handling for the external system used by the After plugin. |

--- a/src/content/docs/next/en/plugin/config-encryption-plugin.md
+++ b/src/content/docs/next/en/plugin/config-encryption-plugin.md
@@ -3,7 +3,7 @@ title: Configuration Encryption
 keywords: [AES, encryption, configuration encryption, encryption plugin]
 description: This guide explains how Nacos configuration encryption works, how to use encryption plugins, which schema changes are required, and how to develop a custom plugin.
 sidebar:
-    order: 5
+    order: 8
 ---
 
 # Configuration Encryption Plugin
@@ -11,6 +11,10 @@ sidebar:
 Configuration encryption protects sensitive configuration content stored in Nacos. When enabled for a config item, Nacos writes ciphertext to the database and stores the data key in `encrypted_data_key`.
 
 Configuration encryption does not replace authentication, network isolation, TLS, or an enterprise key management system. It only prevents sensitive configuration content from being stored and exposed as plain text in Nacos storage and selected transfer paths.
+
+In unified plugin management, the plugin type is `encryption`, its execution mode is `ROUTED`, its load phase is `STANDARD`, and the type is non-critical. `algorithmName()` is both the route key and plugin name, so the plugin identity is `encryption:{algorithmName}`. The Nacos Server distribution does not currently bundle a production encryption algorithm; the AES implementation below is supplied by the external plugin repository.
+
+Discovered algorithms are enabled by default, and unified plugin state is the runtime routing gate. After an algorithm is disabled, reads and writes for `cipher-{algorithm}-` fail explicitly instead of returning ciphertext as plaintext.
 
 ## How It Works
 
@@ -34,7 +38,7 @@ The flow is:
 4. When the config item is queried, Nacos uses `encrypted_data_key` and the same plugin to decrypt the content.
 5. If `dataId` does not start with `cipher-`, the config item is handled as a normal plain-text config.
 
-If `dataId` starts with `cipher-` but the matching plugin is not loaded on the server or client, Nacos logs a warning and keeps processing the original content. In production, verify plugin loading before publishing encrypted configs.
+If `dataId` starts with `cipher-` but the matching algorithm is missing or disabled, the operation fails explicitly. Before production use, verify that the server and every Java SDK expected to encrypt or decrypt on the client side load the plugin.
 
 ## Schema Requirements
 
@@ -121,6 +125,14 @@ Important methods:
 | `decrypt(secretKey, content)` | Decrypts config content. |
 | `encryptSecretKey(secretKey)` | Encrypts or wraps the data key. |
 | `decryptSecretKey(secretKey)` | Decrypts or unwraps the data key. |
+
+`EncryptionPluginService` inherits the unified `PluginConfigSpec`. If a new implementation owns KMS endpoints, credentials, or algorithm settings, declare each `key`, alias, type, default, required flag, sensitivity, and effect mode through `ConfigItemDefinition`. Canonical full keys are:
+
+```properties
+nacos.plugin.encryption.{algorithmName}.{itemKey}
+```
+
+Apply runtime-capable items atomically in `applyConfig`, and return the accepted snapshot from `getCurrentConfig()`. Key material must be declared with `sensitive=true`. An older binary plugin without configuration definitions still loads, but the management APIs report `configurable=false`.
 
 Register the implementation through SPI:
 

--- a/src/content/docs/next/en/plugin/control-plugin.md
+++ b/src/content/docs/next/en/plugin/control-plugin.md
@@ -3,14 +3,14 @@ title: Traffic Control
 keywords: [traffic control, rate limit, connection limit, TPS, Control Plugin]
 description: This guide explains how the Nacos control plugin protects the server with connection and TPS limits, and how to configure or extend it.
 sidebar:
-    order: 9
+    order: 12
 ---
 
 # Traffic Control Plugin
 
 The traffic control plugin protects Nacos Server under high load or abnormal access patterns. It can limit connection count and TPS for core APIs, so the server can reject excessive requests early instead of letting a local traffic problem grow into a cluster-wide outage.
 
-Since Nacos 2.3.0, traffic control can be extended through SPI. The default implementation name is `nacos`. If `nacos.plugin.control.manager.type` is not configured, Nacos uses no-limit managers and does not actively limit connections or TPS.
+Since Nacos 2.3.0, traffic control can be extended through SPI. Its unified type is `control`, execution mode is `EXCLUSIVE`, load phase is `STANDARD`, and the type is non-critical. The built-in identity is `control:nacos`; it declares no configuration definitions and is reported as `configurable=false`. If no implementation is selected, Nacos uses lightweight no-limit facades without starting rule, metric, or limiter resources.
 
 ## Concepts
 
@@ -27,8 +27,10 @@ Since Nacos 2.3.0, traffic control can be extended through SPI. The default impl
 Configure `${nacos.home}/conf/application.properties`:
 
 ```properties
-nacos.plugin.control.manager.type=nacos
+nacos.plugin.control.type=nacos
 ```
+
+The historical `nacos.plugin.control.manager.type` key remains a static alias. The canonical key wins and a migration WARN is logged when both exist. Selection has `RESTART` semantics; the runtime status API cannot switch implementations.
 
 By default, rule files are stored in `${nacos.home}/data/connection` and `${nacos.home}/data/tps`. To use another base directory:
 
@@ -42,6 +44,8 @@ Rules will then be stored in:
 /opt/nacos-control-rules/data/connection
 /opt/nacos-control-rules/data/tps
 ```
+
+The rule directory and external rule storage settings belong to the control module, not to `control:nacos` definitions. The selected implementation is initialized once after unified state restoration and effective configuration application. Unselected implementations remain visible in inventory but do not build managers or start background resources.
 
 After startup, check `${nacos.home}/logs/plugin-control.log` to confirm that the plugin is loaded.
 
@@ -139,7 +143,7 @@ A custom traffic control plugin implements:
 
 | SPI / abstract class | Purpose |
 | --- | --- |
-| `ControlManagerBuilder` | Declares the plugin name and creates connection and TPS managers. |
+| `ControlManagerBuilder` | Declares the plugin name and creates connection and TPS managers from the accepted startup configuration. |
 | `ConnectionControlManager` | Loads connection rules and decides whether new connections are allowed. |
 | `TpsControlManager` | Registers ControlPoints, loads TPS rules, and decides whether requests can continue. |
 | `ExternalRuleStorageBuilder` | Optional. Integrates external rule storage. |
@@ -165,6 +169,8 @@ If external rule storage is implemented, also register:
 ```text
 META-INF/services/com.alibaba.nacos.plugin.control.spi.ExternalRuleStorageBuilder
 ```
+
+A new `ControlManagerBuilder` can declare private settings through `PluginConfigDefinitionSpec`, using canonical keys under `nacos.plugin.control.{pluginName}.{itemKey}`. Until Control defines a safe manager replacement and close lifecycle, every definition must use `RESTART`. The older no-argument builder methods remain binary compatible.
 
 ## Operations Advice
 

--- a/src/content/docs/next/en/plugin/custom-environment-plugin.md
+++ b/src/content/docs/next/en/plugin/custom-environment-plugin.md
@@ -3,7 +3,7 @@ title: Custom Environment Plugin
 keywords: [Custom Environment, custom configuration, database password encryption, Environment Plugin]
 description: Learn how the Nacos custom environment plugin transforms server configuration values during startup.
 sidebar:
-    order: 8
+    order: 11
 ---
 
 # Custom Environment Plugin
@@ -11,6 +11,8 @@ sidebar:
 The custom environment plugin transforms selected Nacos Server configuration values before Nacos consumes them. Typical use cases include decrypting database passwords, adapting deployment-specific variables, and converting secrets from an enterprise key system into startup configuration values that Nacos can read.
 
 It works on **Nacos Server startup configuration**. It does not encrypt or transform business configurations stored in the Nacos configuration center. For business config encryption, see [Configuration Encryption](./config-encryption-plugin.md).
+
+In unified plugin management, the type is `environment`, its execution mode is `CHAIN`, its load phase is `PRE_CONTEXT`, and the type is non-critical. A plugin identity is `environment:{pluginName()}`. Because PRE_CONTEXT must transform the Environment before the Spring context exists, it resolves only `STATIC > DEFAULT` and exposes every configuration item as `RESTART`. Runtime state or configuration updates and later STATIC refreshes do not rerun the plugin; restart is required.
 
 :::note
 The custom environment plugin is mainly for deployment-time adaptation. Plugin APIs may evolve with Nacos versions, so use a plugin version that matches your target Nacos version.
@@ -27,11 +29,12 @@ Rules:
 - Returned entries with `null` values are removed and do not override original configuration.
 - When multiple plugins process the same key, they run by `order()` in ascending order. Later values override earlier values, so a larger `order()` has higher final priority.
 
-For example, a plugin can declare `db.password.0` and convert an encrypted value in `application.properties` into the plain database password required by the datasource initialization logic:
+For example, a plugin can declare the canonical datasource password key and convert an encrypted value in `application.properties` into the plain database password required by datasource initialization:
 
 ```properties
 nacos.custom.environment.enabled=true
-db.password.0=ENC(base64-or-kms-value)
+nacos.plugin.environment.demo-environment.enabled=true
+nacos.plugin.datasource.db.password.0=ENC(base64-or-kms-value)
 ```
 
 ## Enable the Plugin
@@ -43,6 +46,8 @@ Then enable the feature in `${nacos.home}/conf/application.properties`:
 ```properties
 nacos.custom.environment.enabled=true
 ```
+
+This is the static family gate; when false, implementations are not loaded. Each implementation can also set startup state with `nacos.plugin.environment.{pluginName}.enabled`. Runtime status API changes for this type are rejected.
 
 After startup, check `${nacos.home}/logs/nacos.log` for the loading log:
 
@@ -66,7 +71,7 @@ Implement `com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginServi
 
 | Method | Description |
 |--------|-------------|
-| `pluginName()` | Stable plugin name used by logs and plugin state identification. |
+| `pluginName()` | Stable plugin name used in `environment:{pluginName}`. |
 | `propertyKey()` | Configuration keys transformed by this plugin. |
 | `order()` | Override order. Larger values have higher final priority. |
 | `customValue(property)` | Input contains original values for declared keys. Return converted key-value pairs. |
@@ -78,13 +83,14 @@ public class DemoEnvironmentPlugin implements CustomEnvironmentPluginService {
 
     @Override
     public Set<String> propertyKey() {
-        return Collections.singleton("db.password.0");
+        return Collections.singleton("nacos.plugin.datasource.db.password.0");
     }
 
     @Override
     public Map<String, Object> customValue(Map<String, Object> property) {
-        String encrypted = (String) property.get("db.password.0");
-        return Collections.singletonMap("db.password.0", decrypt(encrypted));
+        String key = "nacos.plugin.datasource.db.password.0";
+        String encrypted = (String) property.get(key);
+        return Collections.singletonMap(key, decrypt(encrypted));
     }
 
     @Override
@@ -99,6 +105,8 @@ public class DemoEnvironmentPlugin implements CustomEnvironmentPluginService {
 }
 ```
 
+`CustomEnvironmentPluginService` inherits `PluginConfigSpec`. Private settings use `nacos.plugin.environment.{pluginName}.{itemKey}` and declare metadata through definitions. Even if an implementation declares an item as `RUNTIME`, management normalizes it to `RESTART` and logs a WARN. After the startup snapshot is accepted, later changes require restart. An older binary without definitions still loads but is reported as `configurable=false`.
+
 ## Production Advice
 
 - List the exact configuration keys handled by the plugin. Avoid modifying unrelated startup parameters.
@@ -106,6 +114,7 @@ public class DemoEnvironmentPlugin implements CustomEnvironmentPluginService {
 - Do not hard-code secrets in plugin code. Use environment variables, KMS, HSM, or your enterprise key service.
 - If the plugin calls an external key service, configure timeouts and failure behavior so startup does not wait forever.
 - All nodes should use the same plugin JAR and dependency versions.
+- `propertyKey()` should declare the canonical keys consumed by current modules. An older implementation that declares only `db.password.*` can process only the legacy alias.
 
 ## Troubleshooting
 

--- a/src/content/docs/next/en/plugin/datasource-plugin.md
+++ b/src/content/docs/next/en/plugin/datasource-plugin.md
@@ -3,7 +3,7 @@ title: Multiple Data Sources
 keywords: [MySQL, Derby, PostgreSQL, Oracle, data source plugin, database dialect]
 description: This guide explains how Nacos datasource dialect plugins work, which databases are officially supported, and how to use community or custom datasource plugins.
 sidebar:
-    order: 4
+    order: 7
 ---
 
 # Multiple Data Sources
@@ -11,6 +11,8 @@ sidebar:
 Nacos uses datasource dialect plugins to support different databases. A dialect plugin handles SQL dialect differences, pagination, database functions, generated keys, and table-level mapper implementations for the Nacos logical schema.
 
 Since Nacos 2.2.0, datasource dialects can be extended through SPI. In the current Nacos next version, the official default implementation supports four database types: `derby`, `mysql`, `postgresql`, and `oracle`.
+
+In unified plugin management, the plugin type is `datasource-dialect`, its execution mode is `EXCLUSIVE`, its load phase is `STANDARD`, and the type is critical. The four built-in plugin identities are `datasource-dialect:derby`, `datasource-dialect:mysql`, `datasource-dialect:postgresql`, and `datasource-dialect:oracle`. None declares a `ConfigItemDefinition`, so the management APIs report `configurable=false`; connection and pool settings belong to the datasource module, not to an individual dialect plugin.
 
 :::note
 “Multiple data sources” means multiple database dialects, and multiple connection URLs within the same database type. A running Nacos cluster should select one SQL platform. Do not mix different database types in the same cluster.
@@ -33,67 +35,84 @@ The current Oracle datasource dialect uses pagination syntax supported by Oracle
 
 ## Select A Database Type
 
-Use `spring.sql.init.platform` to select the database type:
+Use the standard selector to choose the database type:
 
 ```properties
-spring.sql.init.platform=mysql
+nacos.plugin.datasource-dialect.type=mysql
 ```
 
-For compatibility with older deployments, Nacos still accepts `spring.datasource.platform`. New deployments should use `spring.sql.init.platform`.
+`spring.sql.init.platform` remains a legacy alias, and the standard key wins when both are present. The older `spring.datasource.platform` property has been removed and is no longer read. Dialect selection is fixed at startup and cannot be changed through the runtime plugin status API.
 
 If the platform is not specified, Nacos selects storage based on the running mode:
 
 | Running mode | Default storage |
 | --- | --- |
-| Standalone | Embedded Derby |
-| Cluster | External database |
+| Standalone, or cluster with `-DembeddedStorage=true` | Embedded Derby |
+| Ordinary cluster | External MySQL |
 
-For production, use an external database and import the matching schema before starting Nacos.
+The selected dialect is the active critical provider. If it is missing or disabled, startup fails with the selected dialect and property instead of falling back to another discovered provider. For production, use an external database and import the matching schema before starting Nacos.
 
 ## External Database Configuration
 
 PostgreSQL example:
 
 ```properties
-spring.sql.init.platform=postgresql
-db.num=1
-db.url.0=jdbc:postgresql://127.0.0.1:5432/nacos
-db.user=nacos
-db.password=nacos
-db.pool.config.driverClassName=org.postgresql.Driver
-db.pool.config.connectionTestQuery=SELECT 1
+nacos.plugin.datasource-dialect.type=postgresql
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:postgresql://127.0.0.1:5432/nacos
+nacos.plugin.datasource.db.user=nacos
+nacos.plugin.datasource.db.password=nacos
+nacos.plugin.datasource.db.pool.config.driver-class-name=org.postgresql.Driver
+nacos.plugin.datasource.db.pool.config.connection-test-query=SELECT 1
 ```
 
 Oracle 12c or later example:
 
 ```properties
-spring.sql.init.platform=oracle
-db.num=1
-db.url.0=jdbc:oracle:thin:@127.0.0.1:1521:XE
-db.user=nacos
-db.password=nacos
-db.pool.config.driverClassName=oracle.jdbc.OracleDriver
-db.pool.config.connectionTestQuery=SELECT 1 FROM dual
+nacos.plugin.datasource-dialect.type=oracle
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:oracle:thin:@127.0.0.1:1521:XE
+nacos.plugin.datasource.db.user=nacos
+nacos.plugin.datasource.db.password=nacos
+nacos.plugin.datasource.db.pool.config.driver-class-name=oracle.jdbc.OracleDriver
+nacos.plugin.datasource.db.pool.config.connection-test-query=SELECT 1 FROM dual
 ```
 
-Properties under `db.pool.config.*` are passed to HikariCP. Configure `connectionTimeout`, `maximumPoolSize`, `minimumIdle`, and other pool properties as needed.
+The stable datasource module settings are listed below. They are static, require restart, and are not exposed by the dialect plugin detail or PUT configuration API.
+
+| Canonical key or pattern | Legacy alias | Default/meaning |
+| --- | --- | --- |
+| `nacos.plugin.datasource.db.num` | `db.num` | External connection count; must be positive for external storage |
+| `nacos.plugin.datasource.db.url.{index}` | `db.url.{index}` | JDBC URL for each connection |
+| `nacos.plugin.datasource.db.user[.{index}]` | `db.user[.{index}]` | Shared or per-connection username |
+| `nacos.plugin.datasource.db.password[.{index}]` | `db.password[.{index}]` | Shared or per-connection password; sensitive |
+| `nacos.plugin.datasource.db.pool.config.connection-timeout` | `db.pool.config.connectionTimeout` or kebab-case form | `3000` ms |
+| `nacos.plugin.datasource.db.pool.config.validation-timeout` | `db.pool.config.validationTimeout` or kebab-case form | `10000` ms |
+| `nacos.plugin.datasource.db.pool.config.idle-timeout` | `db.pool.config.idleTimeout` or kebab-case form | `600000` ms |
+| `nacos.plugin.datasource.db.pool.config.maximum-pool-size` | `db.pool.config.maximumPoolSize` or kebab-case form | `20` |
+| `nacos.plugin.datasource.db.pool.config.minimum-idle` | `db.pool.config.minimumIdle` or kebab-case form | `2` |
+| `nacos.plugin.datasource.db.pool.config.driver-class-name` | `db.pool.config.driverClassName` or kebab-case form | Blank uses the compatibility default driver |
+| `nacos.plugin.datasource.db.pool.config.connection-test-query` | `db.pool.config.connectionTestQuery` or kebab-case form | Blank uses `SELECT 1` |
+| `nacos.plugin.datasource.db.query-timeout` | JVM property `QUERYTIMEOUT` | `3` seconds |
+
+For the same item, the canonical key wins over its alias. Indexed items are resolved independently, so canonical `url.0` and legacy `url.1` can coexist during migration. `nacos.plugin.datasource.db.pool.config.{hikari-property}` can still pass additional JavaBean properties to HikariCP, but only the stable subset above is a long-term Nacos configuration contract.
 
 ### Configure Multiple Database Connections
 
 `db.num` is the number of external database connections. Nacos performs health checks and master selection across these connections. All connections should belong to the same database type.
 
 ```properties
-spring.sql.init.platform=mysql
-db.num=2
-db.url.0=jdbc:mysql://db-0:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
-db.url.1=jdbc:mysql://db-1:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
-db.user.0=nacos
-db.password.0=nacos_password_0
-db.user.1=nacos
-db.password.1=nacos_password_1
+nacos.plugin.datasource-dialect.type=mysql
+nacos.plugin.datasource.db.num=2
+nacos.plugin.datasource.db.url.0=jdbc:mysql://db-0:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.url.1=jdbc:mysql://db-1:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.user.0=nacos
+nacos.plugin.datasource.db.password.0=nacos_password_0
+nacos.plugin.datasource.db.user.1=nacos
+nacos.plugin.datasource.db.password.1=nacos_password_1
 ```
 
-If all connections use the same username and password, you can configure only `db.user` and `db.password`.
+If all connections share credentials, configure only the unindexed `nacos.plugin.datasource.db.user` and `nacos.plugin.datasource.db.password`.
 
 ## Community Datasource Plugins
 
@@ -119,7 +138,7 @@ When using a community or custom plugin:
 1. Select a plugin version that matches your Nacos version.
 2. Build the plugin JAR.
 3. Put the plugin JAR and the database driver JAR into `${nacos.home}/plugins`, or add them to the startup classpath.
-4. Set `spring.sql.init.platform` to the database type declared by the plugin.
+4. Set `nacos.plugin.datasource-dialect.type` to the database type declared by the plugin.
 5. Import the matching database schema.
 6. Restart Nacos and check the startup logs to confirm that the target dialect and mappers are loaded.
 
@@ -153,7 +172,7 @@ com.alibaba.nacos.plugin.datasource.mapper.Mapper
 
 | Symptom | What to check |
 | --- | --- |
-| Dialect not found at startup | Check whether `spring.sql.init.platform` matches the plugin `getType()` value, and whether the plugin JAR is on the classpath. |
+| Dialect not found at startup | Check whether `nacos.plugin.datasource-dialect.type` matches the plugin `getType()` value, and whether the plugin JAR is on the classpath. |
 | Missing mapper error | Check whether the plugin registers all table-level mappers required by Nacos. |
 | Database connection failure | Check JDBC URL, driver class, username, password, network ACL, and pool properties. |
 | Pagination SQL error on Oracle 11g or earlier | The current Oracle plugin supports only Oracle 12c or later. Older Oracle versions require a custom datasource plugin. |

--- a/src/content/docs/next/en/plugin/development.md
+++ b/src/content/docs/next/en/plugin/development.md
@@ -1,0 +1,131 @@
+---
+title: Plugin Development Guide
+keywords: [Plugin Development, Java SPI, PluginConfigSpec, applyConfig, PluginStartupLifecycle]
+description: Learn Nacos server plugin SPI registration, unified configuration, binary compatibility, lifecycle, and development checks.
+sidebar:
+    order: 3
+---
+
+# Plugin Development Guide
+
+When developing a Nacos server plugin, first implement the matching domain SPI, and then integrate unified configuration and state. Unified management does not replace domain behavior contracts or allow a plugin to bypass Nacos resources, authorization, responses, or errors.
+
+## Select the domain SPI
+
+| pluginType | Stable implementation name | Main domain SPI |
+| --- | --- | --- |
+| `auth` | `getAuthServiceName()` | `AuthPluginService` |
+| `datasource-dialect` | `getType()` | `DatabaseDialect` with matching `Mapper` implementations |
+| `config-change` | `getServiceType()` | `ConfigChangePluginService` |
+| `encryption` | `algorithmName()` | `EncryptionPluginService` |
+| `trace` | `getName()` | `NacosTraceSubscriber` |
+| `environment` | `pluginName()` | `CustomEnvironmentPluginService` |
+| `control` | `getName()` | `ControlManagerBuilder` |
+| `visibility` | `getVisibilityServiceName()` | `VisibilityService` |
+| `ai-pipeline` | `pipelineId()` | `PublishPipelineService` |
+| `ai-storage` | `type()` | `AiResourceStorage` / `AiResourceStorageBuilder` |
+| `ai-resource-import` | `pluginName()` | `AiResourceImportServiceBuilder` |
+
+List the implementation class in `META-INF/services/{fully-qualified SPI name}`. Put the plugin JAR under `${nacos.home}/plugins` or on the Nacos Server startup classpath. Every node must also have its dependencies.
+
+## Stable identity and conflicts
+
+The plugin name must be non-blank, stable, and unique within its `pluginType`. Unified registration is first-wins: a later duplicate `pluginId` is ignored with a WARN that names both classes. A domain provider that builds a map from multiple SPI implementations must also detect duplicates and must not silently overwrite with `put`.
+
+Never use SPI scan order as selection. Use the type's static `type` key or the documented domain route.
+
+## Declare unified configuration
+
+A configurable runtime implementation implements `com.alibaba.nacos.api.plugin.PluginConfigSpec`:
+
+```java
+public final class ExamplePlugin implements PluginConfigSpec {
+    private volatile Map<String, String> currentConfig = Map.of();
+
+    @Override
+    public List<ConfigItemDefinition> getConfigDefinitions() {
+        return List.of(
+                new ConfigItemDefinition.Builder(
+                        "timeout", "Timeout", ConfigItemType.NUMBER)
+                        .defaultValue("3000")
+                        .required(true)
+                        .aliases(List.of("legacy.example.timeout"))
+                        .effectMode(ConfigItemEffectMode.RUNTIME)
+                        .build());
+    }
+
+    @Override
+    public void applyConfig(Map<String, String> config) {
+        currentConfig = Map.copyOf(config);
+    }
+
+    @Override
+    public Map<String, String> getCurrentConfig() {
+        return currentConfig;
+    }
+}
+```
+
+Requirements:
+
+- A definition `key` is only the item key. Core builds `nacos.plugin.{pluginType}.{pluginName}.{itemKey}`.
+- Declare `type`, `defaultValue`, `required`, `sensitive`, `effectMode`, and every compatible `alias`.
+- Never declare `enabled`; it belongs to unified plugin state.
+- `applyConfig` receives a complete effective canonical item-key snapshot. Validate and build immutable state before atomically publishing it.
+- `getCurrentConfig` returns the last accepted snapshot instead of re-reading Spring environment.
+- Definition key and alias registration is first-wins. Do not publish internally conflicting definitions.
+
+The default `isConfigurable()` returns true only when definitions are non-empty. Such an implementation must provide reliable apply and snapshot callbacks.
+
+## Effect mode
+
+Use `RUNTIME` only when the field can be changed without rebuilding an irreplaceable resource. Common `RESTART` cases include:
+
+- implementation or provider selection;
+- key parsers, LDAP/OIDC clients, datasources, thread pools, or subprocess options built at startup;
+- resources without a defined atomic replace, close, and failure-recovery lifecycle.
+
+`environment` is `PRE_CONTEXT`. Core exposes any definition it declares as `RUNTIME` as `RESTART` with a WARN.
+
+## Startup lifecycle
+
+A regular implementation follows:
+
+```text
+discover -> restore state -> resolve effective config -> applyConfig
+         -> optional PluginStartupLifecycle.initialize -> expose to domain
+```
+
+Implement `PluginStartupLifecycle` only when runtime resources must be created after config acceptance. `initialize()` must be idempotent and is also used for deferred type loading. It does not automatically enable runtime rebuilding.
+
+A type-level module gate may defer discovery of a non-critical type. Do not independently reload the domain SPI from another singleton or manager, because that bypasses unified state and configuration.
+
+## Legacy binary compatibility
+
+Unified domain SPIs inherit `PluginConfigSpec` through compatibility defaults. An old binary implementation with no definitions still loads and appears as `configurable=false`; current config is empty and apply is a no-op. Do not guess private properties to make it configurable.
+
+A new implementation should declare definitions, implement atomic `applyConfig`, and return its accepted snapshot. Compatibility adapters still exist in a few domains:
+
+- Config Change can still pass old `nacos.core.config.plugin.{name}.*` properties to legacy implementations, but `ConfigChangeConfigs` is deprecated.
+- Visibility uses old `init(Properties)` only for implementations without unified definitions.
+
+These adapters do not make a legacy implementation configurable.
+
+## Security and stability
+
+- Values marked `sensitive=true` must never appear in logs, exceptions, trace, or APIs.
+- Set connection, read, and total timeouts for external IO. Non-decision plugins such as Trace and after-hooks should use dedicated executors and documented degradation.
+- Do not change shared Nacos resource identity, v3 `Result<T>`, error codes, or authorization boundaries.
+- Keep plugin packages, dependencies, static configuration, and alias migration consistent across the cluster.
+- Test state/config updates, duplicate IDs, duplicate definitions, apply failures, and rolling upgrades.
+
+## Pre-release checklist
+
+1. `pluginType:pluginName` is unique in the target cluster.
+2. The SPI filename and implementation class are correct and constructible.
+3. Definitions do not contain `enabled` and have no key/alias conflicts.
+4. `applyConfig` is atomic and safe to retry with the same map.
+5. Fields genuinely support online replacement before being marked `RUNTIME`.
+6. Domain execution checks unified state.
+7. Missing or disabled active critical providers fail explicitly.
+8. Documentation lists canonical keys, aliases, defaults, sensitivity, and effect modes.

--- a/src/content/docs/next/en/plugin/development.md
+++ b/src/content/docs/next/en/plugin/development.md
@@ -30,9 +30,9 @@ List the implementation class in `META-INF/services/{fully-qualified SPI name}`.
 
 ## Stable identity and conflicts
 
-The plugin name must be non-blank, stable, and unique within its `pluginType`. Unified registration is first-wins: a later duplicate `pluginId` is ignored with a WARN that names both classes. A domain provider that builds a map from multiple SPI implementations must also detect duplicates and must not silently overwrite with `put`.
+The plugin name must be non-blank, stable, and unique within its `pluginType`. Providers of the same type are processed in ascending `PluginProvider.getOrder()` order (default `0`); equal-order providers retain SPI discovery order. Unified registration then applies first-wins, so a lower-order provider gets the first registration opportunity and a later duplicate `pluginId` is ignored with a WARN that names both classes. Provider order does not replace EXCLUSIVE selection or domain routing. A domain provider that builds a map from multiple SPI implementations must also detect duplicates and must not silently overwrite with `put`.
 
-Never use SPI scan order as selection. Use the type's static `type` key or the documented domain route.
+Never use equal-order SPI scan order as selection. Use distinct provider orders only when provider precedence is intentional, and use the type's static `type` key or the documented domain route to select an implementation.
 
 ## Declare unified configuration
 
@@ -74,6 +74,7 @@ Requirements:
 - `applyConfig` receives a complete effective canonical item-key snapshot. Validate and build immutable state before atomically publishing it.
 - `getCurrentConfig` returns the last accepted snapshot instead of re-reading Spring environment.
 - Definition key and alias registration is first-wins. Do not publish internally conflicting definitions.
+- For STATIC input, a normalized standard full key wins whenever it exists, including with an empty value. Aliases are read only when it is absent; if several aliases are present, their declaration order determines which one wins.
 
 The default `isConfigurable()` returns true only when definitions are non-empty. Such an implementation must provide reliable apply and snapshot callbacks.
 

--- a/src/content/docs/next/en/plugin/migration.md
+++ b/src/content/docs/next/en/plugin/migration.md
@@ -1,0 +1,104 @@
+---
+title: Plugin Migration Guide
+keywords: [Plugin Migration, Configuration Migration, AI Resource Import, ConfigChangeConfigs, Compatibility]
+description: Migrate historical plugin selection keys, private configuration, and the old AI Resource Import SPI to unified plugin management.
+sidebar:
+    order: 4
+---
+
+# Plugin Migration Guide
+
+Unified plugin management separates four layers: module entry, implementation selection, implementation enabled state, and implementation-owned configuration. Classify existing settings into these layers before upgrading. Do not convert a historical family-wide gate into a private definition or implementation state.
+
+## General migration
+
+1. Record plugin JARs, implementation names, module gates, selection keys, enabled keys, and private properties.
+2. Map every implementation to a stable `pluginType:pluginName`.
+3. Move `EXCLUSIVE` selection to `nacos.plugin.{pluginType}.type`.
+4. Move implementation config to `nacos.plugin.{pluginType}.{pluginName}.{itemKey}`.
+5. Keep aliases for one compatibility window and monitor migration WARN logs; remove them after canonical keys are verified.
+6. Roll out the plugin and static config first, then inspect effective source in plugin detail.
+7. Restart nodes for `RESTART` fields; do not try to update them with PUT APIs.
+
+Canonical keys win when an alias is also present. API aliases are normalized, and `plugin-configs.json` and local-only maps store only canonical item keys.
+
+## Implementation selection
+
+| pluginType | Standard key | Historical alias | Default/behavior |
+| --- | --- | --- | --- |
+| `auth` | `nacos.plugin.auth.type` | `nacos.core.auth.system.type` | Default `nacos`. |
+| `datasource-dialect` | `nacos.plugin.datasource-dialect.type` | `spring.sql.init.platform` | Standalone/embedded defaults to `derby`; ordinary cluster mode defaults to `mysql`. `spring.datasource.platform` is removed. |
+| `control` | `nacos.plugin.control.type` | `nacos.plugin.control.manager.type` | Empty means no-limit. |
+
+All selections are snapshotted at startup. Do not use the status API to switch an exclusive implementation.
+
+## Auth, Visibility, and AI Pipeline
+
+- Move default auth settings from `nacos.core.auth.plugin.nacos.*` and `nacos.core.auth.caching.enabled` to `nacos.plugin.auth.nacos.*`.
+- Move LDAP from `nacos.core.auth.ldap.*` to `nacos.plugin.auth.ldap.*`. The unused `nacos.core.auth.ldap.userdn` template key is not a valid alias.
+- Move OIDC from `nacos.core.auth.plugin.oidc.*` to `nacos.plugin.auth.oidc.*`. All current fields are `RESTART`.
+- `nacos.plugin.visibility.enabled` remains the capability gate; `nacos.plugin.visibility.type` is only historical initial selection. Implementation state belongs to unified `visibility:{name}` state.
+- `nacos.plugin.ai-pipeline.enabled` remains the Pipeline gate. Historical `nacos.plugin.ai-pipeline.type` supplies only initial chain state at startup. Use unified state for later membership and per-node definitions for configuration.
+
+## Config Change
+
+A new Config Change implementation declares `PluginConfigSpec` directly on `ConfigChangePluginService`:
+
+```text
+nacos.plugin.config-change.{pluginName}.{itemKey}
+```
+
+Historical `nacos.core.config.plugin.{pluginName}.*` properties remain available during the compatibility window only for old implementations without definitions. Historical `{name}.enabled` is used only to initialize unified state when no persisted state exists. `ConfigChangeConfigs` is deprecated. New implementations must not depend on it or treat `PLUGIN_PROPERTIES` as a second enabled gate.
+
+Old binary plugins still load but show `configurable=false`. A migration release should add definitions, `applyConfig`, and a current snapshot.
+
+## AI Resource Import breaking change
+
+AI Resource Import has replaced the former "Importer plus clonable Source/preset" model with one Builder for one fixed source:
+
+```text
+ai-resource-import:{pluginName}
+sourceId = managed pluginName
+```
+
+New gates and configuration:
+
+```properties
+nacos.plugin.ai-resource-import.enabled=true
+nacos.plugin.ai-resource-import.{pluginName}.enabled=true
+nacos.plugin.ai-resource-import.{pluginName}.{itemKey}=value
+```
+
+Remove or rewrite these legacy concepts:
+
+- `nacos.plugin.ai.importer.*`
+- `nacos.ai.resource.import.sources[N].*`
+- `AiResourceImportSource`
+- `AiResourceImportSourceProvider` and the Source Provider SPI
+- the preset source model
+- cloning one importer to multiple endpoints through configuration
+
+The existing API `sourceId` is now the managed `pluginName`. The API `pluginName` field remains importer/protocol metadata for Console compatibility. One `pluginName` represents exactly one source. To add a second enterprise endpoint, ship another `AiResourceImportServiceBuilder` with a distinct `pluginName`.
+
+The Builder itself implements `PluginConfigSpec` and provides `pluginName()`, `importerType()`, display metadata, supported resource types, definitions, `applyConfig`, current snapshot, and no-argument `build()`. A request-scoped service is created from the accepted immutable snapshot; requests no longer carry source configuration or arbitrary endpoints.
+
+Built-in sources:
+
+| pluginId | Importer type | Default implementation state | Endpoint |
+| --- | --- | --- | --- |
+| `ai-resource-import:mcp-official` | `mcp-registry` | enabled | Fixed official MCP Registry |
+| `ai-resource-import:mcp-registry-protocol` | `mcp-registry` | disabled | Operator configuration required |
+| `ai-resource-import:skills-sh` | `skills-sh` | enabled | Fixed `https://skills.sh` |
+| `ai-resource-import:skills-well-known` | `skills-well-known` | disabled | Operator configuration required |
+
+`mcp-official` and `skills-sh` retain their Console display names and the user search-select-validate-import experience. Effective historical `nacos.plugin.ai.importer.*` display, description, limit, state, and configurable endpoint keys remain aliases for one migration window. Fixed-source endpoint overrides, `auth-ref`, source/global timeouts, `max-page-count`, `block-private-network`, global defaults, and arbitrary `properties.*` are removed.
+
+There is no compatibility adapter for the old Importer/Source SPI. External implementations must be recompiled and migrated. See [AI Resource Import](./ai-resource-import-plugin.md) for definitions and examples.
+
+## Rollout and rollback
+
+- Verify plugin list/detail, effective sources, sensitive masking, and `RESTART` guidance on one node first.
+- During a rolling upgrade, do not submit runtime config that requires new definitions until every node runs the new plugin.
+- Monitor alias WARN logs in the first release, then remove old keys in the next maintenance window.
+- Before rollback, clear runtime overrides understood only by the new version.
+- The old AI Resource Import SPI has no adapter. Roll back plugin JARs, configuration, and callers together; do not mix the two models.

--- a/src/content/docs/next/en/plugin/migration.md
+++ b/src/content/docs/next/en/plugin/migration.md
@@ -20,7 +20,7 @@ Unified plugin management separates four layers: module entry, implementation se
 6. Roll out the plugin and static config first, then inspect effective source in plugin detail.
 7. Restart nodes for `RESTART` fields; do not try to update them with PUT APIs.
 
-Canonical keys win when an alias is also present. API aliases are normalized, and `plugin-configs.json` and local-only maps store only canonical item keys.
+For STATIC `PluginConfigSpec` items, canonical full keys win by presence, not by a non-blank value. An empty canonical value still suppresses legacy aliases and may fail required-value validation; remove the canonical property entirely only when fallback to an alias is intended. If several aliases are present, the first one in the definition's declaration order wins. Selection keys continue to follow their plugin family's documented rules. API aliases are normalized, and `plugin-configs.json` and local-only maps store only canonical item keys.
 
 ## Implementation selection
 
@@ -39,6 +39,8 @@ All selections are snapshotted at startup. Do not use the status API to switch a
 - Move OIDC from `nacos.core.auth.plugin.oidc.*` to `nacos.plugin.auth.oidc.*`. All current fields are `RESTART`.
 - `nacos.plugin.visibility.enabled` remains the capability gate; `nacos.plugin.visibility.type` is only historical initial selection. Implementation state belongs to unified `visibility:{name}` state.
 - `nacos.plugin.ai-pipeline.enabled` remains the Pipeline gate. Historical `nacos.plugin.ai-pipeline.type` supplies only initial chain state at startup. Use unified state for later membership and per-node definitions for configuration.
+
+The target distribution already declares `nacos.plugin.auth.type=nacos` and the canonical defaults for `auth:nacos`. Copy retained auth selection and implementation values into those canonical keys instead of leaving legacy aliases beside the target defaults. Otherwise the canonical selector keeps `nacos`, and a canonical `PluginConfigSpec` key suppresses its alias even when the canonical value is empty. The startup script specially migrates only a valid legacy token secret found in `application.properties`; migrate all other auth values explicitly.
 
 ## Config Change
 
@@ -68,6 +70,8 @@ nacos.plugin.ai-resource-import.enabled=true
 nacos.plugin.ai-resource-import.{pluginName}.enabled=true
 nacos.plugin.ai-resource-import.{pluginName}.{itemKey}=value
 ```
+
+The family gate defaults to enabled even when neither the standard key nor its legacy alias is configured; only an explicit `false` disables it. A deployment that must keep import disabled during upgrade should set `nacos.plugin.ai-resource-import.enabled=false` before rollout.
 
 Remove or rewrite these legacy concepts:
 

--- a/src/content/docs/next/en/plugin/operations.md
+++ b/src/content/docs/next/en/plugin/operations.md
@@ -1,0 +1,152 @@
+---
+title: Plugin Operations and Configuration
+keywords: [Plugin Management, PluginConfigSpec, plugin-configs.json, Runtime Configuration, Console]
+description: Learn Nacos plugin state, configuration sources, sensitive values, runtime updates, persistence, Console behavior, and troubleshooting.
+sidebar:
+    order: 2
+---
+
+# Plugin Operations and Configuration
+
+This document helps Nacos operators and platform administrators inspect plugins, distinguish module gates from plugin state, and safely update implementation-owned configuration.
+
+## Inventory and detail
+
+In the new Console, Platform Management > Plugin Management groups loaded plugins by `pluginType`. The Admin APIs are:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v3/admin/core/plugin/list` | List loaded plugins, optionally filtered by `pluginType`. |
+| `GET` | `/v3/admin/core/plugin/detail` | Read state, definitions, effective config, and value metadata. |
+| `PUT` | `/v3/admin/core/plugin/status` | Update implementation state. |
+| `PUT` | `/v3/admin/core/plugin/config` | Replace the complete override map of one source. |
+
+Console API exposes equivalent proxies under `/v3/console/plugin/*`. See [Admin API](../manual/admin/admin-api.md) and [Console API](../manual/admin/console-api.md).
+
+Important list and detail fields:
+
+| Field | Meaning |
+| --- | --- |
+| `pluginId` | `{pluginType}:{pluginName}`. |
+| `enabled` | Whether the implementation may participate on the current node. |
+| `executionMode` | `EXCLUSIVE`, `CHAIN`, `ROUTED`, or `BROADCAST`. |
+| `exclusive` | Compatibility field equivalent to `executionMode=EXCLUSIVE`. |
+| `typeCritical` | Whether the type can become critical. |
+| `critical` | Whether this implementation cannot currently be disabled by itself. |
+| `configurable` | Whether at least one valid `ConfigItemDefinition` is declared. |
+| `config` | Accepted effective item-key snapshot; sensitive values are masked. |
+| `configDefinitions` | Definitions including aliases, type, default, required, sensitive, and effect mode. |
+| `configValueMetas` | `source` and `overridden` for each canonical item key. |
+
+## Configuration definitions
+
+`ConfigItemDefinition.key` is an implementation-local item key without the full prefix. Static configuration uses:
+
+```text
+nacos.plugin.{pluginType}.{pluginName}.{itemKey}
+```
+
+| Metadata | Operational meaning |
+| --- | --- |
+| `aliases` | Historical static keys. They remain readable and may be accepted as API input, but emit migration WARN logs. Persistence stores only canonical item keys. |
+| `type` | `STRING`, `NUMBER`, `BOOLEAN`, or `ENUM`. |
+| `defaultValue` | Used when no higher-priority source exists. |
+| `required` | A final value must exist. |
+| `sensitive` | Detail responses mask the value and logs must not expose it. |
+| `effectMode` | `RUNTIME` can be updated online; `RESTART` requires static configuration and restart. |
+
+Definition normalization is first-wins. Blank keys, reserved `enabled`, duplicate keys, and later definitions or aliases that conflict with an earlier key or alias are ignored with WARN logs.
+
+## Sources and precedence
+
+For `STANDARD` plugins, effective values are resolved in this order:
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+| Source | Meaning | Persistence/synchronization |
+| --- | --- | --- |
+| `DEFAULT` | Definition default. | No |
+| `STATIC` | `application.properties`, environment, JVM, or Spring parameters. | Owned by the deployment system |
+| `RUNTIME_PERSISTED` | Cluster-wide runtime override. | Yes |
+| `LOCAL_ONLY` | Current-node diagnosis or emergency override. | No |
+
+`configValueMetas.source` identifies the effective source. `overridden=true` means that more than one non-default source has the same key; `DEFAULT` is not counted.
+
+Runtime-persisted config is stored in `${nacos.home}/data/plugin/plugin-configs.json`. Nacos owns this file; do not edit it manually. It stores only `pluginId + itemKey + value`, not aliases, full static keys, source, or versions. Enabled state is managed separately and is not stored in this file.
+
+## Update semantics
+
+The `config` sent to `PUT .../plugin/config` is the **complete target-source map**, not a patch:
+
+- `localOnly=false` replaces the complete `RUNTIME_PERSISTED` map.
+- `localOnly=true` replaces the current node's complete `LOCAL_ONLY` map.
+- An empty map clears all overrides for that plugin and source.
+- Omitting an existing key removes it. Only `RUNTIME` items can be added, changed, or removed online.
+- Canonical item keys, normalized full keys, and unique aliases are normalized to item keys. Undefined or ambiguous keys return a validation error.
+
+For example, override the default auth token lifetime on only the current node:
+
+```shell
+curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
+  -d 'pluginType=auth' \
+  -d 'pluginName=nacos' \
+  -d 'config={"token.expire.seconds":"3600"}' \
+  -d 'localOnly=true'
+```
+
+Updates for one plugin are serialized. A persisted update stores the source first, then resolves, validates, and applies. Persistence failure leaves memory and the plugin unchanged. If persistence succeeds but `applyConfig` fails, the new source remains accepted and the API reports an explicit error. Fix the plugin and submit the same complete map to retry apply manually.
+
+## `RUNTIME` and `RESTART`
+
+Startup apply accepts both modes. A runtime PUT cannot add, change, or remove a `RESTART` item.
+
+Static refresh follows the same boundary:
+
+- Changed `RUNTIME` static values are resolved and applied when needed.
+- Changed `RESTART` values produce WARN logs, while the process keeps its startup snapshot.
+- Detail responses return the accepted snapshot rather than an unapplied restart-required environment value.
+
+To change a `RESTART` item, update static configuration on all nodes and perform a planned rolling restart.
+
+## Sensitive values
+
+Detail responses mask sensitive items with a value containing `******`. On update, any value containing this standard marker means "preserve the target source value":
+
+- If that source already has the key, Nacos keeps its original value.
+- If the source does not have the key, the input is ignored. Nacos never copies an effective value from another source, such as `STATIC`, into a runtime override.
+
+The Console can therefore submit the masked display value without overwriting a secret. To actually change a secret, submit a new value without the marker. Logs include only `pluginId`, item key, and target source.
+
+## State updates and critical validation
+
+Status APIs support cluster-persisted and `localOnly=true` current-node updates, but some types cannot be switched online:
+
+- `EXCLUSIVE` types use static `type` selection and cannot be switched by the status API.
+- An active critical type must retain every provider required by its policy; invalid updates are rejected before persistence and apply.
+- `environment` runs before context creation, so runtime state updates are rejected.
+- `control` builds its manager bundle during startup and rejects runtime selection changes.
+
+The status API does not modify module gates. For example, `visibility:nacos` may remain loaded and enabled while `nacos.plugin.visibility.enabled=false` prevents the visibility path from running.
+
+## New Console behavior
+
+The Next Console detail view treats the detail API as its source of truth:
+
+- `RUNTIME` definitions are editable. `RESTART` definitions are read-only and instruct users to edit static configuration and restart.
+- Effective source and overridden state are shown for every value.
+- Cluster-wide runtime-persisted and current-node local-only updates are separate modes.
+- A submission retains only overrides belonging to the target source; it does not copy effective `STATIC` or `DEFAULT` values.
+- If any `LOCAL_ONLY` override is active, cluster submission is blocked because lower-priority persisted values are hidden. Clear local-only overrides, refresh detail, and then edit cluster configuration.
+
+This workflow applies to the Next Console only. Legacy Console does not provide the unified config editor.
+
+## Startup and troubleshooting
+
+1. Use the same plugin JARs, dependencies, and versions on every cluster node.
+2. Confirm that the target `pluginId` is available on every node.
+3. Distinguish the module gate, exclusive selection, implementation state, and implementation config.
+4. Inspect effective `source` for unexpected `LOCAL_ONLY` or `RUNTIME_PERSISTED` overrides.
+5. Confirm that nodes restarted after a `RESTART` change.
+6. Remove duplicate implementations or definitions reported by WARN logs; never rely on SPI scan order.

--- a/src/content/docs/next/en/plugin/operations.md
+++ b/src/content/docs/next/en/plugin/operations.md
@@ -55,6 +55,8 @@ nacos.plugin.{pluginType}.{pluginName}.{itemKey}
 | `sensitive` | Detail responses mask the value and logs must not expose it. |
 | `effectMode` | `RUNTIME` can be updated online; `RESTART` requires static configuration and restart. |
 
+During STATIC resolution for `PluginConfigSpec` items, the normalized standard full key is authoritative whenever it exists, including when its value is an empty string. Aliases are considered only when the standard key is absent. If multiple aliases are present, the first alias in the definition's declaration order is used and the remaining aliases are ignored with WARN logs.
+
 Definition normalization is first-wins. Blank keys, reserved `enabled`, duplicate keys, and later definitions or aliases that conflict with an earlier key or alias are ignored with WARN logs.
 
 ## Sources and precedence

--- a/src/content/docs/next/en/plugin/overview.md
+++ b/src/content/docs/next/en/plugin/overview.md
@@ -26,7 +26,7 @@ For example, the default auth plugin is `auth:nacos`, LDAP auth is `auth:ldap`, 
 - `pluginName` is a stable, unique implementation name within that category.
 - `pluginId` is used by management APIs, plugin state, persisted configuration, and diagnostics. Do not change it casually during an upgrade.
 
-Discovery uses a deterministic **first-wins** rule. Null implementations, blank names, and later duplicate `pluginId` values are ignored with WARN logs; an existing registration is never replaced. Configuration definition key and alias conflicts also use first-wins and ignore later conflicting entries.
+Providers of the same type are processed in ascending `PluginProvider.getOrder()` order; equal-order providers retain their SPI service-discovery order. The deterministic **first-wins** rule is applied after that ordering. Null implementations, blank names, and later duplicate `pluginId` values are ignored with WARN logs; an existing registration is never replaced. Configuration definition key and alias conflicts also use first-wins and ignore later conflicting entries.
 
 ## Current plugin types
 

--- a/src/content/docs/next/en/plugin/overview.md
+++ b/src/content/docs/next/en/plugin/overview.md
@@ -1,70 +1,113 @@
 ---
-title: Plugin Overview
-keywords: [Plugin, SPI, extension]
-description: Learn the common Nacos plugin model, loading rules, design principles, and plugin documentation entry points.
+title: Plugin System Overview
+keywords: [Plugin, PluginType, SPI, PluginConfigSpec, Plugin Management]
+description: Learn the unified Nacos plugin identity, execution modes, state, configuration, lifecycle, and all current server plugin types.
 sidebar:
     order: 1
 ---
 
-# Plugin Overview
+# Plugin System Overview
 
-Nacos uses plugins to keep replaceable and extensible capabilities outside the core logic. You can use the built-in implementations, optional official plugins, community plugins, or custom plugins for security, databases, audit, observability, and traffic governance.
+Nacos uses plugins to separate replaceable capabilities such as authentication, database dialects, visibility, auditing, traffic control, and AI extensions from core domain models. A server plugin supplies behavior through a domain SPI and participates in unified inventory, state, configuration, and diagnostics.
 
-The plugin system serves two groups of readers:
+This document covers server plugins managed by the unified system. Java client extensions such as `ClientAuthService`, `IConfigFilter`, and `ServerListProvider` run in client processes and do not appear in the server plugin APIs or Console.
 
-- Users and operators need to know which capability is pluggable, where to place plugin JARs, and which configurations must stay consistent across the cluster.
-- Developers and integrators need to understand the SPI boundary, how to declare implementations, and how to keep plugins from affecting the main Nacos request path.
+## Plugin identity
 
-## How Plugins Are Loaded
+Every server plugin is uniquely identified by a type and implementation name:
 
-Most Nacos plugins are loaded through Java SPI. A plugin JAR declares implementation classes under `META-INF/services`. During startup, Nacos discovers these implementations through `NacosServiceLoader`, then plugin-specific `PluginProvider` implementations collect them into unified plugin information.
+```text
+pluginId = pluginType:pluginName
+```
 
-There are usually two ways to load a plugin:
+For example, the default auth plugin is `auth:nacos`, LDAP auth is `auth:ldap`, and the official MCP import source is `ai-resource-import:mcp-official`.
 
-1. Put the plugin JAR under `${nacos.home}/plugins`.
-2. Add the plugin JAR and required dependencies to the Nacos Server startup classpath.
+- `pluginType` is an extension category in the Nacos `PluginType` registry.
+- `pluginName` is a stable, unique implementation name within that category.
+- `pluginId` is used by management APIs, plugin state, persisted configuration, and diagnostics. Do not change it casually during an upgrade.
 
-In production clusters, all Nacos Server nodes should use the same plugin JAR versions, dependency versions, and plugin configuration. This is especially important for auth, datasource, visibility, config change, and environment plugins because they can affect request results or data read/write behavior.
+Discovery uses a deterministic **first-wins** rule. Null implementations, blank names, and later duplicate `pluginId` values are ignored with WARN logs; an existing registration is never replaced. Configuration definition key and alias conflicts also use first-wins and ignore later conflicting entries.
 
-## Selection Rules
+## Current plugin types
 
-Different plugin types are enabled in different ways:
+| pluginType | Execution mode | Type critical | Initialization | Purpose |
+| --- | --- | --- | --- | --- |
+| `auth` | `EXCLUSIVE` | Yes | `STANDARD` | Select one authentication and authorization implementation. |
+| `datasource-dialect` | `EXCLUSIVE` | Yes | `STANDARD` | Select a database SQL dialect and mapper family. |
+| `config-change` | `CHAIN` | No | `STANDARD` | Run config change plugins by pointcut and order. |
+| `encryption` | `ROUTED` | No | `STANDARD` | Route by the algorithm in an encrypted dataId. |
+| `trace` | `BROADCAST` | No | `STANDARD` | Broadcast events to every matching enabled subscriber. |
+| `environment` | `CHAIN` | No | `PRE_CONTEXT` | Transform environment values in order before Spring context creation. |
+| `control` | `EXCLUSIVE` | No | `STANDARD` | Select one traffic-control manager implementation at startup. |
+| `visibility` | `ROUTED` | No | `STANDARD` | Route visibility decisions from domain requests. |
+| `ai-pipeline` | `CHAIN` | No | `STANDARD` | Run ordered AI resource publish-review nodes. |
+| `ai-storage` | `ROUTED` | Yes | `STANDARD` | Route content storage by `StorageKey.provider`. |
+| `ai-resource-import` | `ROUTED` | No | `STANDARD` | Route by `sourceId` to one fixed external source. |
 
-- **Exclusive plugins**: only one implementation is selected at a time. Auth plugins are selected by `nacos.core.auth.system.type`; datasource dialect plugins are selected by `spring.sql.init.platform`.
-- **Multiple-instance plugins**: multiple implementations may be loaded at the same time. Config change plugins and trace plugins are typical examples.
-- **Built-in and optional implementations**: some implementations are shipped with the Nacos distribution. LDAP, OIDC/OAuth, community datasource plugins, and encryption plugins may require separate plugin packages.
-- **Unified plugin state is not the same as feature configuration**: Nacos 3.2 includes unified plugin management, but each plugin may still require its own feature configuration. Follow the corresponding plugin document for the actual enabling steps.
+`critical` is a type capability; it does not make every implementation of that type permanently non-disableable. `PluginTypePolicy` validates the providers required by the domain only while the type is active. In detail responses, `critical=true` means that this particular implementation cannot currently be disabled by itself, while `typeCritical` identifies the type-level capability.
 
-## Development Principles
+Cluster addressing remains in the plugin documentation for continuity, but current addressing uses `MemberLookup`. It is not a `PluginType` and is not managed by the unified plugin APIs. See [Cluster Addressing](./address-plugin.md).
 
-When developing a plugin, follow these principles:
+## Four execution modes
 
-- **Stay within the documented SPI boundary**. Do not treat internal Nacos classes as stable contracts. When a reference implementation is needed, use the source code of your target Nacos version.
-- **Keep plugin names stable and unique**. Plugin names are used in configuration, logs, and plugin state management. Renaming a plugin affects upgrades and operations.
-- **Avoid blocking the main request path**. Plugins that call networks, disks, audit systems, KMS, or webhooks should use timeouts, fallback behavior, and dedicated executors when needed.
-- **Do not hard-code secrets**. Keys, tokens, and database passwords should come from secure configuration, environment variables, or your enterprise key management system.
-- **Match versions carefully**. Plugin APIs may evolve with Nacos versions. Before upgrading Nacos, validate the plugin version, dependency version, and configuration compatibility together.
-- **Validate before production**. At minimum, verify plugin loading logs, core read/write paths, failure fallback, node restart, rolling upgrade, and rollback.
+- `EXCLUSIVE`: select one implementation at startup. The selection key is `nacos.plugin.{pluginType}.type`; runtime state APIs cannot switch it.
+- `CHAIN`: run every domain-matching enabled implementation in stable order.
+- `ROUTED`: load multiple implementations and let the domain select an enabled implementation by algorithm, provider, `sourceId`, or request context.
+- `BROADCAST`: deliver an event to every enabled implementation that subscribes to it.
 
-## Plugin Documents
+Unified plugin management owns loaded/enabled/config state. Each domain SPI still defines selection, ordering, failure handling, and degradation.
 
-| Plugin | When to read it |
-|--------|-----------------|
-| [Auth Plugin](./auth-plugin.md) | Use default RBAC, LDAP, OIDC/OAuth2, or custom authentication and authorization. |
-| [Visibility Plugin](./visibility-plugin.md) | Control whether AI resources and similar objects are visible to the current caller. |
-| [Multiple Data Sources](./datasource-plugin.md) | Use MySQL, PostgreSQL, Oracle, Derby, or community datasource dialect plugins. |
-| [Configuration Encryption](./config-encryption-plugin.md) | Encrypt sensitive configuration content at storage and decrypt it when reading. |
-| [Config Change Plugin](./config-change-plugin.md) | Validate, audit, or send webhook notifications before or after config changes. |
-| [Tracing](./trace-plugin.md) | Subscribe to internal Nacos operation events for audit, troubleshooting, and operations. |
-| [Custom Environment Plugin](./custom-environment-plugin.md) | Transform server configuration values when Nacos reads them, such as decrypting database passwords. |
-| [Traffic Control](./control-plugin.md) | Limit connection count and TPS to protect Nacos Server stability. |
-| [Cluster Addressing](./address-plugin.md) | Configure how Nacos Server discovers cluster members, such as `file` and `address-server`. |
-| [AI Publish Pipeline](./ai-pipeline-plugin.md) | Run review, scanning, or blocking logic before publishing Skills, Prompts, MCP Servers, AgentSpecs, and other AI resources. |
-| [AI Resource Import](./ai-resource-import-plugin.md) | Import AI resources from MCP registries, Skill marketplaces, or internal catalogs. |
-| [AI Storage](./ai-storage-plugin.md) | Connect custom storage providers for AI resource version content. |
+## State, module switches, and selection
 
-## Reading Guidance
+Do not mix these layers:
 
-For deployment and operations, start with auth, visibility, datasource, configuration encryption, traffic control, cluster addressing, and AI resource import. These topics directly affect production security boundaries, storage, stability, and resource sources.
+| Layer | Responsibility | Example |
+| --- | --- | --- |
+| Module or capability gate | Decides whether the core path enters a capability and may defer loading an entire type. | `nacos.extension.ai.enabled`, `nacos.plugin.visibility.enabled`, `nacos.plugin.ai-pipeline.enabled` |
+| Type selection key | Selects an `EXCLUSIVE` implementation at startup; changes require restart. | `nacos.plugin.auth.type=nacos` |
+| Initial implementation state | Supplies a startup default when no persisted state override exists. | `nacos.plugin.trace.audit.enabled=true` |
+| Unified plugin state | Controls whether a loaded implementation may execute; it may be persisted cluster-wide or changed only on one node. | Plugin status PUT API |
+| Implementation config | Contains only definitions owned by one implementation, not module gates or selection. | `nacos.plugin.auth.nacos.token.expire.seconds` |
 
-For plugin development, start with this page, then read the SPI, loading, and failure fallback sections in the target plugin document. Each plugin has a different integration point, so do not copy configuration or lifecycle assumptions from another plugin type.
+Loaded does not mean enabled, and enabled implementations cannot bypass the module gate. Type-level deferred loading affects first discovery only. Enabling the gate of a deferred non-critical type triggers one-time discovery, state restoration, and config apply. Disabling the gate later stops domain execution but does not unload the instances.
+
+## Unified configuration
+
+An implementation declares `ConfigItemDefinition` entries through `PluginConfigSpec`. The standard static key is:
+
+```text
+nacos.plugin.{pluginType}.{pluginName}.{itemKey}
+```
+
+A definition can declare `key`, `aliases`, `type`, `defaultValue`, `required`, `sensitive`, and `effectMode`. `enabled` is reserved for plugin state and cannot be a normal definition key.
+
+For `STANDARD` plugins, effective value precedence is:
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+The `PRE_CONTEXT` `environment` type resolves only `STATIC > DEFAULT`. It must run before Spring context creation, so all state and configuration changes require restart and cannot use runtime APIs.
+
+For sources, sensitive values, `RUNTIME`/`RESTART`, and API workflows, see [Plugin Operations and Configuration](./operations.md).
+
+## Loading and lifecycle
+
+Regular `STANDARD` plugins are initialized by the unified manager after Spring context refresh. Runtime-persisted configuration is loaded first, and then every configurable plugin receives a complete resolved snapshot through `applyConfig`, even when it has no runtime override.
+
+An adapter that must create resources after configuration can implement `PluginStartupLifecycle`. The unified manager invokes idempotent `initialize()` only for enabled implementations. This callback does not imply that runtime resource replacement is supported; a type without replace-and-close semantics must still reject such switching.
+
+`environment` is discovered, resolved, and applied during `PRE_CONTEXT`. The later unified manager reuses the same instances and accepted snapshots and must not load them again.
+
+## Where to go next
+
+- Operators: read [Plugin Operations and Configuration](./operations.md), then the target plugin-family page.
+- Plugin developers: read [Plugin Development Guide](./development.md), then verify the target domain SPI.
+- Users upgrading old keys or SPIs: read [Plugin Migration Guide](./migration.md).
+
+| Family | Documentation |
+| --- | --- |
+| Auth and visibility | [Auth Plugin](./auth-plugin.md), [Visibility Plugin](./visibility-plugin.md) |
+| Data and config | [Datasource Plugin](./datasource-plugin.md), [Config Encryption](./config-encryption-plugin.md), [Config Change](./config-change-plugin.md) |
+| Stability and observability | [Trace Plugin](./trace-plugin.md), [Custom Environment](./custom-environment-plugin.md), [Control Plugin](./control-plugin.md) |
+| AI extensions | [AI Publish Pipeline](./ai-pipeline-plugin.md), [AI Resource Import](./ai-resource-import-plugin.md), [AI Storage](./ai-storage-plugin.md) |

--- a/src/content/docs/next/en/plugin/trace-plugin.md
+++ b/src/content/docs/next/en/plugin/trace-plugin.md
@@ -3,7 +3,7 @@ title: Tracing
 keywords: [Tracing, audit, diagnostics, Trace Plugin]
 description: Learn the Nacos Trace plugin event model, use cases, development interface, and stability guidance.
 sidebar:
-    order: 7
+    order: 10
 ---
 
 # Tracing Plugin
@@ -11,6 +11,8 @@ sidebar:
 The Nacos Trace plugin subscribes to internal Nacos resource operation events for audit, troubleshooting, and diagnostics. It records Nacos domain events such as service registration, service push, instance health changes, and AI resource operations.
 
 It is not distributed tracing between application services. If you need request spans across business services, use OpenTelemetry, SkyWalking, Zipkin, or another distributed tracing system.
+
+In unified plugin management, the type is `trace`, its execution mode is `BROADCAST`, its load phase is `STANDARD`, and the type is non-critical. A plugin identity is `trace:{getName()}`. The same event can be broadcast to multiple enabled subscribers; state is checked before every dispatch without rebuilding subscriptions.
 
 ## Use Cases
 
@@ -60,7 +62,7 @@ AI resource events:
 
 `DeregisterInstanceTraceEvent` carries a deregistration reason. Common values include `REQUEST`, `NATIVE_DISCONNECTED`, `SYNCED_DISCONNECTED`, and `HEARTBEAT_EXPIRE`.
 
-Nacos provides a default AI resource Trace log subscriber. It writes `AiResourceTraceEvent` records to `ai-resource-trace.log` for AI resource audit compatibility.
+Nacos provides `trace:ai-resource-trace-log`. It writes `AiResourceTraceEvent` records to `ai-resource-trace.log` for AI resource audit compatibility. The implementation is enabled by default, declares no configuration definitions, and is reported as `configurable=false`.
 
 ## Enable a Plugin
 
@@ -90,10 +92,12 @@ Implement `com.alibaba.nacos.plugin.trace.spi.NacosTraceSubscriber`:
 
 | Method | Description |
 |--------|-------------|
-| `getName()` | Stable subscriber name. A later subscriber with the same name replaces an earlier one. |
+| `getName()` | Stable subscriber name. Duplicate identities use first-wins; later discoveries are ignored with a WARN. |
 | `subscribeTypes()` | Event classes this subscriber wants to receive. |
 | `onEvent(event)` | Handle the event. |
 | `executor()` | Optional executor. Return a dedicated executor for slow IO. |
+
+`NacosTraceSubscriber` inherits `PluginConfigSpec`. A new implementation with private settings declares their metadata through definitions, uses canonical keys under `nacos.plugin.trace.{pluginName}.{itemKey}`, and implements `applyConfig` plus a current snapshot. An older binary subscriber without definitions still loads but is reported as not configurable.
 
 Minimal example:
 
@@ -140,4 +144,4 @@ Production advice:
 | Plugin receives no events | Check the JAR, `META-INF/services`, `getName()`, and `subscribeTypes()`. |
 | Event handling blocks | Check whether `onEvent()` performs slow IO. Implement `executor()` if needed. |
 | Logs contain Trace Event Publish failed | Trace queue pressure is high. Check subscriber processing speed and external sinks. |
-| Same-name plugins behave unexpectedly | Check whether multiple subscribers return the same `getName()`. |
+| Same-name plugins behave unexpectedly | Check the WARN log; first-wins keeps the first discovered subscriber and ignores later ones. |

--- a/src/content/docs/next/en/plugin/visibility-plugin.md
+++ b/src/content/docs/next/en/plugin/visibility-plugin.md
@@ -3,7 +3,7 @@ title: Visibility Plugin
 keywords: [Visibility, Plugin, Auth, AI Registry]
 description: Learn what the Nacos visibility plugin does, how the default implementation works, how to configure it, and how it relates to auth plugins.
 sidebar:
-    order: 3
+    order: 6
 ---
 
 # Visibility Plugin
@@ -44,7 +44,7 @@ Then it asks the current auth plugin to evaluate that resource. This keeps the r
 
 ## Default Visibility Implementation
 
-Nacos provides a default visibility implementation named `nacos`. It is provided by the default Nacos auth implementation and currently serves AI Registry resources.
+Nacos provides `visibility:nacos`. `visibility` is a non-critical, `ROUTED`, `STANDARD` type. The built-in implementation declares no private definitions and appears as `configurable=false`.
 
 Default behavior:
 
@@ -64,33 +64,37 @@ List and search APIs must not page first and then filter visibility in memory. T
 
 ## Configuration
 
-The default configuration includes visibility plugin settings:
+Distinguish the capability gate, historical selection, and implementation state:
 
 ```properties
+# Capability gate: disables execution and defers first loading
 nacos.plugin.visibility.enabled=true
+
+# Initial unified state of the built-in implementation
+nacos.plugin.visibility.nacos.enabled=true
+
+# Historical startup selection compatibility
 nacos.plugin.visibility.type=nacos
 ```
 
-When using the default `nacos` visibility implementation, enable Nacos auth as well. The default visibility service reuses user information from the auth context.
+The family gate defaults to enabled. When it is off, the implementation does not execute even if it remains loaded and enabled. Re-enabling triggers discovery, state restoration, and config apply if the type has not loaded yet. Persisted unified state takes precedence over `type` and static `{serviceName}.enabled`.
+
+When using the default implementation, enable Nacos auth as well. It reuses user information from the auth context.
 
 ```properties
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 ```
 
-Plugin-specific properties use this prefix:
+Custom implementations are configurable only when they declare `PluginConfigSpec` definitions. Canonical full keys use:
 
 ```properties
-nacos.plugin.visibility.{serviceName}.*
+nacos.plugin.visibility.{serviceName}.{itemKey}
 ```
 
-For example, a custom plugin named `example` can read:
-
-```properties
-nacos.plugin.visibility.example.timeout=3000
-```
+Do not treat undeclared arbitrary properties as unified config. Old binary and zero-definition implementations still load but appear as `configurable=false`.
 
 ## Visibility SPI
 
@@ -98,11 +102,13 @@ Custom visibility plugins implement `com.alibaba.nacos.plugin.visibility.spi.Vis
 
 | Method | Description |
 | --- | --- |
-| `getVisibilityServiceName()` | Return the plugin name selected by `nacos.plugin.visibility.type`. |
-| `init(properties)` | Initialize plugin-specific properties. |
+| `getVisibilityServiceName()` | Return the stable pluginName. |
+| `init(properties)` | Deprecated legacy callback used only for implementations without definitions. |
 | `resolveDefaultScopeForCreate(identity, apiType, resourceType)` | Return the default `scope` when a create request does not specify one. Default is `PRIVATE`. |
 | `validateVisibility(identity, action, apiType, resource)` | Decide whether one resource is visible or writable for the current identity. |
 | `adviseQuery(identity, action, apiType, queryContext)` | Return visibility advice for list and search queries. |
+
+`VisibilityService` inherits `PluginConfigSpec`. A new implementation declares key/alias/type/default/required/sensitive/effectMode, applies one snapshot atomically, and returns its current config. Unified implementations do not receive legacy `init(Properties)`. Routing checks `visibility:{serviceName}` state before invocation.
 
 ## QueryAdvisor
 

--- a/src/content/docs/next/en/quickstart/quick-start.mdx
+++ b/src/content/docs/next/en/quickstart/quick-start.mdx
@@ -110,8 +110,8 @@ You can obtain the **Nacos distribution package** through the Nacos official web
 The startup program will then prompt you to enter `3` authentication-related configurations (since Nacos 3.0.0, console authentication is enabled by default, so the following 3 authentication configurations must be filled in):
 
 ```
-`nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set with Base64 string: ${your_input_token_secret_key}
-nacos.core.auth.plugin.nacos.token.secret.key` Updated:
+`nacos.plugin.auth.nacos.token.secret.key` is missing, please set with Base64 string: ${your_input_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key` Updated:
 ----------------------------------
 `nacos.core.auth.server.identity.key` is missing, please set: ${your_input_server_identity_key}
 `nacos.core.auth.server.identity.key` Updated:

--- a/src/content/docs/next/zh-cn/contribution/source-code-run-and-start.md
+++ b/src/content/docs/next/zh-cn/contribution/source-code-run-and-start.md
@@ -62,11 +62,11 @@ mvn clean install -Prelease-nacos
 在`Nacos/distribution/target/nacos-server-${version}/nacos/conf/application.properties`文件中添加如下配置：
 
 ```properties
-spring.sql.init.platform=mysql
-db.num=1
-db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-db.user=${MYSQL_USERNAME}
-db.password=${MYSQL_PASSWORD}
+nacos.plugin.datasource-dialect.type=mysql
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.user=${MYSQL_USERNAME}
+nacos.plugin.datasource.db.password=${MYSQL_PASSWORD}
 ```
 
 启动`Nacos-bootstrap`，并指定`nacos.deployment.type`参数为`merged`，启动命令如下：
@@ -75,7 +75,7 @@ db.password=${MYSQL_PASSWORD}
 distribution/target/nacos-server-${version}/nacos/bin/startup.sh -m standalone -d merged
 ```
 
-> 首次启动会引导填写鉴权相关的一些配置参数，`nacos.core.auth.plugin.nacos.token.secret.key`, `nacos.core.auth.server.identity.key` 和 `nacos.core.auth.server.identity.value`, 请按照引导进行填写.
+> 首次启动会引导填写鉴权相关的一些配置参数，`nacos.plugin.auth.nacos.token.secret.key`、`nacos.core.auth.server.identity.key` 和 `nacos.core.auth.server.identity.value`，请按照引导填写。
 
 ### 步骤五：验证Nacos-bootstrap是否启动成功
 

--- a/src/content/docs/next/zh-cn/guide/admin/cluster-mode-quick-start.md
+++ b/src/content/docs/next/zh-cn/guide/admin/cluster-mode-quick-start.md
@@ -88,8 +88,8 @@ cd nacos/distribution/target/nacos-server-1.3.0/nacos/bin
 
 ```properties
 nacos.core.auth.enabled=true
-nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
+nacos.plugin.auth.type=nacos
+nacos.plugin.auth.nacos.token.secret.key=${自定义，保证所有节点一致}
 nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
 nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
 ```

--- a/src/content/docs/next/zh-cn/guide/admin/deployment.md
+++ b/src/content/docs/next/zh-cn/guide/admin/deployment.md
@@ -50,12 +50,12 @@ $ cmd startup.cmd -m standalone
 - 3.修改conf/application.properties文件，增加支持mysql数据源配置（目前只支持mysql），添加mysql数据源的url、用户名和密码。
 
 ```
-spring.datasource.platform=mysql
+nacos.plugin.datasource-dialect.type=mysql
 
-db.num=1
-db.url.0=jdbc:mysql://11.162.196.16:3306/nacos_devtest?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-db.user=nacos_devtest
-db.password=youdontknow
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:mysql://11.162.196.16:3306/nacos_devtest?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+nacos.plugin.datasource.db.user=nacos_devtest
+nacos.plugin.datasource.db.password=youdontknow
 ```
 
 再以单机模式启动nacos，nacos所有写嵌入式数据库的数据都写到了mysql

--- a/src/content/docs/next/zh-cn/guide/admin/nginx-cluster-load-balance-guide.md
+++ b/src/content/docs/next/zh-cn/guide/admin/nginx-cluster-load-balance-guide.md
@@ -45,10 +45,10 @@ spring.cloud.nacos.discovery.server-addr=192.168.190.128:8848,192.168.190.129:88
 **application.properties**（数据库配置）：
 
 ```properties
-spring.datasource.platform=mysql
-db.url.0=jdbc:mysql://192.168.190.1:3306/config?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-db.user.0=root
-db.password.0=your_password
+nacos.plugin.datasource-dialect.type=mysql
+nacos.plugin.datasource.db.url.0=jdbc:mysql://192.168.190.1:3306/config?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.user.0=root
+nacos.plugin.datasource.db.password.0=your_password
 ```
 
 ## Nginx 配置

--- a/src/content/docs/next/zh-cn/guide/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/guide/admin/system-configurations.md
@@ -44,19 +44,14 @@ JAVA_OPT="${JAVA_OPT} -Dnacos.home=${BASE_DIR}"
 
 |参数名	|含义	 |     可选值	 |     默认值| 支持版本 |
 |------|------|-----------|-----------------|-------|
-|db.num| 数据库数目 | 正整数 | 0 | >= 0.1.0 |
-|db.url.0| 第一个数据库的URL | 字符串 | 空 | >= 0.1.0 |
-|db.url.1| 第二个数据库的URL | 字符串 | 空 | >= 0.1.0 |
-|db.user| 数据库连接的用户名 | 字符串 | 空 | >= 0.1.0 |
-|db.password| 数据库连接的密码 | 字符串 | 空 | >= 0.1.0 |
-|spring.datasource.platform|数据库类型|字符串|mysql|>=1.3.0|
-|db.pool.config.xxx| 数据库连接池参数，使用的是hikari连接池，参数与hikari连接池相同，如`db.pool.config.connectionTimeout`或`db.pool.config.maximumPoolSize`|字符串|同hikariCp对应默认配置|>=1.4.1|
+|nacos.plugin.datasource-dialect.type|数据库方言选择|derby/mysql/postgresql/oracle/自定义|按运行模式|next|
+|nacos.plugin.datasource.db.num|外置数据库数目|正整数|0|next|
+|nacos.plugin.datasource.db.url.{index}|逐下标数据库 URL|字符串|空|next|
+|nacos.plugin.datasource.db.user[.{index}]|公共或逐下标用户名|字符串|空|next|
+|nacos.plugin.datasource.db.password[.{index}]|公共或逐下标密码|字符串|空|next|
+|nacos.plugin.datasource.db.pool.config.xxx|HikariCP 参数，稳定项使用 kebab-case|字符串|见插件文档|next|
 
-当前数据库配置支持多数据源。通过`db.num`来指定数据源个数，`db.url.index`为对应的数据库的链接。`db.user`以及`db.password`没有设置`index`时,所有的链接都以`db.user`和`db.password`用作认证。如果不同数据源的用户名称或者用户密码不一样时，可以通过符号`,`来进行切割，或者指定`db.user.index`,`db.user.password`来设置对应数据库链接的用户或者密码。需要注意的是，当`db.user`和`db.password`没有指定下标时，因为当前机制会根据`,`进行切割。所以当用户名或者密码存在`,`时，会把`,`切割后前面的值当成最后的值进行认证，会导致认证失败。
-
-Nacos从1.3版本开始使用HikariCP连接池，但在1.4.1版本前，连接池配置由系统默认值定义，无法自定义配置。在1.4.1后，提供了一个方法能够配置HikariCP连接池。
-`db.pool.config`为配置前缀，`xxx`为实际的hikariCP配置，如`db.pool.config.connectionTimeout`或`db.pool.config.maximumPoolSize`等。更多hikariCP的配置请查看[HikariCP](https://github.com/brettwooldridge/HikariCP) 
-需要注意的是，url,user,password会由`db.url.n`,`db.user`,`db.password`覆盖，driverClassName则是默认的MySQL8 driver（该版本mysql driver支持mysql5.x)
+`spring.sql.init.platform` 和 `db.*` 仍是历史 alias，标准键优先；`spring.datasource.platform` 已移除。完整稳定键、默认值和迁移规则见[多数据源插件](../../plugin/datasource-plugin.md)。
 
 ### CMDB模块
 

--- a/src/content/docs/next/zh-cn/guide/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/guide/admin/system-configurations.md
@@ -44,12 +44,12 @@ JAVA_OPT="${JAVA_OPT} -Dnacos.home=${BASE_DIR}"
 
 |参数名	|含义	 |     可选值	 |     默认值| 支持版本 |
 |------|------|-----------|-----------------|-------|
-|nacos.plugin.datasource-dialect.type|数据库方言选择|derby/mysql/postgresql/oracle/自定义|按运行模式|next|
-|nacos.plugin.datasource.db.num|外置数据库数目|正整数|0|next|
-|nacos.plugin.datasource.db.url.{index}|逐下标数据库 URL|字符串|空|next|
-|nacos.plugin.datasource.db.user[.{index}]|公共或逐下标用户名|字符串|空|next|
-|nacos.plugin.datasource.db.password[.{index}]|公共或逐下标密码|字符串|空|next|
-|nacos.plugin.datasource.db.pool.config.xxx|HikariCP 参数，稳定项使用 kebab-case|字符串|见插件文档|next|
+|nacos.plugin.datasource-dialect.type|数据库方言选择|derby/mysql/postgresql/oracle/自定义|按运行模式|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.num|外置数据库数目|正整数|0|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.url.{index}|逐下标数据库 URL|字符串|空|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.user[.{index}]|公共或逐下标用户名|字符串|空|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.password[.{index}]|公共或逐下标密码|字符串|空|3.3.0 ~ latest|
+|nacos.plugin.datasource.db.pool.config.xxx|HikariCP 参数，稳定项使用 kebab-case|字符串|见插件文档|3.3.0 ~ latest|
 
 `spring.sql.init.platform` 和 `db.*` 仍是历史 alias，标准键优先；`spring.datasource.platform` 已移除。完整稳定键、默认值和迁移规则见[多数据源插件](../../plugin/datasource-plugin.md)。
 

--- a/src/content/docs/next/zh-cn/guide/user/auth.md
+++ b/src/content/docs/next/zh-cn/guide/user/auth.md
@@ -20,14 +20,12 @@ sidebar:
 |参数名|默认值|启止版本|说明|
 |-----|------|------|----|
 |nacos.core.auth.enabled|false|1.2.0 ~ latest|是否开启鉴权功能|
-|nacos.plugin.auth.type|nacos|next|鉴权实现选择；旧 `nacos.core.auth.system.type` 是 alias|
-|nacos.plugin.auth.nacos.token.secret.key|无默认值|next|默认鉴权插件的 accessToken 签名密钥，敏感且 RESTART|
-|nacos.plugin.auth.nacos.token.expire.seconds|18000|next|用户登录 accessToken 过期时间，RUNTIME|
+|nacos.plugin.auth.type|nacos|3.3.0 ~ latest|鉴权实现选择；旧 `nacos.core.auth.system.type` 是 alias|
+|nacos.plugin.auth.nacos.token.secret.key|无默认值|3.3.0 ~ latest|默认鉴权插件的 accessToken 签名密钥，敏感且 RESTART|
+|nacos.plugin.auth.nacos.token.expire.seconds|18000|3.3.0 ~ latest|用户登录 accessToken 过期时间，RUNTIME|
 |nacos.core.auth.enable.userAgentAuthWhite|false|1.4.1 ~ latest|是否使用useragent白名单，主要用于适配老版本升级，**置为true时有安全风险**|
 |nacos.core.auth.server.identity.key|serverIdentity(2.2.1后无默认值)|1.4.1 ~ latest|用于替换useragent白名单的身份识别key，**使用默认值有安全风险**|
 |nacos.core.auth.server.identity.value|security(2.2.1后无默认值)|1.4.1 ~ latest|用于替换useragent白名单的身份识别value，**使用默认值有安全风险**|
-|~~nacos.core.auth.default.token.secret.key~~|SecretKey012345678901234567890123456789012345678901234567890123456789|1.2.0 ~ 2.0.4|同`nacos.core.auth.plugin.nacos.token.secret.key`|
-|~~nacos.core.auth.default.token.expire.seconds~~|18000|1.2.0 ~ 2.0.4|同`nacos.core.auth.plugin.nacos.token.expire.seconds`|
 
 ## 默认控制台登录页
 
@@ -58,28 +56,22 @@ nacos.core.auth.enabled=true
 
 > 注意：
 > 1. 文档中提供的密钥为公开密钥，在实际部署时请更换为其他密钥内容，防止密钥泄漏导致安全风险。
-> 2. 在2.2.0.1版本后，社区发布版本将移除以文档如下值作为默认值，需要自行填充，否则无法启动节点。
+> 2. 签名密钥没有默认值。标准值为空时，发行包启动脚本会先迁移 `application.properties` 中有效的 `nacos.core.auth.plugin.nacos.token.secret.key`；两个 key 都没有有效值时才提示输入。
 > 3. 密钥需要保持节点间一致，长时间不一致可能导致403 invalid token错误。
 
 ```properties
-### The default token(Base64 String):
-nacos.core.auth.default.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
-
-### 2.1.0 版本后
 nacos.plugin.auth.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
 ```
 
-自定义密钥时，推荐将配置项设置为**Base64编码**的字符串，且**原始密钥长度不得低于32字符**。例如下面的的例子：
+自定义密钥时，推荐将配置项设置为 **Base64 编码**的字符串，且**解码后的密钥不得少于 32 字节**。例如：
 
 ```properties
-### The default token(Base64 String):
-nacos.core.auth.default.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
-
-### 2.1.0 版本后
 nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
-> 注意：鉴权开关是修改之后立马生效的，不需要重启服务端。动态修改`token.secret.key`时，请确保token是有效的，如果修改成无效值，会导致后续无法登录，请求访问异常。
+历史 `nacos.core.auth.plugin.nacos.token.secret.key` 仍作为 alias；新配置请使用标准 key。
+
+> 注意：鉴权开关修改后立即生效。`token.secret.key` 是 `RESTART` 配置项，应修改静态配置、确保所有节点一致，再重启服务端。
 
 ### Docker环境
 

--- a/src/content/docs/next/zh-cn/guide/user/auth.md
+++ b/src/content/docs/next/zh-cn/guide/user/auth.md
@@ -20,9 +20,9 @@ sidebar:
 |参数名|默认值|启止版本|说明|
 |-----|------|------|----|
 |nacos.core.auth.enabled|false|1.2.0 ~ latest|是否开启鉴权功能|
-|nacos.core.auth.system.type|nacos|1.2.0 ~ latest|鉴权类型|
-|nacos.core.auth.plugin.nacos.token.secret.key|SecretKey012345678901234567890123456789012345678901234567890123456789(2.2.0.1后无默认值)|2.1.0 ~ latest|默认鉴权插件用于生成用户登陆临时accessToken所使用的密钥，**使用默认值有安全风险**|
-|nacos.core.auth.plugin.nacos.token.expire.seconds|18000|2.1.0 ~ latest|用户登陆临时accessToken的过期时间|
+|nacos.plugin.auth.type|nacos|next|鉴权实现选择；旧 `nacos.core.auth.system.type` 是 alias|
+|nacos.plugin.auth.nacos.token.secret.key|无默认值|next|默认鉴权插件的 accessToken 签名密钥，敏感且 RESTART|
+|nacos.plugin.auth.nacos.token.expire.seconds|18000|next|用户登录 accessToken 过期时间，RUNTIME|
 |nacos.core.auth.enable.userAgentAuthWhite|false|1.4.1 ~ latest|是否使用useragent白名单，主要用于适配老版本升级，**置为true时有安全风险**|
 |nacos.core.auth.server.identity.key|serverIdentity(2.2.1后无默认值)|1.4.1 ~ latest|用于替换useragent白名单的身份识别key，**使用默认值有安全风险**|
 |nacos.core.auth.server.identity.value|security(2.2.1后无默认值)|1.4.1 ~ latest|用于替换useragent白名单的身份识别value，**使用默认值有安全风险**|
@@ -48,7 +48,7 @@ nacos.core.auth.enabled=false
 开启鉴权之后，application.properties中的配置信息为：
 ```java
 ### If turn on auth system:
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 ```
 
@@ -66,7 +66,7 @@ nacos.core.auth.enabled=true
 nacos.core.auth.default.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
 
 ### 2.1.0 版本后
-nacos.core.auth.plugin.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
+nacos.plugin.auth.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
 ```
 
 自定义密钥时，推荐将配置项设置为**Base64编码**的字符串，且**原始密钥长度不得低于32字符**。例如下面的的例子：
@@ -76,7 +76,7 @@ nacos.core.auth.plugin.nacos.token.secret.key=SecretKey0123456789012345678901234
 nacos.core.auth.default.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 
 ### 2.1.0 版本后
-nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
 > 注意：鉴权开关是修改之后立马生效的，不需要重启服务端。动态修改`token.secret.key`时，请确保token是有效的，如果修改成无效值，会导致后续无法登录，请求访问异常。
@@ -128,7 +128,7 @@ nacos.core.auth.enabled=false
 ```
 修改为
 ```
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 ```
 然后再配置nacos启动命令。
@@ -198,13 +198,13 @@ https://github.com/alibaba/nacos/issues/9906
 
 #### 开启方式
 ```
-nacos.core.auth.plugin.nacos.token.cache.enable=true
+nacos.plugin.auth.nacos.token.cache.enable=true
 ```
 
 #### 注意事项
 在开启Token缓存功能之前，服务端对每一个携带用户名密码访问login接口的请求都会生成新的token，接口的返回值中的tokenTtl字段跟服务端配置文件中设置的值相等，配置如下：
 ```
-nacos.core.auth.plugin.nacos.token.expire.seconds=18000
+nacos.plugin.auth.nacos.token.expire.seconds=18000
 ```
 在开启Token缓存功能之后，服务端对每一个携带用户名密码访问login接口的请求，会先检查缓存中是否存在该用户名对应的token。若不存在，生成新的Token，插入缓存再返回；若存在，返回该token，此时tokenTtl字段的值为配置文件中设置的值减去该Token在缓存中存留的时长。
 如果Token在缓存中存留的时长超过配置文件设置的值的90%，当login接口收到请求时，尽管缓存中存在该用户名对应的Token，服务端会重新生成Token返回给请求方，并更新缓存。因此，最差情况下，请求方收到的tokenTtl只有配置文件设置的值的10%。

--- a/src/content/docs/next/zh-cn/guide/user/auth.md
+++ b/src/content/docs/next/zh-cn/guide/user/auth.md
@@ -20,12 +20,15 @@ sidebar:
 |参数名|默认值|启止版本|说明|
 |-----|------|------|----|
 |nacos.core.auth.enabled|false|1.2.0 ~ latest|是否开启鉴权功能|
-|nacos.plugin.auth.type|nacos|3.3.0 ~ latest|鉴权实现选择；旧 `nacos.core.auth.system.type` 是 alias|
+|nacos.plugin.auth.type|nacos|3.3.0 ~ latest|鉴权实现选择|
 |nacos.plugin.auth.nacos.token.secret.key|无默认值|3.3.0 ~ latest|默认鉴权插件的 accessToken 签名密钥，敏感且 RESTART|
 |nacos.plugin.auth.nacos.token.expire.seconds|18000|3.3.0 ~ latest|用户登录 accessToken 过期时间，RUNTIME|
 |nacos.core.auth.enable.userAgentAuthWhite|false|1.4.1 ~ latest|是否使用useragent白名单，主要用于适配老版本升级，**置为true时有安全风险**|
 |nacos.core.auth.server.identity.key|serverIdentity(2.2.1后无默认值)|1.4.1 ~ latest|用于替换useragent白名单的身份识别key，**使用默认值有安全风险**|
 |nacos.core.auth.server.identity.value|security(2.2.1后无默认值)|1.4.1 ~ latest|用于替换useragent白名单的身份识别value，**使用默认值有安全风险**|
+|~~nacos.core.auth.system.type~~|nacos|1.2.0 ~ latest|历史鉴权实现选择 key，已废弃并即将移除；请使用 `nacos.plugin.auth.type`|
+|~~nacos.core.auth.plugin.nacos.token.secret.key~~|无默认值|2.1.0 ~ latest|历史签名密钥 alias，已废弃并即将移除；请使用 `nacos.plugin.auth.nacos.token.secret.key`|
+|~~nacos.core.auth.plugin.nacos.token.expire.seconds~~|18000|2.1.0 ~ latest|历史 token 过期时间 alias，已废弃并即将移除；请使用 `nacos.plugin.auth.nacos.token.expire.seconds`|
 
 ## 默认控制台登录页
 

--- a/src/content/docs/next/zh-cn/manual/admin/admin-api.md
+++ b/src/content/docs/next/zh-cn/manual/admin/admin-api.md
@@ -1501,7 +1501,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 #### 接口描述
 
-通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。支持 localOnly 仅作用于当前节点。
+更新插件的完整目标来源配置。`localOnly=false` 写入持久化运行时来源，`localOnly=true` 只写当前节点本地来源；后者优先级更高。提交 map 会替换该来源的旧 map，空 map 表示清空。只能更新 definitions 中 `effectMode=RUNTIME` 的项，新增、修改或删除 `RESTART` 项都会被拒绝。
 
 #### 起始版本
 
@@ -1529,8 +1529,8 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 |-------------|----------|----|----------------|
 | `pluginType` | `string` | **是** | 插件类型，如 auth。 |
 | `pluginName` | `string` | **是** | 插件名称。 |
-| `config` | `string` | **是** | 插件配置项。 |
-| `localOnly` | `boolean` | 否 | 是否仅写本地，不持久化。 |
+| `config` | `object` | **是** | 以 definition item key 为键的完整配置 map。 |
+| `localOnly` | `boolean` | 否 | `true` 写 `LOCAL_ONLY`；否则写集群持久化的 `RUNTIME_PERSISTED`。 |
 
 #### 返回数据
 
@@ -1542,7 +1542,8 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/state/readiness'
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
-  -H 'Content-Type: application/json' -d '{}'
+  -H 'Content-Type: application/json' \
+  -d '{"pluginType":"auth","pluginName":"ldap","config":{"connect-timeout":"6000"},"localOnly":false}'
 ```
 
 * 返回示例
@@ -1595,16 +1596,20 @@ curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
 | pluginName | `string` | 插件名称 |
 | enabled | `boolean` | 是否启用 |
 | critical | `boolean` | 是否关键插件 |
+| typeCritical | `boolean` | 插件类型是否声明为 critical |
+| executionMode | `string` | `EXCLUSIVE`、`CHAIN`、`ROUTED` 或 `BROADCAST` |
+| exclusive | `boolean` | 是否为排他选择类型 |
 | configurable | `boolean` | 是否可配置 |
-| config | `object` | 配置内容 |
-| configDefinitions | `array` | 配置定义列表 |
+| config | `object` | 当前有效 item map，敏感值已脱敏 |
+| configDefinitions | `array` | definitions，包含 key、aliases、type、defaultValue、required、sensitive 和 effectMode |
+| configValueMetas | `object` | 各 item 的有效值来源和 `overridden` 元数据 |
 
 #### 示例
 
 * 请求示例
 
 ```shell
-curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=auth&pluginName=nacos-default-auth-plugin'
+curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=auth&pluginName=nacos'
 ```
 
 * 返回示例
@@ -1614,14 +1619,18 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/detail?pluginType=
   "code": 0,
   "message": "success",
   "data": {
-    "pluginId": "auth:nacos-default-auth-plugin",
+    "pluginId": "auth:nacos",
     "pluginType": "auth",
-    "pluginName": "nacos-default-auth-plugin",
+    "pluginName": "nacos",
     "enabled": true,
     "critical": true,
-    "configurable": true,
+    "typeCritical": true,
+    "executionMode": "EXCLUSIVE",
+    "exclusive": true,
+    "configurable": false,
     "config": {},
-    "configDefinitions": []
+    "configDefinitions": [],
+    "configValueMetas": {}
   }
 }
 ```
@@ -1674,12 +1683,14 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
   "message": "success",
   "data": [
     {
-      "pluginId": "auth:nacos-default-auth-plugin",
+      "pluginId": "auth:nacos",
       "pluginType": "auth",
-      "pluginName": "nacos-default-auth-plugin",
+      "pluginName": "nacos",
       "enabled": true,
       "critical": true,
-      "configurable": true,
+      "configurable": false,
+      "typeCritical": true,
+      "executionMode": "EXCLUSIVE",
       "exclusive": true
     }
   ]
@@ -1690,7 +1701,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 #### 接口描述
 
-通过该接口，可以更新插件的启用状态（启用或禁用）。支持 localOnly 仅作用于当前节点。
+更新实现状态。`localOnly=false` 写入 `${nacos.home}/data/plugin/plugin-states.json` 并用于集群操作；`localOnly=true` 只影响当前节点且优先。EXCLUSIVE 选择、PRE_CONTEXT 状态以及 active critical provider 不能通过运行时请求非法修改。
 
 #### 起始版本
 
@@ -1731,7 +1742,8 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/list?pluginType=au
 
 ```shell
 curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/status' \
-  -H 'Content-Type: application/json' -d '{}'
+  -H 'Content-Type: application/json' \
+  -d '{"pluginType":"trace","pluginName":"ai-resource-trace-log","enabled":false,"localOnly":false}'
 ```
 
 * 返回示例
@@ -9738,11 +9750,13 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v3/admin/ai/pipelines/detail?pipelineId
 
 ## 10. AI 资源导入
 
+这些 API 只使用统一插件管理中已启用的固定来源。请求和响应的 `sourceId` 等于 managed `pluginName`：`mcp-official`、`mcp-registry-protocol`、`skills-sh` 或 `skills-well-known`。来源描述中的历史字段 `pluginName` 仍表示 importerType（例如 `mcp-registry`），不能把它当作 `sourceId`。同一个实现不能再通过纯配置复制成多个 endpoint。
+
 ### 10.1. 查询 AI 资源导入源
 
 #### 接口描述
 
-通过该接口，可查询当前配置的 AI 资源导入源。
+查询当前已加载且启用的固定 AI 资源导入来源。来源详情与标准 definitions 由 `ai-resource-import:{sourceId}` 管理。
 
 #### 起始版本
 

--- a/src/content/docs/next/zh-cn/manual/admin/auth.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/auth.mdx
@@ -32,16 +32,16 @@ Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴
 
 | 配置项 | 默认配置 | 说明 |
 | --- | --- | --- |
-| `nacos.core.auth.system.type` | `nacos` | 当前使用的鉴权插件类型。支持 `nacos`、`ldap`、`oidc` 或自定义类型。 |
+| `nacos.plugin.auth.type` | `nacos` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias。 |
 | `nacos.core.auth.enabled` | `true` | 是否开启 Open API、SDK 和 gRPC 请求鉴权。 |
 | `nacos.core.auth.admin.enabled` | `true` | 是否开启 Admin API 鉴权。 |
 | `nacos.core.auth.console.enabled` | `true` | 是否开启 Console API 和默认控制台登录鉴权。 |
 | `nacos.core.auth.server.identity.key` | 空 | Nacos Server 节点间通信的身份 key。开启鉴权的集群部署必须配置。 |
 | `nacos.core.auth.server.identity.value` | 空 | Nacos Server 节点间通信的身份 value。开启鉴权的集群部署必须配置。 |
 | `nacos.core.auth.caching.enabled` | `true` | 是否缓存用户、角色、权限信息。权限变更可能存在约 15 秒延迟。 |
-| `nacos.core.auth.plugin.nacos.token.secret.key` | 空 | 默认 Nacos token 签名密钥。建议配置为 Base64 字符串，原始密钥长度不少于 32 字符。 |
-| `nacos.core.auth.plugin.nacos.token.expire.seconds` | `18000` | 默认 Nacos token 有效期，单位秒。 |
-| `nacos.core.auth.plugin.nacos.token.cache.enable` | `false` | 是否缓存已签发 token 的解析和校验结果。 |
+| `nacos.plugin.auth.nacos.token.secret.key` | 空 | 默认 Nacos token 签名密钥，敏感且 RESTART；旧 core key 是 alias。 |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | token 有效期，RUNTIME；旧 core key 是 alias。 |
+| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | token 缓存开关，RUNTIME；旧 core key 是 alias。 |
 
 :::note
 如果你从旧版本升级，实际配置可能保留旧值。请以当前集群的 `application.properties`、环境变量和启动参数为准。
@@ -57,14 +57,14 @@ Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴
     修改 `${nacos.home}/conf/application.properties`：
 
     ```properties
-    nacos.core.auth.system.type=nacos
+    nacos.plugin.auth.type=nacos
     nacos.core.auth.enabled=true
     nacos.core.auth.admin.enabled=true
     nacos.core.auth.console.enabled=true
 
     nacos.core.auth.server.identity.key=${custom_server_identity_key}
     nacos.core.auth.server.identity.value=${custom_server_identity_value}
-    nacos.core.auth.plugin.nacos.token.secret.key=${custom_base64_token_secret_key}
+    nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
     ```
 
     集群模式下，各节点的 `server.identity` 和 `token.secret.key` 必须保持一致。
@@ -146,19 +146,18 @@ LDAP 的工作边界是：
 配置示例：
 
 ```properties
-nacos.core.auth.system.type=ldap
+nacos.plugin.auth.type=ldap
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
-nacos.core.auth.ldap.url=ldap://localhost:389
-nacos.core.auth.ldap.basedc=dc=example,dc=org
-nacos.core.auth.ldap.userDn=cn=admin,${nacos.core.auth.ldap.basedc}
-nacos.core.auth.ldap.password=admin
-nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
-nacos.core.auth.ldap.filter.prefix=uid
-nacos.core.auth.ldap.case.sensitive=true
-nacos.core.auth.ldap.ignore.partial.result.exception=false
+nacos.plugin.auth.ldap.url=ldap://localhost:389
+nacos.plugin.auth.ldap.base-dn=dc=example,dc=org
+nacos.plugin.auth.ldap.user-dn=cn=admin,dc=example,dc=org
+nacos.plugin.auth.ldap.password=${ldap_bind_password}
+nacos.plugin.auth.ldap.filter-prefix=uid
+nacos.plugin.auth.ldap.case-sensitive=true
+nacos.plugin.auth.ldap.ignore-partial-result-exception=false
 ```
 
 启用前请确认：
@@ -175,25 +174,25 @@ OIDC/OAuth2 插件类型是 `oidc`。它通过外部 IdP 完成身份认证，�
 基础配置示例：
 
 ```properties
-nacos.core.auth.system.type=oidc
+nacos.plugin.auth.type=oidc
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
 nacos.core.auth.server.identity.key=${custom_server_identity_key}
 nacos.core.auth.server.identity.value=${custom_server_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${custom_base64_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
 
-nacos.core.auth.plugin.oidc.issuer-uri=https://idp.example.com/realms/nacos
-nacos.core.auth.plugin.oidc.client-id=nacos-server
-nacos.core.auth.plugin.oidc.client-secret=${client_secret}
-nacos.core.auth.plugin.oidc.scope=openid profile email
+nacos.plugin.auth.oidc.issuer-uri=https://idp.example.com/realms/nacos
+nacos.plugin.auth.oidc.client-id=nacos-server
+nacos.plugin.auth.oidc.client-secret=${client_secret}
+nacos.plugin.auth.oidc.scope=openid profile email
 ```
 
 OIDC/OAuth2 模式下，控制台登录走 `/v1/auth/oidc/*` 兼容接口。Java SDK 可通过 OAuth2 Client Credentials flow 获取 bearer token。
 
 :::caution
-如果生产环境需要按资源做权限隔离，请配置 OIDC 插件的外部授权端点。当前实现中 `nacos.core.auth.plugin.oidc.authorization-endpoint` 为空时，非管理员授权判断会默认放行。
+如果生产环境需要按资源做权限隔离，请配置 `nacos.plugin.auth.oidc.authorization-endpoint`。当前实现中该项为空时，非管理员授权判断会默认放行。
 :::
 
 详细配置、Keycloak 示例、外部授权接口和排查方式请参考 [OIDC/OAuth2 认证](./oidc-auth.md)。
@@ -241,7 +240,7 @@ curl -X POST 'http://127.0.0.1:8848/nacos/v3/auth/user/login' \
 默认 Nacos 鉴权支持 token 缓存。开启后，服务端会缓存 token 解析和校验结果，减少频繁解析 JWT 的开销。
 
 ```properties
-nacos.core.auth.plugin.nacos.token.cache.enable=true
+nacos.plugin.auth.nacos.token.cache.enable=true
 ```
 
 注意事项：

--- a/src/content/docs/next/zh-cn/manual/admin/auth.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/auth.mdx
@@ -33,15 +33,15 @@ Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴
 | 配置项 | 默认配置 | 说明 |
 | --- | --- | --- |
 | `nacos.plugin.auth.type` | `nacos` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias。 |
-| `nacos.core.auth.enabled` | `true` | 是否开启 Open API、SDK 和 gRPC 请求鉴权。 |
+| `nacos.core.auth.enabled` | `false` | 是否开启 Open API、SDK 和 gRPC 请求鉴权。 |
 | `nacos.core.auth.admin.enabled` | `true` | 是否开启 Admin API 鉴权。 |
 | `nacos.core.auth.console.enabled` | `true` | 是否开启 Console API 和默认控制台登录鉴权。 |
 | `nacos.core.auth.server.identity.key` | 空 | Nacos Server 节点间通信的身份 key。开启鉴权的集群部署必须配置。 |
 | `nacos.core.auth.server.identity.value` | 空 | Nacos Server 节点间通信的身份 value。开启鉴权的集群部署必须配置。 |
-| `nacos.core.auth.caching.enabled` | `true` | 是否缓存用户、角色、权限信息。权限变更可能存在约 15 秒延迟。 |
-| `nacos.plugin.auth.nacos.token.secret.key` | 空 | 默认 Nacos token 签名密钥，敏感且 RESTART；旧 core key 是 alias。 |
-| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | token 有效期，RUNTIME；旧 core key 是 alias。 |
-| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | token 缓存开关，RUNTIME；旧 core key 是 alias。 |
+| `nacos.plugin.auth.nacos.caching.enabled` | `true` | 是否缓存用户、角色、权限信息；`nacos.core.auth.caching.enabled` 是历史 alias。权限变更可能存在约 15 秒延迟。 |
+| `nacos.plugin.auth.nacos.token.secret.key` | 空 | 默认 Nacos token 签名密钥，敏感且 RESTART；`nacos.core.auth.plugin.nacos.token.secret.key` 是历史 alias。 |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | token 有效期，RUNTIME；`nacos.core.auth.plugin.nacos.token.expire.seconds` 是历史 alias。 |
+| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | token 缓存开关，RUNTIME；`nacos.core.auth.plugin.nacos.token.cache.enable` 是历史 alias。 |
 
 :::note
 如果你从旧版本升级，实际配置可能保留旧值。请以当前集群的 `application.properties`、环境变量和启动参数为准。

--- a/src/content/docs/next/zh-cn/manual/admin/compatibility-and-deprecation.md
+++ b/src/content/docs/next/zh-cn/manual/admin/compatibility-and-deprecation.md
@@ -28,6 +28,7 @@ Nacos 会在版本演进中保留一部分兼容能力，帮助用户完成升�
 | 兼容开关 | 只在升级或迁移窗口期打开。稳定后关闭。 | [系统参数](./system-configurations.md) |
 | Beta/Tag 灰度配置兼容 | Nacos 3.3 起不再自动迁移旧 `config_info_beta`、`config_info_tag` 表，升级前需迁移到 `config_info_gray` 当前灰度模型。当前 beta/tag API 仍由 `config_info_gray` 和 `GrayRule` 支撑。 | [升级手册](./upgrading.mdx)、[配置灰度发布](../user/config/gray-release.md) |
 | 默认命名空间迁移 | Nacos 3.3 起不再自动在空 tenant 与 `public` 之间做存储迁移或双写。空或省略 namespace 请求仍会归一为默认 namespace `public`。 | [升级手册](./upgrading.mdx)、[Java SDK 使用手册](../user/java-sdk/usage.md#13-升级兼容性) |
+| 插件管理重构 | 迁移到 `pluginType:pluginName`、标准 definition key 和统一状态。AI Resource Import 的旧双层 SPI/Source/preset 模型已移除。 | [插件迁移](../../plugin/migration.md)、[AI 资源导入插件](../../plugin/ai-resource-import-plugin.md) |
 | 旧控制台 | 仅用于兼容存量使用习惯。新部署使用新控制台。 | [控制台手册](./console.md#旧控制台) |
 | Java SDK 已废弃配置项 | 不在新系统中继续使用。 | [Java SDK 属性配置](../user/java-sdk/properties.md) |
 | CLI 已废弃命令 | 使用显式生命周期命令替代快捷 publish 命令。 | [Nacos CLI 使用指南](./nacos-cli.md) |
@@ -40,6 +41,12 @@ Nacos 3.3 移除了 Config 3.0 之前的运行时兼容迁移逻辑，包括默�
 从 3.0 之前版本升级到 3.3 时，如果旧部署未使用默认 namespace，且未使用 beta 灰度发布，则本次兼容迁移移除不影响该兼容领域的平滑升级。若使用过默认 namespace 或 beta 灰度发布，则升级到 3.3 前需要自行完成数据迁移：将默认 namespace 数据从空 tenant 迁移到 `public`，并将旧 beta/tag 灰度数据迁移到 `config_info_gray` 当前灰度模型。
 
 这不是移除当前默认 namespace 语义，也不是移除当前 beta/tag 灰度 API。空或省略 namespace 请求仍归一为 `public`；当前 beta/tag 灰度行为仍由 `config_info_gray` 和 `GrayRule` 支撑。
+
+## 插件管理与 AI Resource Import breaking change
+
+next 版本插件使用统一身份、状态、配置来源和生命周期。历史实现如果未实现 `PluginConfigSpec` 仍可加载，但自动显示为 `configurable=false`。Config Change 的 `ConfigChangeConfigs` 已废弃但仍处于兼容周期。
+
+AI Resource Import 是不兼容迁移：`AiResourceImportSource`、Source Provider SPI、preset、`nacos.ai.resource.import.sources[N].*` 以及通过配置复制同一实现到多个 endpoint 的模型均已移除。一个 `pluginName` 现在对应一个确定来源，`sourceId` 等于 managed pluginName；旧 API 的 `pluginName` 字段继续表示 importerType。新部署使用 `nacos.plugin.ai-resource-import.*`，迁移清单见[插件迁移](../../plugin/migration.md)。
 
 ## 使用兼容能力时要确认什么
 

--- a/src/content/docs/next/zh-cn/manual/admin/console-api.md
+++ b/src/content/docs/next/zh-cn/manual/admin/console-api.md
@@ -848,8 +848,8 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespa
 
 | 参数名 | 类型 | 必填 | 参数描述 |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 `auth`（鉴权）、`control`（控制）、`datasource`（数据源）等。 |
-| `pluginName` | `string` | **是** | 插件名称，如 `nacos-default-auth-plugin`。 |
+| `pluginType` | `string` | **是** | 插件类型，如 `auth`、`control`、`datasource-dialect`。 |
+| `pluginName` | `string` | **是** | 插件名称，如 `nacos`；完整身份为 `pluginType:pluginName`。 |
 
 #### 返回数据
 
@@ -860,16 +860,20 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/core/namespace/exist?customNamespa
 | data.pluginName | `string` | 插件名称。 |
 | data.enabled | `boolean` | 当前是否已启用。 |
 | data.critical | `boolean` | 是否为关键插件（关键插件不可被禁用）。 |
+| data.typeCritical | `boolean` | 插件类型是否声明为 critical。 |
+| data.executionMode | `string` | `EXCLUSIVE`、`CHAIN`、`ROUTED` 或 `BROADCAST`。 |
+| data.exclusive | `boolean` | 是否为排他选择类型。 |
 | data.configurable | `boolean` | 是否支持控制台动态配置。 |
-| data.config | `object` | 插件当前配置项。 |
-| data.configDefinitions | `array` | 插件配置项定义列表，用于渲染配置表单。 |
+| data.config | `object` | 有效配置，敏感项显示 masked marker。 |
+| data.configDefinitions | `array` | definition 列表，包含 alias、类型、默认值、必填、敏感和 effectMode。 |
+| data.configValueMetas | `object` | 每项的有效来源与 `overridden` 信息。 |
 
 #### 示例
 
 * 请求示例
 
 ```shell
-curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=nacos-default-auth-plugin'
+curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=nacos'
 ```
 
 * 返回示例
@@ -879,10 +883,12 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=
   "code": 0,
   "message": "success",
   "data": {
-    "name": "nacos-default-auth-plugin",
+    "name": "nacos",
     "type": "auth",
     "enabled": true,
-    "config": {}
+    "config": {},
+    "configDefinitions": [],
+    "configValueMetas": {}
   }
 }
 ```
@@ -913,7 +919,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=
 
 | 参数名 | 类型 | 必填 | 参数描述 |
 |--------|------|------|----------|
-| `pluginType` | `string` | **是** | 插件类型，如 `auth`、`control`、`datasource` 等。 |
+| `pluginType` | `string` | **是** | 插件类型，如 `auth`、`control`、`datasource-dialect`。 |
 | `pluginName` | `string` | **是** | 插件名称。 |
 
 #### 返回数据
@@ -925,7 +931,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin?pluginType=auth&pluginName=
 * 请求示例
 
 ```shell
-curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=auth&pluginName=nacos-default-auth-plugin'
+curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=auth&pluginName=nacos'
 ```
 
 * 返回示例
@@ -944,7 +950,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=aut
 
 #### 接口描述
 
-通过该接口，可以更新插件的配置。需要提供插件类型、名称及配置内容。
+替换目标运行时来源的完整配置 map。只能提交 definitions 中 `RUNTIME` 项；`RESTART` 项在 Next Console 中只读，修改、删除或新增都会被拒绝。敏感字段返回 masked marker 时，原样提交 marker 表示保留目标来源中已有值。
 
 #### 起始版本
 
@@ -968,7 +974,8 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=aut
 |--------|------|------|----------|
 | `pluginType` | `string` | **是** | 插件类型。 |
 | `pluginName` | `string` | **是** | 插件名称。 |
-| `config` | `string` | 否 | 插件配置内容，JSON 对象，具体字段由插件定义。 |
+| `config` | `string` | 否 | 完整 JSON item map，具体字段由插件 definitions 定义。 |
+| `localOnly` | `boolean` | 否 | `true` 仅写当前节点的 `LOCAL_ONLY`；否则写 `RUNTIME_PERSISTED`。 |
 
 #### 返回数据
 
@@ -983,8 +990,9 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/availability?pluginType=aut
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
   -d 'pluginType=auth' \
-  -d 'pluginName=nacos-default-auth-plugin' \
-  -d 'config={}'
+  -d 'pluginName=ldap' \
+  -d 'config={"connect-timeout":"6000"}' \
+  -d 'localOnly=false'
 ```
 
 * 返回示例
@@ -1027,7 +1035,7 @@ curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/config' \
 
 #### 返回数据
 
-返回 data 为插件信息数组，每项包含插件名称、类型、是否启用等。
+返回 data 为插件信息数组，每项包含名称、类型、状态、critical、executionMode、configurable 等元数据。
 
 #### 示例
 
@@ -1045,7 +1053,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
   "message": "success",
   "data": [
     {
-      "name": "nacos-default-auth-plugin",
+      "name": "nacos",
       "type": "auth",
       "enabled": true
     }
@@ -1057,7 +1065,7 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 
 #### 接口描述
 
-通过该接口，可以更新插件的启用状态（启用或禁用）。
+更新插件状态。集群持久化状态优先于静态初值，本地状态优先于持久化状态。EXCLUSIVE 选择、PRE_CONTEXT 实现和 active critical provider 的非法运行时修改会被拒绝。
 
 #### 起始版本
 
@@ -1097,8 +1105,9 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/plugin/list?pluginType=auth'
 ```shell
 curl -X PUT 'http://127.0.0.1:8080/v3/console/plugin/status' \
   -d 'pluginType=auth' \
-  -d 'pluginName=nacos-default-auth-plugin' \
-  -d 'enabled=True'
+  -d 'pluginName=ldap' \
+  -d 'enabled=true' \
+  -d 'localOnly=false'
 ```
 
 * 返回示例
@@ -7827,6 +7836,8 @@ curl -X GET 'http://127.0.0.1:8080/v3/console/ai/pipelines/{pipelineId}'
 ## 10. AI 资源导入
 
 AI 资源导入 API 提供外部 AI 资源导入源查询、搜索、校验与执行能力。
+
+API 的 `sourceId` 等于 managed `pluginName`，当前固定为 `mcp-official`、`mcp-registry-protocol`、`skills-sh` 或 `skills-well-known`。来源描述中的 `pluginName` 字段仍表示 importerType，不是 sourceId。Next Console 保持 `mcp-official` 与 `skills-sh` 原有展示名称和搜索—选择—校验—导入体验，但不再支持 preset 或复制 endpoint。
 
 ### 10.1. 执行 AI 资源导入
 #### 接口描述

--- a/src/content/docs/next/zh-cn/manual/admin/console.md
+++ b/src/content/docs/next/zh-cn/manual/admin/console.md
@@ -104,12 +104,25 @@ AI 管理中心用于管理 AI 应用依赖的资源。新控制台会在 AI 功
 | --- | --- |
 | 命名空间 | 创建、编辑和删除命名空间。 |
 | 集群管理 | 查看集群节点和基础状态。 |
-| 插件管理 | 查看已加载插件和插件状态。 |
+| 插件管理 | 查看统一插件清单、状态、有效配置和来源，并按 definitions 安全更新运行时项。 |
 | 用户列表 | 管理控制台用户。 |
 | 角色管理 | 管理角色和用户关系。 |
 | 权限管理 | 管理资源权限。 |
 
 如果看不到某些菜单，通常是当前用户不是管理员、功能模式限制了模块，或相关功能未启用。
+
+### Next Console 插件管理
+
+插件列表按 `pluginType:pluginName` 展示实现，并标明执行模式、critical 和 configurable。详情页会显示：
+
+- 当前启用状态，以及该状态是持久化集群状态还是当前节点 `localOnly` 覆盖；
+- `configDefinitions` 中的类型、默认值、alias、必填、敏感和 `effectMode`；
+- 每个有效配置值的 `source` 与 `overridden`，来源优先级为 `LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT`；
+- 敏感值的 masked marker，而不是明文。
+
+只有 `RUNTIME` definition 可以在线编辑；`RESTART` 项只读并提示通过静态配置修改后重启。提交配置会替换选定来源的完整 map，空 map 表示清空。集群操作前应先清理当前节点的 `localOnly` 覆盖，否则它仍会压过持久化值。active critical provider、EXCLUSIVE 选择和 PRE_CONTEXT 插件的非法运行时状态修改会被拒绝。
+
+这些能力只适用于 Next Console；Legacy Console 不提供统一插件配置工作流。完整运维语义见[插件运维](../../plugin/operations.md)。
 
 ## 旧控制台
 

--- a/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-best-practices.md
+++ b/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-best-practices.md
@@ -98,10 +98,10 @@ Nacos 3.0 起，控制台端口与服务端主端口解耦。默认端口如下�
 
 ```properties
 nacos.core.auth.enabled=true
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.server.identity.key=${your_identity_key}
 nacos.core.auth.server.identity.value=${your_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${your_token_secret}
+nacos.plugin.auth.nacos.token.secret.key=${your_token_secret}
 ```
 
 建议：
@@ -128,7 +128,7 @@ nacos.core.auth.plugin.nacos.token.secret.key=${your_token_secret}
 当集群承载较多客户端连接或核心接口存在突增流量时，可以启用流量防护插件。建议先使用 `monitor` 模式观察，再切换到 `intercept` 模式。
 
 ```properties
-nacos.plugin.control.manager.type=nacos
+nacos.plugin.control.type=nacos
 ```
 
 重点关注：

--- a/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-cluster.md
+++ b/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-cluster.md
@@ -53,12 +53,12 @@ sidebar:
 然后修改`${nacos.home}/conf/application.properties`文件，增加支持MySQL数据源配置，添加MySQL数据源的url、用户名和密码。
 
 ```
-spring.sql.init.platform=mysql
+nacos.plugin.datasource-dialect.type=mysql
 
-db.num=1
-db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-db.user=${mysql_user}
-db.password=${mysql_password}
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+nacos.plugin.datasource.db.user=${mysql_user}
+nacos.plugin.datasource.db.password=${mysql_password}
 ```
 
 ##### 1.1.3.1. 开启默认鉴权插件
@@ -74,8 +74,8 @@ db.password=${mysql_password}
 nacos.core.auth.enabled=true
 ## 开启控制台访问鉴权，默认为开启
 nacos.core.auth.console.enabled=true
-nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
+nacos.plugin.auth.type=nacos
+nacos.plugin.auth.nacos.token.secret.key=${自定义，保证所有节点一致}
 nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
 nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
 ```
@@ -103,8 +103,8 @@ startup.cmd
 随后启动程序会提示您输入`3个`鉴权相关配置
 
 ```
-`nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
-nacos.core.auth.plugin.nacos.token.secret.key` Updated:
+`nacos.plugin.auth.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key` Updated:
 ----------------------------------
 `nacos.core.auth.server.identity.key` is missing, please set: ${your_input_server_identity_key}
 `nacos.core.auth.server.identity.key` Updated:
@@ -150,8 +150,8 @@ nacos.core.auth.plugin.nacos.token.secret.key` Updated:
 nacos.core.auth.enabled=true
 ## 开启控制台访问鉴权，默认为开启
 nacos.core.auth.console.enabled=true
-nacos.core.auth.system.type=nacos
-nacos.core.auth.plugin.nacos.token.secret.key=${自定义，保证所有节点一致}
+nacos.plugin.auth.type=nacos
+nacos.plugin.auth.nacos.token.secret.key=${自定义，保证所有节点一致}
 nacos.core.auth.server.identity.key=${自定义，保证所有节点一致}
 nacos.core.auth.server.identity.value=${自定义，保证所有节点一致}
 ```

--- a/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-independent.md
+++ b/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-independent.md
@@ -76,7 +76,7 @@ nacos.console.remote.server.context-path=/nacos
 ```properties
 nacos.core.auth.server.identity.key=${your_custom_server_identity_key}
 nacos.core.auth.server.identity.value=${your_custom_server_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${your_custom_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key=${your_custom_token_secret_key}
 ```
 
 :::note
@@ -102,8 +102,8 @@ startup.cmd -d console
 随后启动程序会提示您输入`3个`鉴权相关配置
 
 ```
-`nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
-nacos.core.auth.plugin.nacos.token.secret.key` Updated:
+`nacos.plugin.auth.nacos.token.secret.key` is missing, please set: ${your_input_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key` Updated:
 ----------------------------------
 `nacos.core.auth.server.identity.key` is missing, please set: ${your_input_server_identity_key}
 `nacos.core.auth.server.identity.key` Updated:

--- a/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-standalone.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/deployment/deployment-standalone.mdx
@@ -28,12 +28,12 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     然后修改`${nacos.home}/conf/application.properties`文件，增加支持MySQL数据源配置，添加MySQL数据源的url、用户名和密码。
 
     ```
-    spring.sql.init.platform=mysql
+    nacos.plugin.datasource-dialect.type=mysql
 
-    db.num=1
-    db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-    db.user=${mysql_user}
-    db.password=${mysql_password}
+    nacos.plugin.datasource.db.num=1
+    nacos.plugin.datasource.db.url.0=jdbc:mysql://${mysql_host}:${mysql_port}/${nacos_database}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+    nacos.plugin.datasource.db.user=${mysql_user}
+    nacos.plugin.datasource.db.password=${mysql_password}
     ```
 
     然后按照[快速开始-启动服务器](../../../quickstart/quick-start/#4修改鉴权配置)中的操作，修改Nacos的鉴权配置。

--- a/src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md
+++ b/src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md
@@ -3415,7 +3415,7 @@ try {
 
 #### 描述
 
-查询 Nacos 已加载的插件列表，可按插件类型过滤。
+查询 Nacos 已加载的统一插件列表，可按插件类型过滤。返回身份使用 `pluginType:pluginName`，并包含状态、critical、executionMode 和 configurable 等元数据。
 
 ```java
 List<Map<String, Object>> listPlugins(String pluginType) throws NacosException;
@@ -3452,7 +3452,7 @@ try {
 
 #### 描述
 
-根据插件类型和插件名称查询单个插件的详情。
+根据插件类型和插件名称查询单个插件的详情，包括 definitions、脱敏后的有效配置，以及各项配置的 source/overridden 元数据。
 
 ```java
 Map<String, Object> getPluginDetail(String pluginType, String pluginName) throws NacosException;
@@ -3475,7 +3475,7 @@ Map<String, Object> getPluginDetail(String pluginType, String pluginName) throws
 
 ```java
 try {
-    Map<String, Object> detail = coreMaintainerService.getPluginDetail("auth", "nacos-ldap-auth");
+    Map<String, Object> detail = coreMaintainerService.getPluginDetail("auth", "ldap");
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -3489,7 +3489,7 @@ try {
 
 #### 描述
 
-启用或禁用指定插件。
+启用或禁用指定插件。EXCLUSIVE 选择、PRE_CONTEXT 实现和 active critical provider 不能被非法运行时修改；`localOnly=true` 只影响当前节点且优先于持久化状态。
 
 ```java
 void updatePluginStatus(String pluginType, String pluginName, boolean enabled) throws NacosException;
@@ -3514,8 +3514,8 @@ void updatePluginStatus(String pluginType, String pluginName, boolean enabled, b
 
 ```java
 try {
-    coreMaintainerService.updatePluginStatus("auth", "nacos-ldap-auth", false);
-    coreMaintainerService.updatePluginStatus("auth", "nacos-ldap-auth", false, true);
+    coreMaintainerService.updatePluginStatus("auth", "ldap", false);
+    coreMaintainerService.updatePluginStatus("auth", "ldap", false, true);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -3529,7 +3529,7 @@ try {
 
 #### 描述
 
-更新指定插件的配置项。
+替换指定插件目标来源的完整配置 map。只能运行时更新 `effectMode=RUNTIME` 的 definition；`RESTART` 项的新增、变更或删除会被拒绝。`localOnly=true` 写当前节点的高优先级 `LOCAL_ONLY`，否则写 `RUNTIME_PERSISTED`。
 
 ```java
 void updatePluginConfig(String pluginType, String pluginName, Map<String, String> config) throws NacosException;
@@ -3543,7 +3543,7 @@ void updatePluginConfig(String pluginType, String pluginName, Map<String, String
 |:-----------|:--------------------|:-------|
 | pluginType | string              | 插件类型。  |
 | pluginName | string              | 插件名称。  |
-| config     | Map\<String, String> | 配置键值对。 |
+| config     | Map\<String, String> | 以 definition item key 为键的完整目标来源 map。 |
 | localOnly  | boolean             | 是否仅应用到当前节点。 |
 
 #### 返回参数
@@ -3555,9 +3555,9 @@ void updatePluginConfig(String pluginType, String pluginName, Map<String, String
 ```java
 try {
     Map<String, String> config = new HashMap<>();
-    config.put("serverAddr", "ldap://localhost:389");
-    coreMaintainerService.updatePluginConfig("auth", "nacos-ldap-auth", config);
-    coreMaintainerService.updatePluginConfig("auth", "nacos-ldap-auth", config, true);
+    config.put("connect-timeout", "6000");
+    coreMaintainerService.updatePluginConfig("auth", "ldap", config);
+    coreMaintainerService.updatePluginConfig("auth", "ldap", config, true);
 } catch (NacosException e) {
     e.printStackTrace();
 }
@@ -3594,7 +3594,7 @@ Map<String, Boolean> getPluginAvailability(String pluginType, String pluginName)
 
 ```java
 try {
-    Map<String, Boolean> availability = coreMaintainerService.getPluginAvailability("auth", "nacos-ldap-auth");
+    Map<String, Boolean> availability = coreMaintainerService.getPluginAvailability("auth", "ldap");
 } catch (NacosException e) {
     e.printStackTrace();
 }

--- a/src/content/docs/next/zh-cn/manual/admin/oidc-auth.md
+++ b/src/content/docs/next/zh-cn/manual/admin/oidc-auth.md
@@ -141,7 +141,7 @@ nacos.core.auth.server.identity.value=security
 nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
-> **重要**：如果不设置 `nacos.plugin.auth.nacos.token.secret.key`，启动脚本会进入交互模式要求手动输入密钥，导致服务无法正常启动。旧 core key 仅作为 alias。可使用 `openssl rand -base64 32` 生成密钥。
+> **重要**：标准值为空时，启动脚本会先迁移 `application.properties` 中有效的 `nacos.core.auth.plugin.nacos.token.secret.key`；只有标准 key 和历史 key 都没有有效值时才提示输入。可使用 `openssl rand -base64 32` 生成密钥。
 
 ### 3.3 OIDC 插件核心配置（必填）
 

--- a/src/content/docs/next/zh-cn/manual/admin/oidc-auth.md
+++ b/src/content/docs/next/zh-cn/manual/admin/oidc-auth.md
@@ -122,7 +122,7 @@ curl http://localhost:8081/realms/nacos/.well-known/openid-configuration
 
 ```properties
 ### 启用 OIDC/OAuth2 鉴权系统
-nacos.core.auth.system.type=oidc
+nacos.plugin.auth.type=oidc
 
 ### 启用认证
 nacos.core.auth.enabled=true
@@ -138,48 +138,48 @@ nacos.core.auth.server.identity.key=serverIdentity
 nacos.core.auth.server.identity.value=security
 
 ### Nacos 内部 JWT 签名密钥（Base64 编码，原串至少 32 字符）
-nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
-> **重要**：如果不设置 `nacos.core.auth.plugin.nacos.token.secret.key`，启动脚本会进入交互模式要求手动输入密钥，导致服务无法正常启动。可使用 `openssl rand -base64 32` 生成密钥。
+> **重要**：如果不设置 `nacos.plugin.auth.nacos.token.secret.key`，启动脚本会进入交互模式要求手动输入密钥，导致服务无法正常启动。旧 core key 仅作为 alias。可使用 `openssl rand -base64 32` 生成密钥。
 
 ### 3.3 OIDC 插件核心配置（必填）
 
 ```properties
 ### IdP 的 Issuer URI（用于自动发现 OIDC 端点）
-nacos.core.auth.plugin.oidc.issuer-uri=http://localhost:8081/realms/nacos
+nacos.plugin.auth.oidc.issuer-uri=http://localhost:8081/realms/nacos
 
 ### OAuth2 Client 凭证
-nacos.core.auth.plugin.oidc.client-id=nacos-server
-nacos.core.auth.plugin.oidc.client-secret=nacos-client-secret
+nacos.plugin.auth.oidc.client-id=nacos-server
+nacos.plugin.auth.oidc.client-secret=nacos-client-secret
 
 ### 请求的 OAuth2 scope
-nacos.core.auth.plugin.oidc.scope=openid profile email
+nacos.plugin.auth.oidc.scope=openid profile email
 
 ### 从 ID Token 中读取用户名的 claim 字段
-nacos.core.auth.plugin.oidc.username-claim=preferred_username
+nacos.plugin.auth.oidc.username-claim=preferred_username
 ```
 
 ### 3.4 OIDC 插件可选配置
 
 | 配置项 | 默认值 | 说明 |
 |--------|-------|------|
-| `nacos.core.auth.plugin.oidc.token-validation-method` | `jwt` | Token 校验方式。当前实现按 `jwt` / JWKS 校验；`introspection` 仅是预留配置，不应作为已支持能力使用 |
-| `nacos.core.auth.plugin.oidc.jwks-cache-ttl-seconds` | `3600` | JWKS 公钥缓存 TTL（秒） |
-| `nacos.core.auth.plugin.oidc.roles-claim` | `roles` | ID Token 中读取角色的 claim 名 |
-| `nacos.core.auth.plugin.oidc.admin-role` | `nacos-admin` | 管理员角色名 |
-| `nacos.core.auth.plugin.oidc.auto-create-user` | `true` | 首次登录时是否自动创建用户 |
-| `nacos.core.auth.plugin.oidc.authorization-endpoint` | （空） | 外部授权决策端点。为空时，当前实现会放行非管理员授权判断 |
-| `nacos.core.auth.plugin.oidc.authorization-timeout-ms` | `5000` | 授权请求超时时间（毫秒） |
-| `nacos.core.auth.plugin.oidc.strict-nonce-validation` | `true` | 是否启用严格 nonce 校验 |
-| `nacos.core.auth.plugin.oidc.strict-audience-validation` | `true` | 是否启用严格 audience 校验 |
+| `nacos.plugin.auth.oidc.token-validation-method` | `jwt` | 当前只实现 `jwt` / JWKS；`introspection` 不受支持 |
+| `nacos.plugin.auth.oidc.jwks-cache-ttl-seconds` | `3600` | JWKS 公钥缓存 TTL（秒） |
+| `nacos.plugin.auth.oidc.roles-claim` | `roles` | ID Token 中读取角色的 claim 名 |
+| `nacos.plugin.auth.oidc.admin-role` | `nacos-admin` | 管理员角色名 |
+| `nacos.plugin.auth.oidc.auto-create-user` | `true` | 兼容保留项，当前不改变运行行为 |
+| `nacos.plugin.auth.oidc.authorization-endpoint` | （空） | 外部授权决策端点。为空时，当前实现会放行非管理员授权判断 |
+| `nacos.plugin.auth.oidc.authorization-timeout-ms` | `5000` | 授权请求超时时间（毫秒） |
+| `nacos.plugin.auth.oidc.strict-nonce-validation` | `true` | 是否启用严格 nonce 校验 |
+| `nacos.plugin.auth.oidc.strict-audience-validation` | `true` | 是否启用严格 audience 校验 |
 
 :::note
 `strict-nonce-validation` 和 `strict-audience-validation` 未显式配置时默认开启。仅在开发联调或 IdP 暂时不满足校验要求时，才建议临时关闭，并在生产前恢复。
 :::
 
 :::caution
-如果生产环境需要按命名空间、配置、服务或 AI 资源做权限隔离，请配置 `nacos.core.auth.plugin.oidc.authorization-endpoint`，或提供更严格的授权实现。当前实现中该配置为空时，非管理员授权判断会默认放行。
+如果生产环境需要按命名空间、配置、服务或 AI 资源做权限隔离，请配置 `nacos.plugin.auth.oidc.authorization-endpoint`，或提供更严格的授权实现。当前实现中该配置为空时，非管理员授权判断会默认放行。
 :::
 
 ### 3.5 Java SDK OAuth2 Client Credentials 配置
@@ -293,12 +293,12 @@ tail -f logs/start.out
 
 ### 7.1 启动卡在 "Please input the JWT token secret key"
 
-**原因**：`nacos.core.auth.plugin.nacos.token.secret.key` 未设置。
+**原因**：`nacos.plugin.auth.nacos.token.secret.key` 未设置。
 
 **解决**：在 `application.properties` 中配置密钥：
 
 ```properties
-nacos.core.auth.plugin.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
 ```
 
 ### 7.2 启动失败：Empty identity
@@ -325,7 +325,7 @@ nacos.core.auth.server.identity.value=security
 **排查**：
 1. 检查 `issuer-uri` 是否正确（注意末尾不要带斜杠）
 2. 查看 `logs/nacos.log` 中的错误详情
-3. 开发联调时可临时关闭严格 audience 校验：`nacos.core.auth.plugin.oidc.strict-audience-validation=false`
+3. 开发联调时可临时关闭严格 audience 校验：`nacos.plugin.auth.oidc.strict-audience-validation=false`
 4. 确认 IdP 的 JWKS 端点可访问
 
 ### 7.5 登出后立即被自动登入

--- a/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
@@ -228,14 +228,14 @@ Raft 参数通过 `nacos.core.protocol.raft.data.*` 配置。`data` 是当前代
 | `nacos.core.auth.enabled` | 是否开启 SDK/gRPC 请求鉴权。 | `false` |
 | `nacos.core.auth.admin.enabled` | 是否开启 `/v3/admin/*` Admin API 鉴权。 | `true` |
 | `nacos.core.auth.console.enabled` | 是否开启 `/v3/console/*` Console API 和登录鉴权。 | `true` |
-| `nacos.core.auth.caching.enabled` | 是否缓存鉴权信息。开启后权限变更会有短暂延迟。 | `true` |
+| `nacos.plugin.auth.nacos.caching.enabled` | 是否缓存鉴权信息；`nacos.core.auth.caching.enabled` 是历史 alias。开启后权限变更会有短暂延迟。 | `true` |
 | `nacos.core.auth.server.identity.key` | Server 间请求身份标识 key。开启鉴权时必须设置。 | 空 |
 | `nacos.core.auth.server.identity.value` | Server 间请求身份标识 value。开启鉴权时必须设置。 | 空 |
 | `nacos.security.ignore.urls` | 鉴权忽略路径。该参数属于历史兼容项，未来可能废弃。 | 发行包默认值 |
 | `nacos.plugin.auth.nacos.token.cache.enable` | 默认鉴权插件 token 缓存；旧 `nacos.core.auth.plugin.nacos.token.cache.enable` 是 alias。 | `false` |
-| `nacos.plugin.auth.nacos.token.expire.seconds` | 默认鉴权插件 token 过期秒数；旧 core key 是 alias。 | `18000` |
-| `nacos.plugin.auth.nacos.token.secret.key` | JWT 签名密钥，敏感且 RESTART；旧 core key 是 alias。 | 空 |
-| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | 是否允许 AI 资源匿名读取；旧 core key 是 alias。 | `false` |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | 默认鉴权插件 token 过期秒数；`nacos.core.auth.plugin.nacos.token.expire.seconds` 是历史 alias。 | `18000` |
+| `nacos.plugin.auth.nacos.token.secret.key` | JWT 签名密钥，敏感且 RESTART；`nacos.core.auth.plugin.nacos.token.secret.key` 是历史 alias。 | 空 |
+| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | 是否允许 AI 资源匿名读取；`nacos.core.auth.nacos.anonymous.ai.enabled` 是历史 alias。 | `false` |
 | `nacos.plugin.visibility.enabled` | 是否开启可见性插件。 | `true` |
 | `nacos.plugin.visibility.type` | 可见性插件类型。默认 `nacos` 实现会复用默认鉴权插件用户信息。 | `nacos` |
 
@@ -245,8 +245,8 @@ LDAP 与 OIDC/OAuth2 是可选插件。下表列出标准前缀，具体 definit
 
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
-| `nacos.plugin.auth.ldap.{itemKey}` | LDAP definitions：`url`、`base-dn`、`timeout`、`user-dn`、`password`、`filter-prefix`、`case-sensitive`、`ignore-partial-result-exception`。 | 见鉴权插件文档 |
-| `nacos.plugin.auth.oidc.{itemKey}` | OIDC definitions，包括 issuer/client、JWT/JWKS、claim、外部授权和严格校验选项。当前只实现 `jwt`/JWKS，不支持 introspection。 | 见鉴权插件文档 |
+| `nacos.plugin.auth.ldap.{itemKey}` | LDAP definitions：`url`、`base-dn`、`timeout`、`user-dn`、`password`、`filter-prefix`、`case-sensitive`、`ignore-partial-result-exception`。 | 见[鉴权插件文档](../../plugin/auth-plugin.md) |
+| `nacos.plugin.auth.oidc.{itemKey}` | OIDC definitions，包括 issuer/client、JWT/JWKS、claim、外部授权和严格校验选项。当前只实现 `jwt`/JWKS，不支持 introspection。 | 见[鉴权插件文档](../../plugin/auth-plugin.md) |
 
 ## 插件参数
 
@@ -291,12 +291,12 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 | `nacos.ai.mcp.registry.port` | 旧参数名，已废弃。请改用 `nacos.ai.registry.port`。 | `9080` |
 | `nacos.plugin.ai-pipeline.enabled` | AI Pipeline 动态模块总开关；关闭时延迟加载类型。 | `false` |
 | `nacos.plugin.ai-pipeline.type` | 历史启动链，仅用于没有持久化状态时初始化节点状态。 | 空 |
-| `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions；只有 `order` 为 RUNTIME。 | 见 Pipeline 插件文档 |
-| `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions；只有 `order` 为 RUNTIME。 | 见 Pipeline 插件文档 |
+| `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions；只有 `order` 为 RUNTIME。 | 见 [AI Pipeline 插件文档](../../plugin/ai-pipeline-plugin.md) |
+| `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions；只有 `order` 为 RUNTIME。 | 见 [AI Pipeline 插件文档](../../plugin/ai-pipeline-plugin.md) |
 | `nacos.ai.skill.auto-publish-after-review.enabled` | Skill 审核通过后是否自动发布版本。 | `false` |
-| `nacos.plugin.ai-resource-import.enabled` | AI Resource Import 模块总开关；发行包 `application.properties` 显式设为开启。 | `true`（发行包） |
+| `nacos.plugin.ai-resource-import.enabled` | AI Resource Import 模块总开关；标准 key 和 alias 都未配置时仍默认开启，只有显式 `false` 才关闭。发行包也显式将标准 key 设为 `true`。 | `true` |
 | `nacos.plugin.ai-resource-import.{pluginName}.enabled` | 每个固定来源的启动初始状态。 | `mcp-official`/`skills-sh` 开启，其余关闭 |
-| `nacos.plugin.ai-resource-import.{pluginName}.{itemKey}` | 来源 definitions；endpoint/网络开关为 RESTART，其余展示和限制为 RUNTIME。 | 见导入插件文档 |
+| `nacos.plugin.ai-resource-import.{pluginName}.{itemKey}` | 来源 definitions；endpoint/网络开关为 RESTART，其余展示和限制为 RUNTIME。 | 见 [AI 资源导入插件文档](../../plugin/ai-resource-import-plugin.md) |
 | `nacos.ai.resource.import.legacy-mcp-api-enabled` | 是否临时重新开启已废弃的 MCP 导入 API。 | `false` |
 | `nacos.ai.resource.import.allow-user-url` | 重新开启旧 MCP 导入 API 时，是否允许抓取用户提供的 URL。 | `false` |
 

--- a/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
@@ -55,16 +55,17 @@ Nacos 通过数据源方言插件支持 Derby、MySQL、PostgreSQL、Oracle 和�
 
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
-| `spring.sql.init.platform` | 数据库类型。可设置为 `derby`、`mysql`、`postgresql`、`oracle` 或自定义方言插件类型。`oracle` 要求 Oracle 12c 及以上版本。 | 空 |
-| `db.num` | 数据库连接地址数量。 | `0` |
-| `db.url.0`、`db.url.1` | JDBC URL。通过下标配置多个连接地址。 | 空 |
-| `db.user`、`db.password` | 所有连接共用的数据库账号密码。 | 空 |
-| `db.user.0`、`db.password.0` | 指定下标连接的账号密码。需要每个连接不同账号时使用。 | 空 |
-| `db.pool.config.*` | HikariCP 连接池参数，例如 `db.pool.config.connectionTimeout`。 | HikariCP 默认值 |
+| `nacos.plugin.datasource-dialect.type` | 启动时选择 `derby`、`mysql`、`postgresql`、`oracle` 或自定义方言。 | 单机/embedded 为 `derby`，普通集群为 `mysql` |
+| `nacos.plugin.datasource.db.num` | 外置数据库连接地址数量。 | `0` |
+| `nacos.plugin.datasource.db.url.{index}` | 逐下标 JDBC URL。 | 空 |
+| `nacos.plugin.datasource.db.user[.{index}]` | 公共或逐连接用户名。 | 空 |
+| `nacos.plugin.datasource.db.password[.{index}]` | 公共或逐连接密码。 | 空 |
+| `nacos.plugin.datasource.db.pool.config.*` | HikariCP 参数；稳定键使用 kebab-case，例如 `maximum-pool-size`。 | 各项默认值见数据源插件文档 |
+| `nacos.plugin.datasource.db.query-timeout` | JDBC query timeout，单位秒。 | `3` |
 | `nacos.plugin.datasource.log.enabled` | 是否输出数据源插件相关日志。 | `true` |
 
 :::note
-`spring.datasource.platform` 是旧版本兼容参数。新部署请使用 `spring.sql.init.platform`。
+`spring.sql.init.platform` 是方言选择的历史 alias；`db.*` 是连接配置 alias。标准键优先。`spring.datasource.platform` 已移除。
 :::
 
 ## Web 与控制台
@@ -223,7 +224,7 @@ Raft 参数通过 `nacos.core.protocol.raft.data.*` 配置。`data` 是当前代
 
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
-| `nacos.core.auth.system.type` | 鉴权插件类型。默认实现为 `nacos`；也可接入 LDAP、OIDC/OAuth2 或自定义插件。 | `nacos` |
+| `nacos.plugin.auth.type` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias。 | `nacos` |
 | `nacos.core.auth.enabled` | 是否开启 SDK/gRPC 请求鉴权。 | `false` |
 | `nacos.core.auth.admin.enabled` | 是否开启 `/v3/admin/*` Admin API 鉴权。 | `true` |
 | `nacos.core.auth.console.enabled` | 是否开启 `/v3/console/*` Console API 和登录鉴权。 | `true` |
@@ -231,41 +232,21 @@ Raft 参数通过 `nacos.core.protocol.raft.data.*` 配置。`data` 是当前代
 | `nacos.core.auth.server.identity.key` | Server 间请求身份标识 key。开启鉴权时必须设置。 | 空 |
 | `nacos.core.auth.server.identity.value` | Server 间请求身份标识 value。开启鉴权时必须设置。 | 空 |
 | `nacos.security.ignore.urls` | 鉴权忽略路径。该参数属于历史兼容项，未来可能废弃。 | 发行包默认值 |
-| `nacos.core.auth.plugin.nacos.token.cache.enable` | 默认鉴权插件是否缓存 token。 | `false` |
-| `nacos.core.auth.plugin.nacos.token.expire.seconds` | 默认鉴权插件 token 过期时间，单位秒。 | `18000` |
-| `nacos.core.auth.plugin.nacos.token.secret.key` | 默认鉴权插件 JWT 签名密钥。需要使用 Base64 字符串，原始密钥长度不少于 32 字符。 | 空 |
-| `nacos.core.auth.nacos.anonymous.ai.enabled` | 是否允许 AI 资源匿名读取。当前主要面向 Skill 和 AgentSpec。 | `false` |
+| `nacos.plugin.auth.nacos.token.cache.enable` | 默认鉴权插件 token 缓存；旧 `nacos.core.auth.plugin.nacos.token.cache.enable` 是 alias。 | `false` |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | 默认鉴权插件 token 过期秒数；旧 core key 是 alias。 | `18000` |
+| `nacos.plugin.auth.nacos.token.secret.key` | JWT 签名密钥，敏感且 RESTART；旧 core key 是 alias。 | 空 |
+| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | 是否允许 AI 资源匿名读取；旧 core key 是 alias。 | `false` |
 | `nacos.plugin.visibility.enabled` | 是否开启可见性插件。 | `true` |
 | `nacos.plugin.visibility.type` | 可见性插件类型。默认 `nacos` 实现会复用默认鉴权插件用户信息。 | `nacos` |
 
 ### LDAP、OIDC 与 OAuth2
 
-LDAP 从 Nacos 3.2 起作为可选插件独立维护。OIDC/OAuth2 也是插件能力。使用前请确认对应插件已经随发行包提供或已放入插件目录。
+LDAP 与 OIDC/OAuth2 是可选插件。下表列出标准前缀，具体 definitions、alias、默认值和 effectMode 见[鉴权插件](../../plugin/auth-plugin.md)。
 
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
-| `nacos.core.auth.ldap.url` | LDAP server 地址。 | 空 |
-| `nacos.core.auth.ldap.basedc` | LDAP base DN。 | 空 |
-| `nacos.core.auth.ldap.userDn` | LDAP 管理用户 DN。 | 空 |
-| `nacos.core.auth.ldap.password` | LDAP 管理用户密码。 | 空 |
-| `nacos.core.auth.ldap.userdn` | 登录用户 DN 模板，`{0}` 表示用户名。 | 空 |
-| `nacos.core.auth.ldap.filter.prefix` | 用户过滤字段前缀。 | `uid` |
-| `nacos.core.auth.ldap.case.sensitive` | 用户名是否大小写敏感。 | `true` |
-| `nacos.core.auth.ldap.ignore.partial.result.exception` | 是否忽略 LDAP partial result 异常。 | `false` |
-| `nacos.core.auth.plugin.oidc.issuer-uri` | OIDC issuer URI，用于自动发现。 | 空 |
-| `nacos.core.auth.plugin.oidc.client-id` | OIDC client id。 | 空 |
-| `nacos.core.auth.plugin.oidc.client-secret` | OIDC client secret。 | 空 |
-| `nacos.core.auth.plugin.oidc.scope` | OIDC scope。 | `openid` |
-| `nacos.core.auth.plugin.oidc.token-validation-method` | token 校验方式，可选 `jwt` 或 `introspection`。 | 空 |
-| `nacos.core.auth.plugin.oidc.jwks-cache-ttl-seconds` | JWKS 缓存时间，单位秒。 | 空 |
-| `nacos.core.auth.plugin.oidc.username-claim` | 用户名 claim。 | `sub` |
-| `nacos.core.auth.plugin.oidc.roles-claim` | 角色 claim。 | 空 |
-| `nacos.core.auth.plugin.oidc.admin-role` | 管理员角色名。 | 空 |
-| `nacos.core.auth.plugin.oidc.auto-create-user` | 首次登录时是否自动创建用户。 | `true` |
-| `nacos.core.auth.plugin.oidc.authorization-endpoint` | 外部授权端点。 | 空 |
-| `nacos.core.auth.plugin.authorization-timeout-ms` | 外部授权请求超时，单位毫秒。 | 空 |
-| `nacos.core.auth.plugin.oidc.strict-nonce-validation` | 是否严格校验 nonce。 | `false` |
-| `nacos.core.auth.plugin.oidc.strict-audience-validation` | 是否严格校验 audience。 | `false` |
+| `nacos.plugin.auth.ldap.{itemKey}` | LDAP definitions：`url`、`base-dn`、`timeout`、`user-dn`、`password`、`filter-prefix`、`case-sensitive`、`ignore-partial-result-exception`。 | 见鉴权插件文档 |
+| `nacos.plugin.auth.oidc.{itemKey}` | OIDC definitions，包括 issuer/client、JWT/JWKS、claim、外部授权和严格校验选项。当前只实现 `jwt`/JWKS，不支持 introspection。 | 见鉴权插件文档 |
 
 ## 插件参数
 
@@ -274,15 +255,13 @@ LDAP 从 Nacos 3.2 起作为可选插件独立维护。OIDC/OAuth2 也是插件�
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
 | `nacos.custom.environment.enabled` | 是否启用自定义环境变量插件。 | `false` |
-| `nacos.plugin.control.manager.type` | 流量防护插件类型。配置为 `nacos` 时使用默认实现。 | 空 |
+| `nacos.plugin.control.type` | 启动时选择流量防护实现；`nacos.plugin.control.manager.type` 是历史 alias。 | 空（no-limit） |
 | `nacos.plugin.control.rule.local.basedir` | 本地流量防护规则目录。 | `${nacos.home}` |
 | `nacos.plugin.control.rule.external.storage` | 外部规则存储类型，需要自行实现。 | 空 |
-| `nacos.core.config.plugin.webhook.enabled` | 是否启用配置变更 Webhook 插件。 | `false` |
-| `nacos.core.config.plugin.webhook.url` | Webhook 地址。 | 空 |
-| `nacos.core.config.plugin.webhook.contentMaxCapacity` | Webhook 推送内容最大大小，单位 byte。 | `102400` |
-| `nacos.core.config.plugin.whitelist.enabled` | 是否启用配置导入后缀白名单插件。 | `false` |
-| `nacos.core.config.plugin.whitelist.suffixs` | 允许导入的配置文件后缀。 | `xml,text,properties,yaml,html` |
-| `nacos.core.config.plugin.fileformatcheck.enabled` | 是否启用导入文件格式检查插件。 | `false` |
+| `nacos.plugin.{pluginType}.{pluginName}.enabled` | 实现级启动初始状态；持久化/本地 state 可覆盖。 | 由实现和类型策略决定 |
+| `nacos.plugin.{pluginType}.{pluginName}.{itemKey}` | 实现 definitions 的标准配置键。 | 由 definition 决定 |
+
+配置变更插件的历史 `nacos.core.config.plugin.{pluginName}.*` 只用于旧二进制兼容；Nacos Server 不内置 webhook、whitelist 或 fileformatcheck 实现。新实现使用 `nacos.plugin.config-change.{pluginName}.{itemKey}`。
 
 ## Istio 与 Prometheus 服务发现
 
@@ -310,20 +289,18 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 | `nacos.ai.skill.registry.enabled` | 是否启用 Skill Registry 协议适配。开启后会使用 `nacos.ai.registry.port` 暴露独立端口。 | `false` |
 | `nacos.ai.registry.port` | AI Registry 协议适配端口。 | `9080` |
 | `nacos.ai.mcp.registry.port` | 旧参数名，已废弃。请改用 `nacos.ai.registry.port`。 | `9080` |
-| `nacos.plugin.ai-pipeline.enabled` | 是否启用 AI 发布 Pipeline。未配置时不会主动禁用，但如果 `type` 为空，Pipeline 不会执行。 | 空 |
-| `nacos.plugin.ai-pipeline.type` | Pipeline 节点类型，例如 `skill-scanner`。多个类型用逗号分隔。 | 空 |
-| `nacos.plugin.ai-pipeline.skill-scanner.enabled` | 传给内置 `skill-scanner` 节点的启用配置。 | 空 |
-| `nacos.plugin.ai-pipeline.skill-scanner.command` | 外部 Skill 扫描工具命令路径。 | 空 |
+| `nacos.plugin.ai-pipeline.enabled` | AI Pipeline 动态模块总开关；关闭时延迟加载类型。 | `false` |
+| `nacos.plugin.ai-pipeline.type` | 历史启动链，仅用于没有持久化状态时初始化节点状态。 | 空 |
+| `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions；只有 `order` 为 RUNTIME。 | 见 Pipeline 插件文档 |
+| `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions；只有 `order` 为 RUNTIME。 | 见 Pipeline 插件文档 |
 | `nacos.ai.skill.auto-publish-after-review.enabled` | Skill 审核通过后是否自动发布版本。 | `false` |
-| `nacos.ai.resource.import.enabled` | 是否启用显式配置的 AI 资源导入来源。 | `false` |
+| `nacos.plugin.ai-resource-import.enabled` | AI Resource Import 模块总开关；发行包 `application.properties` 显式设为开启。 | `true`（发行包） |
+| `nacos.plugin.ai-resource-import.{pluginName}.enabled` | 每个固定来源的启动初始状态。 | `mcp-official`/`skills-sh` 开启，其余关闭 |
+| `nacos.plugin.ai-resource-import.{pluginName}.{itemKey}` | 来源 definitions；endpoint/网络开关为 RESTART，其余展示和限制为 RUNTIME。 | 见导入插件文档 |
 | `nacos.ai.resource.import.legacy-mcp-api-enabled` | 是否临时重新开启已废弃的 MCP 导入 API。 | `false` |
 | `nacos.ai.resource.import.allow-user-url` | 重新开启旧 MCP 导入 API 时，是否允许抓取用户提供的 URL。 | `false` |
-| `nacos.plugin.ai.importer.mcp.official.enabled` | 是否启用内置官方 MCP Registry 导入来源。 | `true` |
-| `nacos.plugin.ai.importer.skills.well-known.enabled` | 是否启用 Skill well-known 导入来源。 | `false` |
-| `nacos.plugin.ai.importer.skills.well-known.url` | Skill well-known registry 根地址。 | 空 |
-| `nacos.plugin.ai.importer.skills.skills-sh.enabled` | 是否启用 `skills.sh` 导入来源。 | `true` |
-| `nacos.plugin.ai.importer.<preset>.allow-http` | 是否允许指定来源使用非 HTTPS endpoint。仅受控环境中开启。 | `false` |
-| `nacos.plugin.ai.importer.<preset>.allow-private-network` | 是否允许指定来源访问私网或 localhost endpoint。仅受控环境中开启。 | `false` |
+
+旧 `nacos.plugin.ai.importer.*`、`nacos.ai.resource.import.sources[N].*`、preset 和复制 endpoint 模型已移除或只保留明确列出的迁移 alias，不能用于新部署。详见 [AI 资源导入插件](../../plugin/ai-resource-import-plugin.md)。
 
 ## 实验性功能
 

--- a/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
@@ -239,6 +239,18 @@ ${nacos.home}/bin/startup.cmd
 java -jar ./mcp-migration-tool.jar localhost:8848 nacos ${your_password}
 ```
 
+#### 2.1.9. 迁移统一插件配置
+
+升级到包含统一插件管理重构的 next 版本前，盘点 `${nacos.home}/plugins`、`application.properties` 和自动化配置：
+
+1. 将实现身份统一为 `pluginType:pluginName`，并把选择键和实现配置迁移到 `nacos.plugin.*` 标准键。
+2. 备份 `${nacos.home}/data/plugin/plugin-states.json` 和 `plugin-configs.json`；不要直接复制与目标插件清单不匹配的运行时文件。
+3. 用 Next Console 或 Admin API 检查 definitions、有效来源和 sensitive 脱敏结果。`RESTART` 项写入静态配置后重启，不能用 PUT API 修改。
+4. 对 AI Resource Import，删除 Source/preset/list 配置和旧 SPI JAR，按四个固定 `pluginName` 重新配置。旧双层 Importer/Source SPI 不再加载。
+5. 对 Config Change 外部插件，迁移到 `PluginConfigSpec`；`ConfigChangeConfigs` 和旧 core 前缀只作为兼容路径。
+
+完整 key/SPI 对照与回滚建议见[插件迁移](../../plugin/migration.md)。
+
 ###  2.2. Docker/Kubernetes升级
 
 #### 2.2.1 确认表结构

--- a/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
@@ -239,17 +239,11 @@ ${nacos.home}/bin/startup.cmd
 java -jar ./mcp-migration-tool.jar localhost:8848 nacos ${your_password}
 ```
 
-#### 2.1.9. 迁移统一插件配置
+#### 2.1.9. 迁移统一插件配置（Nacos 3.3.0+）
 
-升级到包含统一插件管理重构的 next 版本前，盘点 `${nacos.home}/plugins`、`application.properties` 和自动化配置：
+没有使用自定义服务端插件的用户，只需对比当前部署与目标发行包的 `application.properties`，再参考[系统参数](./system-configurations.md)把保留的旧配置迁移到标准 key。AI Resource Import 的模块开关未配置时现在默认开启；如果升级后仍需保持关闭，应在发布前明确设置 `nacos.plugin.ai-resource-import.enabled=false`。使用过旧 Source/preset/list 配置的部署还需按 [AI Resource Import 迁移说明](../../plugin/migration.md#ai-resource-import-breaking-change)处理。
 
-1. 将实现身份统一为 `pluginType:pluginName`，并把选择键和实现配置迁移到 `nacos.plugin.*` 标准键。
-2. 备份 `${nacos.home}/data/plugin/plugin-states.json` 和 `plugin-configs.json`；不要直接复制与目标插件清单不匹配的运行时文件。
-3. 用 Next Console 或 Admin API 检查 definitions、有效来源和 sensitive 脱敏结果。`RESTART` 项写入静态配置后重启，不能用 PUT API 修改。
-4. 对 AI Resource Import，删除 Source/preset/list 配置和旧 SPI JAR，按四个固定 `pluginName` 重新配置。旧双层 Importer/Source SPI 不再加载。
-5. 对 Config Change 外部插件，迁移到 `PluginConfigSpec`；`ConfigChangeConfigs` 和旧 core 前缀只作为兼容路径。
-
-完整 key/SPI 对照与回滚建议见[插件迁移](../../plugin/migration.md)。
+使用自研或第三方服务端插件的用户，除完成上述配置对比外，还需要在升级前检查插件兼容性变化。其中，AI Resource Import 的旧 Importer/Source SPI 已移除，Config Change 的 `ConfigChangeConfigs` 已废弃且只在兼容周期内保留。请先阅读[插件迁移指南](../../plugin/migration.md)，再按使用情况查看 [AI 资源导入插件](../../plugin/ai-resource-import-plugin.md)、[Config Change 插件](../../plugin/config-change-plugin.md)和[插件开发指南](../../plugin/development.md)。
 
 ###  2.2. Docker/Kubernetes升级
 

--- a/src/content/docs/next/zh-cn/manual/user/ai/skill-registry.md
+++ b/src/content/docs/next/zh-cn/manual/user/ai/skill-registry.md
@@ -98,21 +98,25 @@ Skill 从创建到使用，经历以下完整流程：
 
 Pipeline 是可配置的审核流程，在 Skill 发布前进行自动化检查。**Pipeline 默认关闭**，关闭时提交审核会直接发布为 online 状态。
 
-Pipeline 采用插件化架构，通过 Java SPI 机制加载检查节点。内置提供 **skill-scanner** 插件（基于 [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)），用户也可以实现 `PublishPipelineServiceBuilder` 接口开发自定义插件，并通过 SPI 注册到 Pipeline 中。多个插件按 `getPreferOrder()` 排序串行执行，前一个通过后才执行下一个。
+Pipeline 通过 Java SPI 加载直接实现 `PublishPipelineService` 的检查节点。内置 `ai-pipeline:skill-scanner`（基于 [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)）和 `ai-pipeline:skill-spector`，两者都支持 Skill、AgentSpec 和 Prompt。多个启用节点按 `getPreferOrder()` 升序串行执行，前一个通过后才执行下一个。旧 `PublishPipelineServiceBuilder` SPI 已移除。
 
 开启 Pipeline 需要在 `application.properties` 中配置：
 
 ```properties
-# 启用 Pipeline 并指定检查节点
+# 启用 Pipeline；type 仅用于首次迁移时初始化链状态
 nacos.plugin.ai-pipeline.enabled=true
-nacos.plugin.ai-pipeline.type=skill-scanner
+nacos.plugin.ai-pipeline.type=skill-scanner,skill-spector
 
-# 检查节点配置（以 skill-scanner 为例）
+# 实现启动状态和配置
 nacos.plugin.ai-pipeline.skill-scanner.enabled=true
 nacos.plugin.ai-pipeline.skill-scanner.command=/path/to/skill-scanner
+nacos.plugin.ai-pipeline.skill-spector.enabled=true
+nacos.plugin.ai-pipeline.skill-spector.command=/path/to/skill-spector
 ```
 
-skill-scanner 插件检测以下风险：
+持久化或运行时统一状态是当前链成员的权威来源。只有两个节点的 `order` definition 可运行时修改；命令、LLM 和扫描参数均为 `RESTART`。完整 definitions 见 [AI 发布 Pipeline 插件](../../../plugin/ai-pipeline-plugin.md)。
+
+扫描节点可检测以下风险：
 
 - Prompt 注入攻击
 - 数据泄露风险

--- a/src/content/docs/next/zh-cn/manual/user/auth.mdx
+++ b/src/content/docs/next/zh-cn/manual/user/auth.mdx
@@ -135,7 +135,7 @@ curl -X GET 'http://127.0.0.1:8848/nacos/v2/cs/config?accessToken=${accessToken}
 
 ### OIDC/OAuth2 鉴权
 
-当服务端使用 `nacos.core.auth.system.type=oidc` 时，不使用 `/v3/auth/user/login` 获取 token。请从企业 IdP 获取 OAuth2/OIDC token，然后请求 Nacos 时携带：
+当服务端使用 `nacos.plugin.auth.type=oidc` 时，不使用 `/v3/auth/user/login` 获取 token。请从企业 IdP 获取 OAuth2/OIDC token，然后请求 Nacos 时携带：
 
 ```powershell
 curl -X GET 'http://127.0.0.1:8848/nacos/v2/cs/config?dataId=example.properties&group=DEFAULT_GROUP' \
@@ -155,7 +155,7 @@ OIDC/OAuth2 的服务端配置请参考[运维手册 - OIDC/OAuth2 认证](../ad
 常见原因包括：
 
 - token 已过期。
-- 集群节点之间 `nacos.core.auth.plugin.nacos.token.secret.key` 不一致。
+- 集群节点之间 `nacos.plugin.auth.nacos.token.secret.key` 不一致。
 - 服务端切换了鉴权插件类型。
 - 权限被修改，但客户端仍在使用旧 token。
 

--- a/src/content/docs/next/zh-cn/plugin/address-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/address-plugin.md
@@ -3,7 +3,7 @@ title: 集群寻址
 keywords: [寻址, 集群成员, address-server, cluster.conf]
 description: 本文介绍 Nacos Server 集群成员寻址机制，以及 file 和 address-server 两种常用寻址方式。
 sidebar:
-    order: 10
+    order: 13
 ---
 
 # 集群寻址

--- a/src/content/docs/next/zh-cn/plugin/ai-pipeline-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/ai-pipeline-plugin.md
@@ -1,76 +1,86 @@
 ---
 title: AI 发布 Pipeline
-keywords: [AI Pipeline, AI 管理中心, Skill, Prompt, MCP, AgentSpec]
-description: 本文介绍 Nacos AI 发布 Pipeline 插件的使用场景、启用方式、执行模型和开发边界。
+keywords: [AI Pipeline, AI 管理中心, Skill, Prompt, AgentSpec]
+description: 本文介绍 Nacos AI 发布 Pipeline 插件的执行模型、内置实现、配置和开发方式。
 sidebar:
-    order: 11
+    order: 14
 ---
 
 # AI 发布 Pipeline 插件
 
-AI 发布 Pipeline 插件用于在 AI 资源发布前做审核、扫描或拦截。它适合放在生产发布链路上，帮助平台团队检查 Skill、Prompt、MCP Server、AgentSpec 等资源是否满足安全、格式或合规要求。
+AI 发布 Pipeline 在 AI 资源发布前执行审核、扫描或拦截。它可以批准或拒绝发布，但不能改变资源的规范身份、版本或可见性。
 
-Pipeline 属于 AI 资源治理。它可以批准或拒绝一次发布操作，但不改变 AI 资源的命名空间、资源名、版本和可见性模型。
+统一插件类型为 `ai-pipeline`，执行模式为 `CHAIN`，加载阶段为 `STANDARD`，类型非 critical。一次发布会筛选支持目标资源类型且状态启用的节点，再按 `getPreferOrder()` 升序串行执行；任一节点拒绝后停止剩余节点并保存结果。
 
-## 什么时候使用
+## 开关、状态和加载
 
-建议在以下场景启用 Pipeline：
+三类控制项职责不同：
 
-- Skill 包需要安全扫描，避免引入危险脚本、越权访问或不符合企业规范的内容。
-- Prompt、AgentSpec 或 MCP Server 需要经过格式校验、合规检查或人工流程。
-- 生产环境希望把“创建草稿”和“正式发布”隔离开。
-- 管理员需要看到每次发布审核的结果和失败原因。
+| 配置或状态 | 职责 |
+| --- | --- |
+| `nacos.plugin.ai-pipeline.enabled` | AI 模块拥有的动态总开关。为 `false` 时延迟加载该类型；切换为 `true` 后才发现服务、恢复状态并应用配置。 |
+| `nacos.plugin.ai-pipeline.type` | 历史启动链组成，只在没有持久化状态时初始化实现状态。 |
+| `ai-pipeline:{pipelineId}` 状态 | 当前链成员的权威来源。禁用节点仍保留在清单中，但不参与发布。 |
+| `nacos.plugin.ai-pipeline.{pipelineId}.{itemKey}` | 节点通过 `PluginConfigSpec` 声明和消费的私有配置。 |
 
-如果没有启用 Pipeline，资源提交后可能直接进入可发布或上线状态。是否直接发布由具体资源类型和当前控制台流程决定。
+总开关关闭或没有匹配节点时，发布不被 Pipeline 拦截。服务实例必须保持轻量，在第一次 `applyConfig` 前不要初始化 CLI、连接或线程等运行资源。
 
-## 执行模型
+## 内置节点
 
-Pipeline 是有序链式插件。一次发布会按资源类型选择匹配的 Pipeline 节点，并按 `getPreferOrder()` 升序执行。
+Nacos 内置以下两个节点，均支持 `SKILL`、`AGENTSPEC` 和 `PROMPT`：
 
-```text
-提交发布
-  -> 创建 Pipeline 执行记录
-  -> 按顺序执行节点
-  -> 全部通过：发布继续
-  -> 任一拒绝：发布停止，版本保持未发布状态
-```
+| pluginId | 默认状态 | 作用 |
+| --- | --- | --- |
+| `ai-pipeline:skill-scanner` | 启用 | 调用 `skill-scanner` CLI 扫描资源。 |
+| `ai-pipeline:skill-spector` | 启用 | 调用 `skill-spector` CLI 进行静态和可选 LLM 风险分析。 |
 
-执行时需要注意：
+### skill-scanner definitions
 
-- Pipeline 只处理被配置且支持目标资源类型的节点。
-- 某个节点拒绝后，后续节点不会继续执行。
-- Pipeline 关闭或没有匹配节点时，发布流程不会被 Pipeline 拦截。
-- 管理员的强制发布会跳过 Pipeline 校验。它适合应急，不适合日常发布。
+标准前缀为 `nacos.plugin.ai-pipeline.skill-scanner.`：
 
-当前统一插件管理可以列出已加载的 `ai-pipeline` 插件。但在执行链路完全接入统一启停状态前，Pipeline 是否参与发布主要由 Pipeline 自身配置控制。
+| key | aliases | 类型 | 默认值 | sensitive | effectMode |
+| --- | --- | --- | --- | --- | --- |
+| `order` | 无 | NUMBER | `100` | 否 | RUNTIME |
+| `command` | `executable`, `path` | STRING | `skill-scanner` | 否 | RESTART |
+| `use-llm` | `useLlm` | BOOLEAN | `false` | 否 | RESTART |
+| `llm-api-key` | `llmApiKey` | STRING | 空 | 是 | RESTART |
+| `llm-model` | `llmModel` | STRING | 空 | 否 | RESTART |
+| `llm-provider` | `llmProvider` | STRING | 空 | 否 | RESTART |
+| `enable-meta` | `enableMeta` | BOOLEAN | `false` | 否 | RESTART |
 
-## 启用内置 skill-scanner
-
-Nacos 默认插件集合中提供了 `skill-scanner` Pipeline 节点。它可以处理 Skill、Prompt、AgentSpec 中可扫描的内容，常见场景是接入外部 Skill 扫描工具。
-
-在 `${nacos.home}/conf/application.properties` 中启用：
+示例：
 
 ```properties
 nacos.plugin.ai-pipeline.enabled=true
-nacos.plugin.ai-pipeline.type=skill-scanner
-nacos.plugin.ai-pipeline.skill-scanner.enabled=true
-nacos.plugin.ai-pipeline.skill-scanner.command=/path/to/skill-scanner
+nacos.plugin.ai-pipeline.skill-scanner.command=/opt/scanners/skill-scanner
+nacos.plugin.ai-pipeline.skill-scanner.use-llm=true
+nacos.plugin.ai-pipeline.skill-scanner.llm-api-key=${SKILL_SCANNER_API_KEY}
 ```
 
-配置含义：
+### skill-spector definitions
 
-| 配置项 | 说明 |
-| --- | --- |
-| `nacos.plugin.ai-pipeline.enabled` | 是否启用 AI Pipeline。 |
-| `nacos.plugin.ai-pipeline.type` | 参与执行的 Pipeline 节点类型。 |
-| `nacos.plugin.ai-pipeline.skill-scanner.enabled` | 是否启用 `skill-scanner` 节点。 |
-| `nacos.plugin.ai-pipeline.skill-scanner.command` | Skill 扫描工具命令路径。 |
+标准前缀为 `nacos.plugin.ai-pipeline.skill-spector.`：
 
-生产环境应在所有 Nacos Server 节点上使用相同插件版本和相同配置。扫描命令依赖外部可执行文件时，也要保证每个节点都能访问该命令。
+| key | aliases | 类型 | 默认值 | sensitive | effectMode |
+| --- | --- | --- | --- | --- | --- |
+| `order` | 无 | NUMBER | `90` | 否 | RUNTIME |
+| `command` | `executable`, `path` | STRING | `skill-spector` | 否 | RESTART |
+| `use-llm` | `useLlm` | BOOLEAN | `false` | 否 | RESTART |
+| `provider` | 无 | STRING | 空 | 否 | RESTART |
+| `model` | 无 | STRING | 空 | 否 | RESTART |
+| `api-key` | `apiKey` | STRING | 空 | 是 | RESTART |
+| `base-url` | `baseUrl` | STRING | 空 | 否 | RESTART |
+| `log-level` | `logLevel` | STRING | `WARNING` | 否 | RESTART |
+| `risk-score-threshold` | `riskScoreThreshold` | NUMBER | `50` | 否 | RESTART |
+| `max-findings` | `maxFindings` | NUMBER | `20` | 否 | RESTART |
+
+`risk-score-threshold` 限制为 `0..100`；`max-findings` 最大为 `100`，零、负数或无效值使用默认值。现有进程环境变量优先于从 SkillSpector 插件配置复制的值。
+
+除 `order` 外，两个内置节点都会在首次应用配置时解析命令并创建不可变扫描选项，因此这些字段需要重启。敏感 API key 在详情响应中脱敏。找不到命令时节点仍可查询，但实际扫描会拒绝发布并提示安装。
 
 ## 开发自定义 Pipeline
 
-自定义 Pipeline 节点依赖：
+依赖：
 
 ```xml
 <dependency>
@@ -80,43 +90,29 @@ nacos.plugin.ai-pipeline.skill-scanner.command=/path/to/skill-scanner
 </dependency>
 ```
 
-实现 `com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder`，并通过 Java SPI 声明：
+直接实现 `com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService`，提供 public 无参构造方法，并通过以下 Java SPI 注册：
 
 ```text
-META-INF/services/com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder
+META-INF/services/com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService
 ```
 
-核心方法：
-
 | 方法 | 说明 |
 | --- | --- |
-| `pipelineId()` | 稳定节点 ID，用于配置、日志和执行记录。 |
-| `build(properties)` | 根据配置创建 `PublishPipelineService`。 |
+| `pipelineId()` | 稳定节点名，组成 `ai-pipeline:{pipelineId}`。 |
+| `execute(context)` | 执行审核并返回通过或拒绝。 |
+| `getPreferOrder()` | 链顺序，值越小越早。 |
+| `pipelineResourceTypes()` | 支持的资源类型。 |
+| `getConfigDefinitions()` | 声明 definitions。 |
+| `applyConfig(config)` | 原子应用完整有效 item map。 |
+| `getCurrentConfig()` | 返回已接受配置快照。 |
 
-`PublishPipelineService` 需要提供：
+旧 `PublishPipelineServiceBuilder` SPI 和任意 `Properties` 构建路径已经移除。旧插件必须迁移为服务本身实现 `PluginConfigSpec`；不能只替换 SPI 注册文件而保留 builder。
 
-| 方法 | 说明 |
-| --- | --- |
-| `pipelineId()` | 运行时节点 ID。 |
-| `execute(context)` | 执行审核逻辑，返回通过或拒绝。 |
-| `getPreferOrder()` | 节点执行顺序，值越小越早执行。 |
-| `pipelineResourceTypes()` | 支持的资源类型，如 Skill、Prompt、MCP 或 AgentSpec。 |
+## 运维建议
 
-## 开发建议
+- 所有节点保持相同的插件 JAR、CLI 和 RESTART 配置；`order` 可通过统一 PUT 配置在运行时调整。
+- 外部命令设置超时并返回可读拒绝原因，不要在日志中输出资源全文或凭据。
+- 用详情页确认 `effectiveConfig`、来源和当前快照；修改 RESTART 字段后重启所有节点。
+- Pipeline 结果是发布治理记录，不替代资源鉴权、可见性或内容存储。
 
-- 让同一资源版本和同一输入得到确定结果，避免审核结果随机变化。
-- 调用外部系统时必须设置超时。不要让发布链路无限等待。
-- 拒绝发布时返回可读的原因，方便资源作者修复。
-- 不要在 Pipeline 中修改资源内容。需要修改内容时，应回到草稿编辑流程。
-- 不要在日志中输出完整 Skill 包、Prompt 内容、密钥或凭证。
-
-## 排查
-
-| 现象 | 排查方向 |
-| --- | --- |
-| 提交后没有进入审核 | 检查 `nacos.plugin.ai-pipeline.enabled` 和 `nacos.plugin.ai-pipeline.type` 是否配置。 |
-| `skill-scanner` 未执行 | 检查 `skill-scanner.enabled`、扫描命令路径和插件 JAR 是否在 classpath 中。 |
-| 发布一直失败 | 查看 Pipeline 执行记录，确认是哪一个节点拒绝，并检查返回原因。 |
-| 统一插件管理显示已禁用但仍执行 | 以当前版本的 Pipeline 配置为准。统一启停状态尚未完全接入执行链路。 |
-
-相关内容可继续阅读 [AI 资源生命周期](../manual/user/ai/ai-resource-lifecycle.md) 和 [AI 资源导入插件](./ai-resource-import-plugin.md)。
+相关内容：[插件运维](./operations.md)、[插件开发](./development.md)、[AI 资源生命周期](../manual/user/ai/ai-resource-lifecycle.md)。

--- a/src/content/docs/next/zh-cn/plugin/ai-resource-import-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/ai-resource-import-plugin.md
@@ -1,184 +1,195 @@
 ---
 title: AI 资源导入
-keywords: [AI 资源导入, MCP Registry, Skill Registry, AI 管理中心]
-description: 本文介绍 Nacos AI 资源导入插件的来源配置、导入流程、内置来源、安全边界和扩展方式。
+keywords: [AI 资源导入, MCP Registry, Skill Registry, PluginConfigSpec]
+description: 介绍统一管理后的 AI Resource Import 插件、四个内置来源、配置 definitions、安全边界和旧 SPI 迁移。
 sidebar:
-    order: 12
+    order: 15
 ---
 
 # AI 资源导入插件
 
-AI 资源导入插件用于把外部 registry、市场或企业内部资源库中的 AI 资源导入 Nacos AI 管理中心。导入后，资源会进入 Nacos 的命名空间、版本、可见性和生命周期体系。
+AI Resource Import 插件把外部 registry、市场或企业资源库中的 MCP Server、Skill 等资源转换为 Nacos 可校验和写入的 artifact。它只负责外部协议和转换；命名空间、资源身份、鉴权、可见性、版本、发布 Pipeline 和存储仍由 AI Registry 领域负责。
 
-导入插件只负责“从哪里发现资源”和“如何把外部资源转换成可导入内容”。它不拥有 Nacos 资源身份、鉴权、可见性、发布生命周期和存储模型。
+## 统一来源模型
 
-## 适用场景
-
-常见场景包括：
-
-- 从官方 MCP registry 导入 MCP Server。
-- 从 Skill well-known 地址导入 Skill。
-- 从 skills.sh 或企业内部 Skill 市场导入 Skill。
-- 让企业内部工具市场、私有 Git 索引或模型平台成为 AI 管理中心的资源来源。
-
-导入适合做资源初始化和统一治理，不适合绕过 Nacos 的发布、审核和权限流程。
-
-## 导入流程
-
-统一导入流程如下：
+`ai-resource-import` 是 `ROUTED` 插件类型。一个 Builder 就是一个确定的外部来源：
 
 ```text
-查询来源 -> 搜索候选资源 -> 选择候选 -> 校验冲突和依赖 -> 执行导入
+pluginId = ai-resource-import:{pluginName}
+sourceId = managed pluginName
 ```
 
-每个导入来源由运维人员配置，并通过 `sourceId` 暴露给用户。用户在导入时选择 `sourceId`，不能在请求中提交任意 endpoint、IP、凭证或 registry 根路径。
+请求中的 `sourceId` 直接路由到一个 enabled Builder。原有 API 字段 `pluginName` 仍表示 importer/protocol 类型，以兼容 Console 数据模型；它不是 managed pluginName。
 
-| 阶段 | 说明 |
-| --- | --- |
-| 查询来源 | 返回当前可用于某类资源的导入来源。 |
-| 搜索候选 | 从指定来源搜索摘要信息，不下载完整资源内容。 |
-| 校验 | 拉取必要 artifact，检查类型、大小、冲突和依赖。 |
-| 执行 | 将有效 artifact 交给对应资源 Operator，写入 Nacos AI 资源。 |
+```text
+sourceId
+  -> AiResourceImportServiceBuilder(已接受配置快照)
+  -> 请求级 AiResourceImportService
+  -> AiResourceOperator(resourceType)
+```
 
-浏览器或控制台不应接收完整 artifact。MCP specification、Skill ZIP 等内容只应在服务端导入链路中流转。
+一个 `pluginName` 只能代表一个来源。不能再通过纯配置把同一个实现复制成多个 endpoint；如需另一个固定来源，必须提供不同 `pluginName` 的 Builder。
 
-## 来源配置
+## 开关、状态和默认行为
 
-一个来源通常包含以下信息：
-
-| 字段 | 说明 |
-| --- | --- |
-| `sourceId` | 稳定来源 ID，用户导入时选择它。 |
-| `pluginName` | `ai-resource-import` 类型下的 importer 实现名。 |
-| `resourceTypes` | 支持的资源类型，例如 `mcp` 或 `skill`。 |
-| `endpoint` | 运维配置的来源地址。 |
-| `enabled` | 来源是否启用。 |
-| `authRef` | 可选的服务端凭证引用。凭证不返回给用户。 |
-| `connectTimeout` / `readTimeout` | 访问外部来源的超时。 |
-| `maxPageCount` / `maxItemCount` | 分页和条目限制。 |
-| `maxArtifactSize` | 单个 artifact 最大大小。 |
-| `properties` | importer 专属非敏感配置。 |
-
-显式来源可以配置在 `nacos.ai.resource.import.sources[...]` 下，并通过 `nacos.ai.resource.import.enabled=true` 开启。内置 preset 来源使用 `nacos.plugin.ai.importer.*` 前缀独立启用或关闭。
-
-默认插件加载时，官方 MCP Registry 和 skills.sh 来源会启用。需要关闭时，可以把对应 preset 的 `enabled` 配置为 `false`。
-
-## 内置来源
-
-### MCP 官方 Registry
-
-启用官方 MCP 来源：
+AI 模块和当前功能模式允许时，family switch 决定是否加载导入插件：
 
 ```properties
-nacos.plugin.ai.importer.mcp.official.enabled=true
+nacos.plugin.ai-resource-import.enabled=true
 ```
 
-默认来源信息：
+`nacos.ai.resource.import.enabled` 是历史 alias，标准 key 优先。官方发行包的 `application.properties` 将标准 key 设置为 `true`，因此 AI Resource Import 默认开启；只有部署需要关闭该能力时才显式设置为 `false`。
 
-| 项目 | 默认值 |
-| --- | --- |
-| `sourceId` | `mcp-official` |
-| importer | `mcp-registry` |
-| 资源类型 | `mcp` |
-| endpoint | `https://registry.modelcontextprotocol.io/v0/servers` |
-
-可以通过 `nacos.plugin.ai.importer.mcp.official.*` 覆盖来源 ID、展示名、endpoint、认证引用、超时和大小限制。
-
-### Skill Well-known
-
-启用 Skill well-known 来源：
+每个来源的初始状态使用：
 
 ```properties
-nacos.plugin.ai.importer.skills.well-known.enabled=true
-nacos.plugin.ai.importer.skills.well-known.url=https://developers.cloudflare.com
+nacos.plugin.ai-resource-import.{pluginName}.enabled=true
 ```
 
-默认来源信息：
+有持久化统一插件状态时，持久化状态优先。运行时请求还会再次检查 Builder 状态，disabled 来源不会出现在来源列表，也不能执行 search、validate 或 execute。
 
-| 项目 | 默认值 |
-| --- | --- |
-| `sourceId` | `skills-well-known` |
-| importer | `skills-well-known` |
-| 资源类型 | `skill` |
-| endpoint | `nacos.plugin.ai.importer.skills.well-known.url` |
+## 四个内置来源
 
-该来源会尝试读取 `/.well-known/agent-skills`，并兼容旧的 `/.well-known/skills`。它支持 Skill discovery v0.1.0 和 v0.2.0。
+| pluginId | API importer type | 资源 | endpoint | 发行配置初始状态 |
+| --- | --- | --- | --- | --- |
+| `ai-resource-import:mcp-official` | `mcp-registry` | `mcp` | 固定官方 MCP Registry | enabled |
+| `ai-resource-import:mcp-registry-protocol` | `mcp-registry` | `mcp` | 运维必须配置 | disabled |
+| `ai-resource-import:skills-sh` | `skills-sh` | `skill` | 固定 `https://skills.sh` | enabled |
+| `ai-resource-import:skills-well-known` | `skills-well-known` | `skill` | 运维必须配置 | disabled |
 
-### skills.sh
+`mcp-official` 的 Console 展示名仍是 `Official MCP Registry`，`skills-sh` 仍显示 `skills.sh`。用户原有的来源选择、搜索、勾选候选、校验和执行体验保持不变。
 
-启用 skills.sh 来源：
+### 固定 endpoint 来源
+
+`mcp-official` 和 `skills-sh` 不声明 `endpoint`、`allow-http` 或 `allow-private-network`，也不接受旧 endpoint override。来源地址是实现身份的一部分。
 
 ```properties
-nacos.plugin.ai.importer.skills.skills-sh.enabled=true
+nacos.plugin.ai-resource-import.mcp-official.enabled=true
+nacos.plugin.ai-resource-import.skills-sh.enabled=true
 ```
 
-默认来源信息：
+### 运维配置 endpoint 来源
 
-| 项目 | 默认值 |
+启用任意 MCP Registry protocol endpoint：
+
+```properties
+nacos.plugin.ai-resource-import.mcp-registry-protocol.enabled=true
+nacos.plugin.ai-resource-import.mcp-registry-protocol.endpoint=https://registry.example.com/v0/servers
+```
+
+启用 Skill well-known registry：
+
+```properties
+nacos.plugin.ai-resource-import.skills-well-known.enabled=true
+nacos.plugin.ai-resource-import.skills-well-known.endpoint=https://skills.example.com
+```
+
+`skills-well-known` 支持 discovery schema v0.1.0 和 v0.2.0。endpoint 是 registry 根地址时，会依次尝试 `/.well-known/agent-skills/index.json` 和 `/.well-known/skills/index.json`。
+
+## 配置 definitions
+
+所有 canonical full key 使用：
+
+```text
+nacos.plugin.ai-resource-import.{pluginName}.{itemKey}
+```
+
+公共 item：
+
+| item key | type | default | effectMode | 适用实现 | 含义 |
+| --- | --- | --- | --- | --- | --- |
+| `endpoint` | `STRING` | 空 | `RESTART` | 两个可配置 endpoint 来源 | Registry/marketplace 根地址；启用后实际构建时不能为空。 |
+| `allow-http` | `BOOLEAN` | `false` | `RESTART` | 两个可配置 endpoint 来源 | 是否允许非 HTTPS。 |
+| `allow-private-network` | `BOOLEAN` | `false` | `RESTART` | 两个可配置 endpoint 来源 | 是否允许本机或私网目标。 |
+| `display-name` | `STRING` | 各实现展示名 | `RUNTIME` | 全部 | API 和 Console 展示名。 |
+| `description` | `STRING` | 各实现描述 | `RUNTIME` | 全部 | API 和 Console 描述。 |
+| `max-item-count` | `NUMBER` | `500` | `RUNTIME` | 全部 | 一次请求允许的最大结果/文件数。 |
+| `max-artifact-size` | `NUMBER` | `10485760` | `RUNTIME` | 全部 | HTTP 响应或 artifact 最大字节数。 |
+
+这些 definition 当前都是 `required=false`、`sensitive=false`。`mcp-official` 和 `skills-sh` 只声明四个 `RUNTIME` 展示/限制字段；另外两个实现声明全部七项。
+
+`endpoint`、`allow-http` 和 `allow-private-network` 不能用运行时 PUT 增加、修改或删除。修改静态配置并重启。其他四项可以通过 Console 或 PUT API 运行时更新，更新后的不可变 Builder 快照用于后续新请求。
+
+## 有效配置和 alias
+
+有效值遵循统一优先级：
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+旧 `nacos.plugin.ai.importer.*` key 只在一个迁移窗口作为 alias 读取：
+
+| 新 pluginName | 旧前缀/alias 范围 |
 | --- | --- |
-| `sourceId` | `skills-sh` |
-| importer | `skills-sh` |
-| 资源类型 | `skill` |
-| endpoint | `https://skills.sh` |
+| `mcp-official` | `nacos.plugin.ai.importer.mcp.official.` 下的展示、描述、限制和历史状态。 |
+| `skills-sh` | `nacos.plugin.ai.importer.skills.skills-sh.` 下的展示、描述、限制和历史状态。 |
+| `skills-well-known` | `nacos.plugin.ai.importer.skills.well-known.`；旧 `url`/`endpoint`、网络开关、展示、描述、限制和状态。 |
+| `mcp-registry-protocol` | 无旧 alias。 |
+
+固定来源的 endpoint override、`auth-ref`、来源/全局 timeout、`max-page-count`、`block-private-network`、全局默认值和任意 `properties.*` 已移除。
+
+## 导入流程和生命周期
+
+```text
+列出来源 -> 搜索候选 -> 用户明确选择 -> 校验 -> 执行
+```
+
+- search 为一个请求构建 service，只返回候选摘要，不返回 MCP tools、Skill 包或秘密。
+- validate 和 execute 分别构建一个 service，并在一次操作内复用它处理所有已选项，最后在 `finally` 中关闭。
+- fetch 返回 artifact，但不能直接写 Nacos；资源 Operator 负责领域校验和持久化。
+- 浏览器不能默认选择搜索结果；全选后也必须允许取消单项。
+
+统一 API：
+
+| 方法 | Admin | Console |
+| --- | --- | --- |
+| 来源 | `GET /v3/admin/ai/import/sources` | `GET /v3/console/ai/import/sources` |
+| 搜索 | `POST /v3/admin/ai/import/search` | `POST /v3/console/ai/import/search` |
+| 校验 | `POST /v3/admin/ai/import/validate` | `POST /v3/console/ai/import/validate` |
+| 执行 | `POST /v3/admin/ai/import/execute` | `POST /v3/console/ai/import/execute` |
 
 ## 安全边界
 
-内置来源默认要求 HTTPS，并默认禁止访问 localhost、loopback、link-local、multicast 和私网地址。只有运维人员明确确认环境安全时，才应打开下列配置：
+- 用户请求不能提交任意 URL、IP、registry 根地址或凭证。
+- 默认只允许 HTTPS，并阻止 loopback、link-local、multicast 和私网 DNS 结果。
+- 只有运维拥有的可配置来源可以显式开启 `allow-http` 或 `allow-private-network`。
+- 所有派生 URL 和重定向都必须重新校验相同网络策略。
+- HTTP 响应和 artifact 必须受 `max-artifact-size` 限制；结果/文件数受 `max-item-count` 限制。
+- Skill 包导入不得执行脚本，必须校验路径、摘要和压缩包总大小。
 
-| 配置后缀 | 含义 | 默认值 |
-| --- | --- | --- |
-| `allow-http` / `allowHttp` | 允许非 HTTPS endpoint。 | `false` |
-| `allow-private-network` / `allowPrivateNetwork` | 允许私网、localhost 等地址。 | `false` |
+## 开发自定义来源
 
-不要把外部 registry 当成可信输入。导入前仍需要校验文件路径、压缩包大小、摘要、内容类型和冲突策略。
+实现 `com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder` 并通过 Java SPI 注册。Builder 本身是 managed plugin 和 `PluginConfigSpec`：
 
-## API 入口
-
-统一导入 API 包括 Admin API 和 Console API：
-
-| 接口面 | 路径 |
+| Builder 方法 | 要求 |
 | --- | --- |
-| Admin API | `/v3/admin/ai/import/sources`、`/search`、`/validate`、`/execute` |
-| Console API | `/v3/console/ai/import/sources`、`/search`、`/validate`、`/execute` |
+| `pluginName()` | 稳定 managed 名称和 API `sourceId`。 |
+| `importerType()` | API 兼容字段 `pluginName` 的 importer/protocol 元数据。 |
+| `displayName()` / `description()` | 来自已接受配置快照。 |
+| `supportedResourceTypes()` | 这个固定来源可产生的资源类型。 |
+| `getConfigDefinitions()` | 声明来源拥有的全部 item。 |
+| `applyConfig(config)` | 原子替换不可变有效配置快照。 |
+| `getCurrentConfig()` | 返回最后接受的 canonical item-key 快照。 |
+| `build()` | 从一个快照构建请求级 service，不再接受额外 properties。 |
 
-详细参数请参考 [运维 API](../manual/admin/admin-api.md) 和 [控制台 API](../manual/admin/console-api.md)。
-
-## 开发自定义 Importer
-
-自定义 importer 依赖：
-
-```xml
-<dependency>
-    <groupId>com.alibaba.nacos</groupId>
-    <artifactId>nacos-ai-plugin</artifactId>
-    <version>${project.version}</version>
-</dependency>
-```
-
-实现 `com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder`，并通过 Java SPI 声明：
+SPI 文件：
 
 ```text
 META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder
 ```
 
-核心接口：
+插件名冲突采用 first-wins + WARN。
 
-| 方法 | 说明 |
-| --- | --- |
-| `importerType()` | 稳定 importer 名称。 |
-| `build(properties)` | 使用 importer 配置创建导入服务。 |
-| `supportedResourceTypes()` | 支持导入的资源类型。 |
-| `search(context)` | 返回候选摘要，不返回完整 payload。 |
-| `fetch(context, item)` | 拉取选中资源的 artifact，不写入 Nacos。 |
+## Breaking change 与迁移
 
-如果需要提供预置来源，可以实现 `AiResourceImportSourceProvider`，并通过对应 SPI 文件声明。
+旧的 Importer/Source 双 SPI 已移除，没有兼容 adapter。外部插件必须迁移并重新编译：
 
-## 排查
+- 删除 `AiResourceImportSource` 和 Source Provider SPI。
+- 删除 `nacos.ai.resource.import.sources[N].*`、preset 和复制 endpoint 的模型。
+- 把来源 ID 固定为 Builder `pluginName()`，实现 `PluginConfigSpec` 和无参 `build()`。
+- 把仍有效的属性迁到标准 full key。
 
-| 现象 | 排查方向 |
-| --- | --- |
-| 来源列表为空 | 检查 `nacos.ai.resource.import.enabled`、来源 `enabled` 和 importer 插件是否加载。 |
-| 搜索失败 | 检查 endpoint、网络连通性、超时、认证引用和 HTTPS/私网限制。 |
-| 校验出现冲突 | 查看资源名、版本和是否已有 editing/reviewing 版本。必要时重新编辑或使用覆盖策略。 |
-| 导入后不可见 | 检查资源命名空间、可见性、鉴权和资源状态。 |
-| 私网来源无法访问 | 只有确认风险后，才在对应来源上启用 `allow-private-network`。 |
+旧 MCP import compatibility API 默认关闭；如需短期迁移，可使用 `nacos.ai.resource.import.legacy-mcp-api-enabled=true`。允许旧 API 抓取用户 URL 还必须额外显式开启 `nacos.ai.resource.import.allow-user-url=true`，不应作为长期方案。
+
+参见[插件迁移指南](./migration.md)和[兼容与废弃](../manual/admin/compatibility-and-deprecation.md)。

--- a/src/content/docs/next/zh-cn/plugin/ai-resource-import-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/ai-resource-import-plugin.md
@@ -38,7 +38,7 @@ AI 模块和当前功能模式允许时，family switch 决定是否加载导入
 nacos.plugin.ai-resource-import.enabled=true
 ```
 
-`nacos.ai.resource.import.enabled` 是历史 alias，标准 key 优先。官方发行包的 `application.properties` 将标准 key 设置为 `true`，因此 AI Resource Import 默认开启；只有部署需要关闭该能力时才显式设置为 `false`。
+`nacos.ai.resource.import.enabled` 是历史 alias。标准 key 只要存在就具有优先级，即使值为空也不回退 alias。两个 key 都未配置时 family gate 仍默认开启；只有显式配置 `false` 才关闭 AI Resource Import。发行包也显式将标准 key 设为 `true`。
 
 每个来源的初始状态使用：
 
@@ -50,7 +50,7 @@ nacos.plugin.ai-resource-import.{pluginName}.enabled=true
 
 ## 四个内置来源
 
-| pluginId | API importer type | 资源 | endpoint | 发行配置初始状态 |
+| pluginId | API importer type | 资源 | endpoint | 默认实现状态 |
 | --- | --- | --- | --- | --- |
 | `ai-resource-import:mcp-official` | `mcp-registry` | `mcp` | 固定官方 MCP Registry | enabled |
 | `ai-resource-import:mcp-registry-protocol` | `mcp-registry` | `mcp` | 运维必须配置 | disabled |

--- a/src/content/docs/next/zh-cn/plugin/ai-storage-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/ai-storage-plugin.md
@@ -3,7 +3,7 @@ title: AI 存储
 keywords: [AI 存储, AI 管理中心, AI Storage, Plugin]
 description: 本文介绍 Nacos AI 存储插件的职责、默认实现、路由模型和自定义开发边界。
 sidebar:
-    order: 13
+    order: 16
 ---
 
 # AI 存储插件
@@ -11,6 +11,8 @@ sidebar:
 AI 存储插件用于保存 AI 资源版本关联的二进制或文本内容。它只负责按 storage key 读、写、删除内容。资源元数据、版本、标签、可见性和生命周期仍由 AI 管理中心负责。
 
 这个边界很重要。不要把存储插件理解为新的 AI 资源模型。它只是内容存储后端。
+
+统一插件类型为 `ai-storage`，执行模式为 `ROUTED`，加载阶段为 `STANDARD`，类型 critical。插件身份是 `ai-storage:{provider}`。路由器会在每次操作前检查统一状态；被禁用的 provider 会明确失败，不会回退到另一个已发现实现。
 
 ## 什么时候需要关注
 
@@ -44,11 +46,24 @@ provider -> opaque key
 
 默认 provider 是 `nacos_config`。它通过 Nacos 配置存储保存 AI 资源内容，适合默认部署和中小规模资源内容。
 
+内置插件身份为 `ai-storage:nacos_config`，默认启用、不声明 definitions，因此 `configurable=false`。AI 模块启用时，它通常是 active critical provider，不能在仍被任一资源域选择时禁用。
+
 使用默认 provider 时仍要注意：
 
 - AI 资源从用户视角仍是 Skill、Prompt、MCP 或 AgentSpec，不是普通配置。
 - 配置加密、数据库、备份和容量策略可能间接影响默认存储。
 - 大体积资源或高频下载场景，需要结合实际压测评估。
+
+Prompt、Skill、AgentSpec 和 Agent 分别用以下模块路由键选择 provider：
+
+```properties
+nacos.ai.prompt.storage.provider=nacos_config
+nacos.ai.skill.storage.provider=nacos_config
+nacos.ai.agentspec.storage.provider=nacos_config
+nacos.ai.agent.storage.provider=nacos_config
+```
+
+这些键是 AI 资源域路由策略，不是 `ai-storage:nacos_config` 的 definitions。AI 模块启用时，每个不同的选中 provider 都必须已发现且启用；其它可用 provider 不能作为回退。AI 功能模式关闭或 `nacos.extension.ai.enabled=false` 时，该类型不构成启动要求。
 
 ## 开发自定义存储
 
@@ -84,6 +99,8 @@ META-INF/services/com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorageBuild
 | `get(storageKey)` | 读取内容，不存在时返回空结果。 |
 | `delete(storageKey)` | 删除内容。 |
 
+`AiResourceStorage` 继承 `PluginConfigSpec`。有私有配置的实现应通过 definitions 声明，并使用 `nacos.plugin.ai-storage.{provider}.{itemKey}`；builder 只负责创建服务，definitions、`applyConfig` 和当前快照属于构建出的服务实例。旧二进制服务未声明 definitions 时仍可加载，但自动显示为不可配置。
+
 ## 实现要求
 
 自定义 provider 应在文档和运维说明中明确：
@@ -97,15 +114,15 @@ META-INF/services/com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorageBuild
 
 存储插件不得修改资源元数据、版本状态、标签、可见性和鉴权结果。发布前审核仍由 [AI 发布 Pipeline 插件](./ai-pipeline-plugin.md) 负责。
 
-## 当前集成说明
+## 状态和启动校验
 
-核心插件管理可以列出已加载的 `ai-storage` 插件。当前版本中，统一插件启停状态尚未完全接入 `AiResourceStorageRouter`。在该集成完成前，实际路由由已注册的 storage provider 控制。
+统一插件状态已经接入 `AiResourceStorageRouter`。非 critical provider 被禁用后仍保持加载和可见，但新操作会失败。AI storage 实例在 Spring Context 刷新期间由 builder 注册，所以选中 provider 的 critical 校验会在注册完成后、Nacos 报告启动成功前执行。
 
 ## 排查
 
 | 现象 | 排查方向 |
 | --- | --- |
-| 资源内容读取失败 | 检查元数据中的 provider 是否存在，目标存储插件是否加载。 |
+| 资源内容读取失败 | 检查元数据中的 provider、资源域选择键、插件是否加载且统一状态为启用。 |
 | 上传成功但下载失败 | 检查 `save` 后的一致性、对象存储权限、网络和 key 生成逻辑。 |
 | 删除后仍可下载 | 检查 provider 的删除一致性和缓存策略。 |
 | 切换 provider 后旧资源不可读 | 检查迁移计划。旧版本资源仍会使用旧 provider 的 storage key。 |

--- a/src/content/docs/next/zh-cn/plugin/auth-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/auth-plugin.md
@@ -3,12 +3,12 @@ title: 鉴权插件
 keywords: [鉴权, 插件, RBAC, LDAP, OIDC, OAuth2]
 description: 本文介绍 Nacos 鉴权插件的工作模型、内置实现、默认鉴权实现提供的 v3 Auth API，以及自定义插件开发方式。
 sidebar:
-    order: 2
+    order: 5
 ---
 
 # 鉴权插件
 
-Nacos 从 2.1.0 开始支持通过 [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html) 扩展鉴权能力。服务端会根据 `application.properties` 中的 `nacos.core.auth.system.type` 选择一个鉴权插件，用它完成身份认证和权限校验。
+Nacos 从 2.1.0 开始支持通过 [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html) 扩展鉴权能力。服务端通过 `nacos.plugin.auth.type` 在启动时选择一个鉴权插件；`nacos.core.auth.system.type` 是历史 alias。
 
 鉴权插件回答的问题是：**当前请求是谁发起的，它是否可以对目标资源执行这个操作**。
 
@@ -17,6 +17,24 @@ IdentityContext + Resource + Action -> 允许或拒绝
 ```
 
 如果你只是想开启 Nacos 自带的鉴权能力，请先阅读[运维手册 - 权限校验](../manual/admin/auth.mdx)。如果你要接入企业身份系统，请阅读 [OIDC/OAuth2 认证](../manual/admin/oidc-auth.md)。本文更关注插件模型、内置插件边界和扩展开发。
+
+## 统一管理契约
+
+`auth` 是 `EXCLUSIVE`、`STANDARD` 插件类型，类型级 `critical=true`。当任一鉴权入口开关启用，或显式配置了鉴权类型时，选中的 provider 就是 active critical 实现；缺失或 disabled 会让启动失败，Nacos 不会选择另一个实现作为回退。
+
+| 实现 | pluginId | configurable | 选择与生命周期 |
+| --- | --- | --- | --- |
+| 默认 Nacos | `auth:nacos` | 是 | 默认选择；token secret 为 `RESTART`，其他私有字段可运行时 apply。 |
+| LDAP | `auth:ldap` | 是 | 全部私有字段为 `RESTART`。 |
+| OIDC | `auth:oidc` | 是 | 全部私有字段为 `RESTART`；被选中时额外校验有效配置。 |
+
+选择 key：
+
+```properties
+nacos.plugin.auth.type=nacos
+```
+
+选择在启动时快照，不能通过插件状态 API 运行时切换。`nacos.core.auth.enabled`、`nacos.core.auth.admin.enabled` 和 `nacos.core.auth.console.enabled` 是请求入口开关，不是 `auth:nacos` 的 definition，也不会被插件管理 API 修改。
 
 ## 鉴权插件中的概念
 
@@ -76,19 +94,31 @@ Nacos 3.2 提供以下内置鉴权实现。它们都通过同一套鉴权 SPI �
 
 ### 默认 Nacos 鉴权实现
 
-默认 Nacos 鉴权实现的插件类型是 `nacos`。它提供用户名密码登录、JWT token、用户管理、角色管理、权限管理，以及默认 AI 资源可见性实现。
+默认 Nacos 鉴权实现的 `pluginId` 是 `auth:nacos`。它提供用户名密码登录、JWT token、用户管理、角色管理、权限管理，以及默认 AI 资源可见性实现。
 
 开启时通常需要配置：
 
 ```properties
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 nacos.core.auth.server.identity.key=${custom_server_identity_key}
 nacos.core.auth.server.identity.value=${custom_server_identity_value}
-nacos.core.auth.plugin.nacos.token.secret.key=${custom_base64_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
 ```
+
+`auth:nacos` definitions：
+
+| item key | 历史 alias | type / default | sensitive | effectMode |
+| --- | --- | --- | --- | --- |
+| `token.secret.key` | `nacos.core.auth.plugin.nacos.token.secret.key` | `STRING` / 空 | 是 | `RESTART` |
+| `token.expire.seconds` | `nacos.core.auth.plugin.nacos.token.expire.seconds` | `NUMBER` / `18000` | 否 | `RUNTIME` |
+| `token.cache.enable` | `nacos.core.auth.plugin.nacos.token.cache.enable` | `BOOLEAN` / `false` | 否 | `RUNTIME` |
+| `caching.enabled` | `nacos.core.auth.caching.enabled` | `BOOLEAN` / `true` | 否 | `RUNTIME` |
+| `anonymous.ai.enabled` | `nacos.core.auth.nacos.anonymous.ai.enabled` | `BOOLEAN` / `false` | 否 | `RUNTIME` |
+
+以上 definition 都是 `required=false`。启用需要 token 的鉴权入口时，`token.secret.key` 实际必须是 Base64 编码且解码后不少于 32 字节。插件详情会脱敏展示它。
 
 默认实现使用 RBAC 模型：
 
@@ -145,7 +175,7 @@ OIDC/OAuth2 模式下，用户、角色、密码和权限通常由外部 IdP 或
 
 ### LDAP 鉴权插件
 
-LDAP 插件类型是 `ldap`。Nacos 3.2 起，LDAP 插件从默认鉴权实现中分离为独立可选插件。
+LDAP 插件的 `pluginId` 是 `auth:ldap`。Nacos 3.2 起，LDAP 插件从默认鉴权实现中分离为独立可选插件。
 
 LDAP 插件的边界是：
 
@@ -157,18 +187,32 @@ LDAP 插件的边界是：
 启用示例：
 
 ```properties
-nacos.core.auth.system.type=ldap
+nacos.plugin.auth.type=ldap
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
-nacos.core.auth.ldap.url=ldap://localhost:389
-nacos.core.auth.ldap.basedc=dc=example,dc=org
-nacos.core.auth.ldap.userDn=cn=admin,${nacos.core.auth.ldap.basedc}
-nacos.core.auth.ldap.password=admin
-nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
-nacos.core.auth.ldap.filter.prefix=uid
+nacos.plugin.auth.ldap.url=ldap://localhost:389
+nacos.plugin.auth.ldap.base-dn=dc=example,dc=org
+nacos.plugin.auth.ldap.user-dn=cn=admin,dc=example,dc=org
+nacos.plugin.auth.ldap.password=${ldap_bind_password}
+nacos.plugin.auth.ldap.filter-prefix=uid
 ```
+
+`auth:ldap` definitions 全部是 `RESTART` 且 `required=false`：
+
+| item key | 历史 alias | type / default | sensitive |
+| --- | --- | --- | --- |
+| `url` | `nacos.core.auth.ldap.url` | `STRING` / `ldap://localhost:389` | 否 |
+| `base-dn` | `nacos.core.auth.ldap.basedc` | `STRING` / `dc=example,dc=org` | 否 |
+| `timeout` | `nacos.core.auth.ldap.timeout` | `NUMBER` / `3000` | 否 |
+| `user-dn` | `nacos.core.auth.ldap.userDn` | `STRING` / `cn=admin,dc=example,dc=org` | 否 |
+| `password` | `nacos.core.auth.ldap.password` | `STRING` / `password` | 是 |
+| `filter-prefix` | `nacos.core.auth.ldap.filter.prefix` | `STRING` / `uid` | 否 |
+| `case-sensitive` | `nacos.core.auth.ldap.case.sensitive` | `BOOLEAN` / `true` | 否 |
+| `ignore-partial-result-exception` | `nacos.core.auth.ldap.ignore.partial.result.exception` | `BOOLEAN` / `false` | 否 |
+
+历史 `nacos.core.auth.ldap.userdn` 模板 key 没有被生产实现消费，不是受支持 alias。
 
 部署时请确认：
 
@@ -177,7 +221,7 @@ nacos.core.auth.ldap.filter.prefix=uid
 
 ### OIDC/OAuth2 鉴权插件
 
-OIDC/OAuth2 插件类型是 `oidc`。它面向企业 SSO 和外部身份提供方，支持通过 OIDC Discovery 接入 Keycloak、Okta、Auth0、Microsoft Entra ID 等 IdP。
+OIDC/OAuth2 插件的 `pluginId` 是 `auth:oidc`。它面向企业 SSO 和外部身份提供方，支持通过 OIDC Discovery 接入 Keycloak、Okta、Auth0、Microsoft Entra ID 等 IdP。
 
 它和默认 Nacos 鉴权的差异是：
 
@@ -191,16 +235,35 @@ OIDC/OAuth2 插件类型是 `oidc`。它面向企业 SSO 和外部身份提供�
 启用示例：
 
 ```properties
-nacos.core.auth.system.type=oidc
+nacos.plugin.auth.type=oidc
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 
-nacos.core.auth.plugin.oidc.issuer-uri=https://idp.example.com/realms/nacos
-nacos.core.auth.plugin.oidc.client-id=nacos-server
-nacos.core.auth.plugin.oidc.client-secret=${client_secret}
-nacos.core.auth.plugin.oidc.scope=openid profile email
+nacos.plugin.auth.oidc.issuer-uri=https://idp.example.com/realms/nacos
+nacos.plugin.auth.oidc.client-id=nacos-server
+nacos.plugin.auth.oidc.client-secret=${client_secret}
+nacos.plugin.auth.oidc.scope=openid profile email
 ```
+
+`auth:oidc` 全部字段为 `RESTART`、`required=false`，历史 alias 统一为 `nacos.core.auth.plugin.oidc.{itemKey}`：
+
+| item key | type / default | sensitive | 说明 |
+| --- | --- | --- | --- |
+| `issuer-uri` | `STRING` / 空 | 否 | 选中 OIDC 时条件必需。 |
+| `client-id` | `STRING` / 空 | 否 | 选中 OIDC 时条件必需。 |
+| `client-secret` | `STRING` / 空 | 是 | 浏览器登录还要求该值。 |
+| `scope` | `STRING` / `openid profile email` | 否 | 登录请求 scope。 |
+| `token-validation-method` | `STRING` / `jwt` | 否 | 当前只实现 JWT/JWKS。 |
+| `jwks-cache-ttl-seconds` | `NUMBER` / `3600` | 否 | 正数。 |
+| `username-claim` | `STRING` / `preferred_username` | 否 | 用户名 claim。 |
+| `roles-claim` | `STRING` / `roles` | 否 | 角色 claim。 |
+| `admin-role` | `STRING` / `nacos-admin` | 否 | 全局管理员映射。 |
+| `auto-create-user` | `BOOLEAN` / `true` | 否 | 保留兼容项，当前不改变运行行为。 |
+| `authorization-endpoint` | `STRING` / 空 | 否 | 非管理员外部授权端点。 |
+| `authorization-timeout-ms` | `NUMBER` / `5000` | 否 | 外部授权超时。 |
+| `strict-nonce-validation` | `BOOLEAN` / `true` | 否 | 严格校验 nonce。 |
+| `strict-audience-validation` | `BOOLEAN` / `true` | 否 | 严格校验 audience/azp。 |
 
 详细配置、Keycloak 示例和排查方法请参考[运维手册 - OIDC/OAuth2 认证](../manual/admin/oidc-auth.md)。
 
@@ -220,7 +283,7 @@ nacos.core.auth.plugin.oidc.scope=openid profile email
 
 | 方法 | 说明 |
 | --- | --- |
-| `getAuthServiceName()` | 返回插件名，需要和 `nacos.core.auth.system.type` 对应。 |
+| `getAuthServiceName()` | 返回稳定 pluginName，需要和 `nacos.plugin.auth.type` 对应。 |
 | `identityNames()` | 声明插件需要从请求中提取的身份字段。 |
 | `enableAuth(action, type)` | 判断指定操作和资源类型是否需要鉴权。 |
 | `validateIdentity(identityContext, resource)` | 校验身份，并把已认证用户等信息写入 `IdentityContext`。 |
@@ -231,11 +294,13 @@ nacos.core.auth.plugin.oidc.scope=openid profile email
 插件打包后放入 `${nacos-server.path}/plugins`，并配置：
 
 ```properties
-nacos.core.auth.system.type=${authServiceName}
+nacos.plugin.auth.type=${authServiceName}
 nacos.core.auth.enabled=true
 ```
 
 重启后，可以在 `${nacos-server.path}/logs/nacos.log` 中查看插件加载日志。
+
+`AuthPluginService` 继承 `PluginConfigSpec`。旧二进制实现没有 definitions 时仍可加载，但显示 `configurable=false`。新实现需要声明自己的 definitions，实现原子 `applyConfig` 并返回当前配置快照；不要把模块入口开关、`type` 选择或 `enabled` 声明为私有配置。
 
 ## 客户端鉴权插件
 

--- a/src/content/docs/next/zh-cn/plugin/config-change-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/config-change-plugin.md
@@ -3,12 +3,14 @@ title: 配置变更
 keywords: [配置变更, 配置审计, 配置格式校验, webhook]
 description: 本文介绍 Nacos 配置变更插件的用途、执行模型、启用方式和自定义开发方式。
 sidebar:
-    order: 6
+    order: 9
 ---
 
 # 配置变更插件
 
 配置变更插件用于在配置发布、修改、删除、导入等操作前后织入自定义逻辑。它适合做配置治理，而不是替代 Nacos 的配置存储模型。
+
+在统一插件管理中，本插件类型为 `config-change`，执行模式为 `CHAIN`，加载阶段为 `STANDARD`，类型非 critical。插件身份是 `config-change:{getServiceType()}`。Nacos Server 仓库只定义 SPI 和执行切面，不内置 `webhook`、`whitelist` 或 `fileformatcheck` 等生产实现；这些示例只有在外部插件 JAR 加入 classpath 后才存在。
 
 常见场景包括：
 
@@ -45,39 +47,27 @@ sidebar:
 Before 插件会影响配置变更主链路。请避免在 Before 插件中调用慢接口或不可控外部系统。After 插件失败不会回滚已经完成的配置变更。
 :::
 
-## 启用插件
+## 启用与配置插件
 
 先将插件 JAR 放入 `${nacos.home}/plugins`，或加入 Nacos Server 启动 classpath。插件实现需要通过 `META-INF/services/com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService` 声明。
 
-然后在 `${nacos.home}/conf/application.properties` 中启用目标插件：
+插件是否参与候选链只由统一状态 `config-change:{pluginName}` 决定。历史启用键只在不存在持久化状态时初始化该状态，缺省仍为 `false`：
 
 ```properties
 nacos.core.config.plugin.${configChangePluginName}.enabled=true
 ```
 
-`${configChangePluginName}` 必须和插件实现的 `getServiceType()` 返回值一致。Nacos 3.2 起还有统一插件状态管理能力，但配置变更执行链路仍会读取上述 `enabled` 配置，因此生产使用时请同时按插件文档完成启用配置。
+`${configChangePluginName}` 必须和 `getServiceType()` 一致。持久化状态优先；启动后请通过插件状态 API 或 Next Console 管理，不需要维护第二个执行门禁。
 
-插件可以读取自己的自定义配置：
-
-```properties
-nacos.core.config.plugin.${configChangePluginName}.${propertyKey}=${propertyValue}
-```
-
-例如 Webhook、白名单、文件格式校验类插件可以使用如下配置：
+新插件通过 `PluginConfigSpec` 声明配置，标准全键为：
 
 ```properties
-# webhook
-nacos.core.config.plugin.webhook.enabled=true
-nacos.core.config.plugin.webhook.url=http://localhost:8080/webhook/send?token=***
-nacos.core.config.plugin.webhook.contentMaxCapacity=102400
-
-# whitelist
-nacos.core.config.plugin.whitelist.enabled=true
-nacos.core.config.plugin.whitelist.suffixs=xml,text,properties,yaml,html
-
-# file format check
-nacos.core.config.plugin.fileformatcheck.enabled=true
+nacos.plugin.config-change.${configChangePluginName}.${itemKey}=${propertyValue}
 ```
+
+实现应声明 definition 的 key、历史 alias、类型、默认值、必填、敏感和生效模式，并通过 `applyConfig` 接收有效配置。Nacos 会把当前有效 item map 同时放入 `ConfigChangeConstants.PLUGIN_PROPERTIES`，保持现有请求契约。
+
+未实现 definition 的旧二进制插件继续使用已废弃的兼容适配器读取 `nacos.core.config.plugin.{pluginName}.{propertyKey}`；它仍可加载并收到静态属性，但管理端显示 `configurable=false`，首次使用会记录迁移告警。`ConfigChangeConfigs` 已废弃但仍处于兼容周期，新代码不要继续依赖它。
 
 ## 开发插件
 
@@ -117,6 +107,8 @@ nacos.core.config.plugin.fileformatcheck.enabled=true
 | `args` | Before 插件提供的替换参数。替换时必须保持原参数顺序和类型。 |
 | `retVal` | 预留返回值。 |
 
+新实现还应实现 `PluginConfigSpec` 的定义、应用和当前快照方法。运行时配置必须先完成整组校验再原子切换；旧二进制实现可以继续沿用默认方法。
+
 ## 生产建议
 
 - Before 插件要保持轻量，必须设置清晰的失败策略。
@@ -129,7 +121,8 @@ nacos.core.config.plugin.fileformatcheck.enabled=true
 
 | 现象 | 排查方向 |
 |-----|---------|
-| 插件未执行 | 检查 JAR 是否在 classpath 中，`META-INF/services` 是否声明正确，`enabled` 是否为 `true`。 |
+| 插件未执行 | 检查 JAR、`META-INF/services` 和统一插件状态；首次迁移时再检查历史 `enabled` 初始化值。 |
 | Before 插件没有拦截 | 检查 `executeType()`、`pointcutMethodNames()` 和 `response.setSuccess(false)` 是否正确。 |
-| 插件配置为空 | 检查配置前缀是否为 `nacos.core.config.plugin.${serviceType}.`，其中 `serviceType` 和 `getServiceType()` 保持一致。 |
+| 新插件配置为空 | 检查标准前缀 `nacos.plugin.config-change.${serviceType}.`、definitions 和 `applyConfig`。 |
+| 旧插件配置为空 | 检查兼容前缀 `nacos.core.config.plugin.${serviceType}.`；该路径已废弃，应安排迁移。 |
 | 变更后通知不稳定 | 检查 After 插件外部系统超时、重试和异常处理。 |

--- a/src/content/docs/next/zh-cn/plugin/config-encryption-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/config-encryption-plugin.md
@@ -3,7 +3,7 @@ title: 配置加密
 keywords: [AES, encryption, 配置加密, 加密插件]
 description: 本文介绍 Nacos 配置加密插件的工作方式、使用步骤、数据表要求和自定义扩展方式。
 sidebar:
-    order: 5
+    order: 8
 ---
 
 # 配置加密插件
@@ -11,6 +11,10 @@ sidebar:
 配置加密用于保护存储在 Nacos 中的敏感配置内容。开启后，符合命名规则的配置会以密文写入数据库，并通过 `encrypted_data_key` 保存解密所需的数据密钥。
 
 配置加密不替代鉴权、网络隔离、TLS 或企业密钥管理系统。它解决的是“配置内容在 Nacos 存储层和部分传输链路中不直接暴露明文”的问题。
+
+在统一插件管理中，本插件类型为 `encryption`，执行模式为 `ROUTED`，加载阶段为 `STANDARD`，类型非 critical。`algorithmName()` 同时是路由键和插件名，因此插件身份为 `encryption:{algorithmName}`。Nacos Server 发布包目前不内置生产加密算法实现；下面的 AES 实现来自外部插件仓库。
+
+已发现的算法默认启用，统一插件状态是运行时路由门禁。禁用某个算法后，使用 `cipher-{algorithm}-` 的读写会明确失败，不会把密文当成明文返回。
 
 ## 工作方式
 
@@ -34,7 +38,7 @@ cipher-aes-application-prod.yaml
 4. 查询配置时，Nacos 使用 `encrypted_data_key` 和同一个算法插件解密内容。
 5. 如果 `dataId` 不以 `cipher-` 开头，配置按普通明文配置处理。
 
-如果 `dataId` 使用了 `cipher-` 前缀，但服务端或客户端没有加载对应算法插件，Nacos 会记录告警日志，并保留原内容处理。生产环境应在发布前验证插件已经正确加载。
+如果 `dataId` 使用了 `cipher-` 前缀，但对应算法未加载或被禁用，操作会明确失败。生产环境应在发布前验证服务端和需要客户端侧加解密的 Java SDK 都已经正确加载插件。
 
 ## 数据表要求
 
@@ -121,6 +125,14 @@ com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService
 | `decrypt(secretKey, content)` | 解密配置内容。 |
 | `encryptSecretKey(secretKey)` | 加密或封装数据密钥。 |
 | `decryptSecretKey(secretKey)` | 解密或解析数据密钥。 |
+
+`EncryptionPluginService` 继承统一的 `PluginConfigSpec`。新实现如果有 KMS 地址、凭据或算法参数，应通过 `ConfigItemDefinition` 声明 `key`、alias、类型、默认值、是否必填、是否敏感和生效模式，标准全键为：
+
+```properties
+nacos.plugin.encryption.{algorithmName}.{itemKey}
+```
+
+运行时可变项在 `applyConfig` 中原子应用，并由 `getCurrentConfig()` 返回已接受快照；密钥类字段必须声明 `sensitive=true`。未实现配置定义的旧二进制插件仍可加载，但管理端显示 `configurable=false`。
 
 插件需要通过 SPI 文件注册：
 

--- a/src/content/docs/next/zh-cn/plugin/control-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/control-plugin.md
@@ -3,14 +3,14 @@ title: 流量防护
 keywords: [流量防护, 限流, 连接数限制, TPS, Control Plugin]
 description: 本文介绍 Nacos 流量防护插件的能力、默认实现、规则配置和自定义扩展方式。
 sidebar:
-    order: 9
+    order: 12
 ---
 
 # 流量防护插件
 
 流量防护插件用于在高压或异常访问场景下保护 Nacos 服务端。它可以限制连接数量，也可以限制核心接口的 TPS，帮助服务端快速拒绝过量请求，避免局部流量问题扩大成集群不可用。
 
-Nacos 2.3.0 起支持通过 SPI 注入流量防护插件。当前默认实现的插件名是 `nacos`。如果没有配置 `nacos.plugin.control.manager.type`，Nacos 会使用 no limit 实现，不主动限制连接和 TPS。
+Nacos 2.3.0 起支持通过 SPI 注入流量防护插件。统一插件类型为 `control`，执行模式为 `EXCLUSIVE`，加载阶段为 `STANDARD`，类型非 critical。当前内置插件身份是 `control:nacos`，不声明配置 definitions，因此 `configurable=false`。如果没有选择实现，Nacos 使用轻量 no-limit facade，不加载规则、指标或限流后台资源。
 
 ## 核心概念
 
@@ -27,8 +27,10 @@ Nacos 2.3.0 起支持通过 SPI 注入流量防护插件。当前默认实现的
 在 `${nacos.home}/conf/application.properties` 中配置：
 
 ```properties
-nacos.plugin.control.manager.type=nacos
+nacos.plugin.control.type=nacos
 ```
+
+历史键 `nacos.plugin.control.manager.type` 仍是静态 alias；同时配置时标准键优先并记录迁移 WARN。选择是 `RESTART` 语义，运行时状态 API 不能切换实现。
 
 默认规则文件存储在 `${nacos.home}/data/connection` 和 `${nacos.home}/data/tps`。如果希望换到其他目录：
 
@@ -42,6 +44,8 @@ nacos.plugin.control.rule.local.basedir=/opt/nacos-control-rules
 /opt/nacos-control-rules/data/connection
 /opt/nacos-control-rules/data/tps
 ```
+
+规则目录和外部规则存储属于 control 模块配置，不是 `control:nacos` 的 definitions。选择的实现会在统一状态恢复和有效配置应用后执行一次启动初始化；未选择的实现仍可列出，但不会构建 manager 或启动后台资源。
 
 启动后可以查看 `${nacos.home}/logs/plugin-control.log`，确认插件是否加载成功。
 
@@ -139,7 +143,7 @@ nacos.plugin.control.rule.external.storage=${controlPluginName}
 
 | SPI / 抽象类 | 作用 |
 | --- | --- |
-| `ControlManagerBuilder` | 声明插件名，并创建连接数管理器和 TPS 管理器。 |
+| `ControlManagerBuilder` | 声明插件名，并根据启动时有效配置创建连接数管理器和 TPS 管理器。 |
 | `ConnectionControlManager` | 加载连接数规则，并判断新连接是否允许建立。 |
 | `TpsControlManager` | 注册 ControlPoint，加载 TPS 规则，并判断请求是否允许继续执行。 |
 | `ExternalRuleStorageBuilder` | 可选。用于接入外部规则存储。 |
@@ -165,6 +169,8 @@ META-INF/services/com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder
 ```text
 META-INF/services/com.alibaba.nacos.plugin.control.spi.ExternalRuleStorageBuilder
 ```
+
+新 `ControlManagerBuilder` 可以通过 `PluginConfigDefinitionSpec` 声明私有配置，标准键为 `nacos.plugin.control.{pluginName}.{itemKey}`。在 control 定义安全的 manager 替换/关闭生命周期前，这些 definitions 必须使用 `RESTART`；旧 builder 的无参数构建方法仍保持二进制兼容。
 
 ## 运维建议
 

--- a/src/content/docs/next/zh-cn/plugin/custom-environment-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/custom-environment-plugin.md
@@ -3,7 +3,7 @@ title: 自定义环境变量
 keywords: [自定义环境变量, 自定义配置, 数据库密码加密, Environment Plugin]
 description: 本文介绍 Nacos 自定义环境变量插件的用途、执行规则、启用方式和开发方式。
 sidebar:
-    order: 8
+    order: 11
 ---
 
 # 自定义环境变量插件
@@ -11,6 +11,8 @@ sidebar:
 自定义环境变量插件用于在 Nacos Server 消费配置项之前，对指定配置值进行转换。典型场景是数据库密码解密、部署环境特殊变量适配、敏感配置从企业密钥系统转换为 Nacos 可识别的启动配置。
 
 它处理的是 **Nacos Server 启动期配置**，不是配置中心里的业务配置。业务配置加密请参考[配置加密插件](./config-encryption-plugin.md)。
+
+在统一插件管理中，本插件类型为 `environment`，执行模式为 `CHAIN`，加载阶段为 `PRE_CONTEXT`，类型非 critical。插件身份是 `environment:{pluginName()}`。PRE_CONTEXT 必须在 Spring Context 建立前改写 Environment，因此只解析 `STATIC > DEFAULT`，所有配置项都按 `RESTART` 展示；运行时状态、配置更新和后续 STATIC 刷新均不会重新执行插件，必须重启。
 
 :::note
 自定义环境变量插件主要用于部署环境适配。插件 API 可能随 Nacos 版本演进，请使用和目标 Nacos 版本匹配的插件。
@@ -27,11 +29,12 @@ sidebar:
 - 返回值为 `null` 的配置项会被移除，不会覆盖原始配置。
 - 多个插件处理同一个 key 时，按 `order()` 升序执行；后写入的值覆盖先写入的值，因此更大的 `order()` 拥有更高最终优先级。
 
-例如，一个插件声明处理 `db.password.0`，可以把配置文件中的密文转换成明文数据库密码：
+例如，一个插件声明处理标准数据源密码键，可以把配置文件中的密文转换成明文数据库密码：
 
 ```properties
 nacos.custom.environment.enabled=true
-db.password.0=ENC(base64-or-kms-value)
+nacos.plugin.environment.demo-environment.enabled=true
+nacos.plugin.datasource.db.password.0=ENC(base64-or-kms-value)
 ```
 
 转换后的值会被 Nacos 数据源初始化逻辑读取。
@@ -45,6 +48,8 @@ db.password.0=ENC(base64-or-kms-value)
 ```properties
 nacos.custom.environment.enabled=true
 ```
+
+该键是静态模块总开关，关闭时不会加载实现。每个实现还可以通过 `nacos.plugin.environment.{pluginName}.enabled` 指定启动初始状态；运行时状态 API 对该类型的变更请求会被拒绝。
 
 启动后，可在 `${nacos.home}/logs/nacos.log` 中查看插件加载日志：
 
@@ -68,7 +73,7 @@ nacos.custom.environment.enabled=true
 
 | 方法 | 说明 |
 |-----|------|
-| `pluginName()` | 稳定插件名称，用于日志和插件状态识别。 |
+| `pluginName()` | 稳定插件名称，组成 `environment:{pluginName}`。 |
 | `propertyKey()` | 插件需要转换的配置 key 集合。 |
 | `order()` | 覆盖顺序，值越大最终优先级越高。 |
 | `customValue(property)` | 输入为声明 key 的原始值，返回转换后的 key-value。 |
@@ -80,13 +85,14 @@ public class DemoEnvironmentPlugin implements CustomEnvironmentPluginService {
 
     @Override
     public Set<String> propertyKey() {
-        return Collections.singleton("db.password.0");
+        return Collections.singleton("nacos.plugin.datasource.db.password.0");
     }
 
     @Override
     public Map<String, Object> customValue(Map<String, Object> property) {
-        String encrypted = (String) property.get("db.password.0");
-        return Collections.singletonMap("db.password.0", decrypt(encrypted));
+        String key = "nacos.plugin.datasource.db.password.0";
+        String encrypted = (String) property.get(key);
+        return Collections.singletonMap(key, decrypt(encrypted));
     }
 
     @Override
@@ -101,6 +107,8 @@ public class DemoEnvironmentPlugin implements CustomEnvironmentPluginService {
 }
 ```
 
+`CustomEnvironmentPluginService` 继承 `PluginConfigSpec`。私有配置使用 `nacos.plugin.environment.{pluginName}.{itemKey}`，并通过 definitions 声明元数据。即使实现把某项标为 `RUNTIME`，管理端也会归一化为 `RESTART` 并记录 WARN；启动时应用接受的快照后，后续变更要求重启。旧二进制实现未声明 definitions 时仍可加载，但 `configurable=false`。
+
 ## 生产建议
 
 - 明确列出插件会处理哪些配置 key，避免误改其它启动参数。
@@ -108,6 +116,7 @@ public class DemoEnvironmentPlugin implements CustomEnvironmentPluginService {
 - 不要在插件中硬编码密钥。请使用环境变量、KMS、HSM 或企业密钥服务。
 - 如果插件访问外部密钥系统，请设置超时和降级策略，避免启动过程无限等待。
 - 所有节点应使用相同版本的插件 JAR 和依赖 JAR。
+- `propertyKey()` 应声明当前模块实际消费的标准键；只声明 `db.password.*` 的旧实现只能处理历史 alias。
 
 ## 排查
 

--- a/src/content/docs/next/zh-cn/plugin/datasource-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/datasource-plugin.md
@@ -3,7 +3,7 @@ title: 多数据源
 keywords: [MySQL, Derby, PostgreSQL, Oracle, 数据源插件, 数据库方言]
 description: 本文介绍 Nacos 数据源方言插件的使用方式、官方内置数据库类型、社区扩展插件和自定义开发方式。
 sidebar:
-    order: 4
+    order: 7
 ---
 
 # 多数据源插件
@@ -11,6 +11,8 @@ sidebar:
 Nacos 通过数据源方言插件适配不同数据库。插件负责处理 SQL 方言、分页、函数、主键返回方式，以及 Nacos 逻辑表对应的 mapper 实现。
 
 从 Nacos 2.2.0 开始，数据源方言可以通过 SPI 扩展。当前 Nacos next 版本的官方默认实现已经支持 4 种数据库：`derby`、`mysql`、`postgresql` 和 `oracle`。
+
+在统一插件管理中，本插件类型为 `datasource-dialect`，执行模式为 `EXCLUSIVE`，加载阶段为 `STANDARD`，并且是 critical 类型。四个内置插件身份分别为 `datasource-dialect:derby`、`datasource-dialect:mysql`、`datasource-dialect:postgresql` 和 `datasource-dialect:oracle`。它们均不声明 `ConfigItemDefinition`，因此管理端显示 `configurable=false`；数据库连接和连接池参数属于数据源模块配置，而不是任一方言插件的私有配置。
 
 :::note
 这里的“多数据源”主要指多种数据库方言，以及同一数据库类型下的多个连接地址。一个 Nacos 集群运行时只能选择一种 SQL platform，不建议把不同数据库类型混在同一个集群配置中使用。
@@ -33,67 +35,84 @@ Nacos 通过数据源方言插件适配不同数据库。插件负责处理 SQL 
 
 ## 选择数据库类型
 
-推荐使用 `spring.sql.init.platform` 指定数据库类型：
+使用标准选择键指定数据库类型：
 
 ```properties
-spring.sql.init.platform=mysql
+nacos.plugin.datasource-dialect.type=mysql
 ```
 
-为了兼容旧版本，Nacos 仍然兼容 `spring.datasource.platform`。新部署建议统一使用 `spring.sql.init.platform`。
+`spring.sql.init.platform` 是仍受支持的历史 alias；同时配置时标准键优先。更早的 `spring.datasource.platform` 已移除，不再读取。方言选择在启动时确定，不能通过运行时插件状态 API 切换。
 
 如果没有显式指定数据库类型，Nacos 会根据运行模式选择默认存储：
 
 | 运行模式 | 默认存储 |
 | --- | --- |
-| 单机模式 | 内置 Derby |
-| 集群模式 | 外置数据库 |
+| 单机模式，或集群模式且 `-DembeddedStorage=true` | 内置 Derby |
+| 普通集群模式 | 外置 MySQL |
 
-生产环境建议使用外置数据库，并在启动 Nacos 前导入对应数据库的 schema。
+选中的方言是 active critical provider。插件缺失或被禁用时，Nacos 会明确报错并终止启动，不会回退到另一个已发现的方言。生产环境建议使用外置数据库，并在启动 Nacos 前导入对应数据库的 schema。
 
 ## 外置数据库配置
 
 以 PostgreSQL 为例：
 
 ```properties
-spring.sql.init.platform=postgresql
-db.num=1
-db.url.0=jdbc:postgresql://127.0.0.1:5432/nacos
-db.user=nacos
-db.password=nacos
-db.pool.config.driverClassName=org.postgresql.Driver
-db.pool.config.connectionTestQuery=SELECT 1
+nacos.plugin.datasource-dialect.type=postgresql
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:postgresql://127.0.0.1:5432/nacos
+nacos.plugin.datasource.db.user=nacos
+nacos.plugin.datasource.db.password=nacos
+nacos.plugin.datasource.db.pool.config.driver-class-name=org.postgresql.Driver
+nacos.plugin.datasource.db.pool.config.connection-test-query=SELECT 1
 ```
 
 以 Oracle 12c 及以上版本为例：
 
 ```properties
-spring.sql.init.platform=oracle
-db.num=1
-db.url.0=jdbc:oracle:thin:@127.0.0.1:1521:XE
-db.user=nacos
-db.password=nacos
-db.pool.config.driverClassName=oracle.jdbc.OracleDriver
-db.pool.config.connectionTestQuery=SELECT 1 FROM dual
+nacos.plugin.datasource-dialect.type=oracle
+nacos.plugin.datasource.db.num=1
+nacos.plugin.datasource.db.url.0=jdbc:oracle:thin:@127.0.0.1:1521:XE
+nacos.plugin.datasource.db.user=nacos
+nacos.plugin.datasource.db.password=nacos
+nacos.plugin.datasource.db.pool.config.driver-class-name=oracle.jdbc.OracleDriver
+nacos.plugin.datasource.db.pool.config.connection-test-query=SELECT 1 FROM dual
 ```
 
-`db.pool.config.*` 会传递给 HikariCP。可以按需配置 `connectionTimeout`、`maximumPoolSize`、`minimumIdle` 等连接池参数。
+稳定的数据源模块配置如下。它们均为静态、重启生效，不会出现在方言插件详情或 PUT 配置 API 中。
+
+| 标准键或模式 | 历史 alias | 默认值/说明 |
+| --- | --- | --- |
+| `nacos.plugin.datasource.db.num` | `db.num` | 外置连接数量，使用外置存储时必须为正数 |
+| `nacos.plugin.datasource.db.url.{index}` | `db.url.{index}` | 每个连接的 JDBC URL |
+| `nacos.plugin.datasource.db.user[.{index}]` | `db.user[.{index}]` | 公共或逐连接用户名 |
+| `nacos.plugin.datasource.db.password[.{index}]` | `db.password[.{index}]` | 公共或逐连接密码，敏感值 |
+| `nacos.plugin.datasource.db.pool.config.connection-timeout` | `db.pool.config.connectionTimeout` 或 kebab-case 形式 | `3000` 毫秒 |
+| `nacos.plugin.datasource.db.pool.config.validation-timeout` | `db.pool.config.validationTimeout` 或 kebab-case 形式 | `10000` 毫秒 |
+| `nacos.plugin.datasource.db.pool.config.idle-timeout` | `db.pool.config.idleTimeout` 或 kebab-case 形式 | `600000` 毫秒 |
+| `nacos.plugin.datasource.db.pool.config.maximum-pool-size` | `db.pool.config.maximumPoolSize` 或 kebab-case 形式 | `20` |
+| `nacos.plugin.datasource.db.pool.config.minimum-idle` | `db.pool.config.minimumIdle` 或 kebab-case 形式 | `2` |
+| `nacos.plugin.datasource.db.pool.config.driver-class-name` | `db.pool.config.driverClassName` 或 kebab-case 形式 | 空值使用兼容默认驱动 |
+| `nacos.plugin.datasource.db.pool.config.connection-test-query` | `db.pool.config.connectionTestQuery` 或 kebab-case 形式 | 空值使用 `SELECT 1` |
+| `nacos.plugin.datasource.db.query-timeout` | JVM 属性 `QUERYTIMEOUT` | `3` 秒 |
+
+同一配置同时出现标准键和 alias 时，标准键优先；索引项逐项解析，迁移期间允许标准 `url.0` 与历史 `url.1` 并存。`nacos.plugin.datasource.db.pool.config.{hikari-property}` 仍可向 HikariCP 传递其他 JavaBean 属性，但只有上表列出的稳定子集属于长期配置契约。
 
 ### 配置多个数据库连接
 
 `db.num` 表示外置数据库连接数量。Nacos 会对多个连接做健康检查和主库选择。多个连接应属于同一种数据库类型。
 
 ```properties
-spring.sql.init.platform=mysql
-db.num=2
-db.url.0=jdbc:mysql://db-0:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
-db.url.1=jdbc:mysql://db-1:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
-db.user.0=nacos
-db.password.0=nacos_password_0
-db.user.1=nacos
-db.password.1=nacos_password_1
+nacos.plugin.datasource-dialect.type=mysql
+nacos.plugin.datasource.db.num=2
+nacos.plugin.datasource.db.url.0=jdbc:mysql://db-0:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.url.1=jdbc:mysql://db-1:3306/nacos?characterEncoding=utf8&useSSL=false&serverTimezone=UTC
+nacos.plugin.datasource.db.user.0=nacos
+nacos.plugin.datasource.db.password.0=nacos_password_0
+nacos.plugin.datasource.db.user.1=nacos
+nacos.plugin.datasource.db.password.1=nacos_password_1
 ```
 
-如果所有连接使用同一个用户名和密码，也可以只配置 `db.user` 和 `db.password`。
+如果所有连接使用同一个用户名和密码，也可以只配置不带索引的 `nacos.plugin.datasource.db.user` 和 `nacos.plugin.datasource.db.password`。
 
 ## 社区数据源插件
 
@@ -119,7 +138,7 @@ db.password.1=nacos_password_1
 1. 选择与 Nacos 版本匹配的插件版本。
 2. 编译插件并取得插件 JAR。
 3. 将插件 JAR 和数据库驱动 JAR 放到 `${nacos.home}/plugins`，或者通过启动参数追加到 classpath。
-4. 在 `application.properties` 中设置 `spring.sql.init.platform` 为插件声明的数据库类型。
+4. 在 `application.properties` 中将 `nacos.plugin.datasource-dialect.type` 设置为插件声明的数据库类型。
 5. 导入对应数据库 schema。
 6. 重启 Nacos，并检查启动日志中是否加载了目标 dialect 和 mapper。
 
@@ -153,7 +172,7 @@ com.alibaba.nacos.plugin.datasource.mapper.Mapper
 
 | 现象 | 建议检查 |
 | --- | --- |
-| 启动时找不到 dialect | `spring.sql.init.platform` 是否与插件 `getType()` 返回值一致，插件 JAR 是否进入 classpath。 |
+| 启动时找不到 dialect | `nacos.plugin.datasource-dialect.type` 是否与插件 `getType()` 返回值一致，插件 JAR 是否进入 classpath。 |
 | 启动或查询时报缺少 mapper | 插件是否注册了所有 Nacos 需要的表级 mapper。 |
 | 数据库连接失败 | JDBC URL、驱动类、用户名、密码、网络 ACL 和连接池参数是否正确。 |
 | Oracle 11g 或更低版本分页 SQL 报错 | 当前 Oracle 插件仅支持 Oracle 12c 及以上版本。低版本 Oracle 需要自定义插件适配。 |

--- a/src/content/docs/next/zh-cn/plugin/development.md
+++ b/src/content/docs/next/zh-cn/plugin/development.md
@@ -1,0 +1,131 @@
+---
+title: 插件开发指南
+keywords: [插件开发, Java SPI, PluginConfigSpec, applyConfig, PluginStartupLifecycle]
+description: 说明 Nacos 服务端插件的 SPI 注册、统一配置契约、二进制兼容、生命周期和开发检查项。
+sidebar:
+    order: 3
+---
+
+# 插件开发指南
+
+开发 Nacos 服务端插件时，先选择对应领域 SPI，再接入统一配置和状态。统一插件管理不会替代领域行为接口，也不会允许插件绕过 Nacos 的资源、鉴权、响应或错误模型。
+
+## 选择领域 SPI
+
+| pluginType | 稳定实现名来源 | 主要领域 SPI |
+| --- | --- | --- |
+| `auth` | `getAuthServiceName()` | `AuthPluginService` |
+| `datasource-dialect` | `getType()` | `DatabaseDialect`，并配套 `Mapper` |
+| `config-change` | `getServiceType()` | `ConfigChangePluginService` |
+| `encryption` | `algorithmName()` | `EncryptionPluginService` |
+| `trace` | `getName()` | `NacosTraceSubscriber` |
+| `environment` | `pluginName()` | `CustomEnvironmentPluginService` |
+| `control` | `getName()` | `ControlManagerBuilder` |
+| `visibility` | `getVisibilityServiceName()` | `VisibilityService` |
+| `ai-pipeline` | `pipelineId()` | `PublishPipelineService` |
+| `ai-storage` | `type()` | `AiResourceStorage` / `AiResourceStorageBuilder` |
+| `ai-resource-import` | `pluginName()` | `AiResourceImportServiceBuilder` |
+
+把实现类写入对应的 `META-INF/services/{SPI 接口全限定名}`。插件 JAR 可以放到 `${nacos.home}/plugins` 或 Nacos Server 启动 classpath。外部依赖也必须在每个节点可用。
+
+## 稳定身份和冲突
+
+插件名称必须非空、稳定，并在同一 `pluginType` 内唯一。统一注册采用 first-wins：后发现的重复 `pluginId` 会被忽略并记录包含两边实现类的 WARN。领域 provider 从多个 SPI 实现构造 map 时也必须先检查重复，不能用 `put` 静默覆盖。
+
+不要把 SPI 扫描顺序当成选择机制。需要选择实现时使用对应类型的静态 `type` key或领域路由字段。
+
+## 声明统一配置
+
+可配置的运行时实现实现 `com.alibaba.nacos.api.plugin.PluginConfigSpec`：
+
+```java
+public final class ExamplePlugin implements PluginConfigSpec {
+    private volatile Map<String, String> currentConfig = Map.of();
+
+    @Override
+    public List<ConfigItemDefinition> getConfigDefinitions() {
+        return List.of(
+                new ConfigItemDefinition.Builder(
+                        "timeout", "Timeout", ConfigItemType.NUMBER)
+                        .defaultValue("3000")
+                        .required(true)
+                        .aliases(List.of("legacy.example.timeout"))
+                        .effectMode(ConfigItemEffectMode.RUNTIME)
+                        .build());
+    }
+
+    @Override
+    public void applyConfig(Map<String, String> config) {
+        currentConfig = Map.copyOf(config);
+    }
+
+    @Override
+    public Map<String, String> getCurrentConfig() {
+        return currentConfig;
+    }
+}
+```
+
+约束如下：
+
+- definition 的 `key` 只写 item key。标准静态 key 由核心拼为 `nacos.plugin.{pluginType}.{pluginName}.{itemKey}`。
+- 完整声明 `type`、`defaultValue`、`required`、`sensitive`、`effectMode` 和需要兼容的 `aliases`。
+- 不得声明 `enabled`，它属于统一插件状态。
+- `applyConfig` 接收 canonical item-key 的完整有效快照，应先校验并构建新不可变状态，再一次性发布，避免调用方观察到半更新。
+- `getCurrentConfig` 返回插件最后接受的快照，不要重新读取 Spring environment。
+- definition key 和 alias 也采用 first-wins；不要发布内部互相冲突的 definition。
+
+只有 definition 非空时，默认 `isConfigurable()` 才返回 `true`。实现必须同时提供可靠的 `applyConfig` 和当前快照。
+
+## effect mode
+
+只有不需要重建不可替换运行资源的字段才标记 `RUNTIME`。以下情况通常使用 `RESTART`：
+
+- 实现选择或路由 provider 选择；
+- 密钥解析器、LDAP/OIDC client、数据库、线程池或外部进程选项在启动时构建；
+- 尚未定义原子替换、关闭和失败回滚生命周期。
+
+`environment` 属于 `PRE_CONTEXT`。即使实现把 definition 声明为 `RUNTIME`，统一管理也会复制为 `RESTART` 并记录 WARN。
+
+## 启动生命周期
+
+普通实现的启动流程是：
+
+```text
+发现 -> 恢复状态 -> 解析有效配置 -> applyConfig
+     -> （可选）PluginStartupLifecycle.initialize -> 对领域可见
+```
+
+只有需要在配置接受后创建运行资源的适配器才实现 `PluginStartupLifecycle`。`initialize()` 必须幂等，也会用于类型延迟加载。它不自动赋予运行时 rebuild 能力。
+
+类型级模块开关可以让非 critical 类型延迟发现。插件不应在其他静态单例或领域 manager 中再次独立加载 SPI，否则会绕过统一状态与配置。
+
+## 旧二进制实现兼容
+
+统一后的领域 SPI 通过默认方法继承 `PluginConfigSpec`。旧二进制实现没有 definition 时仍可加载，并显示 `configurable=false`；默认 current map 为空，默认 `applyConfig` 为 no-op。不要为了让旧插件出现在配置界面而猜测其私有属性。
+
+新实现应主动声明 definition、实现原子 `applyConfig`，并返回当前快照。对于仍处于兼容周期的领域适配器：
+
+- Config Change 的旧 `nacos.core.config.plugin.{name}.*` 属性仍可传给旧实现，但 `ConfigChangeConfigs` 已废弃。
+- Visibility 的旧 `init(Properties)` 只用于没有统一 definition 的旧实现。
+
+这些适配器不让旧实现自动变成 configurable。
+
+## 安全和稳定性
+
+- `sensitive=true` 的值不得写入日志、异常、trace 或 API；实现也要识别从核心收到的是明文有效快照。
+- 外部 IO 设置连接、读取和总耗时限制。Trace/after-hook 等非主决策插件应使用独立 executor 并定义降级行为。
+- 插件不能改变共享 Nacos 资源身份、v3 `Result<T>` 响应、错误码和鉴权边界。
+- 集群插件包、依赖、静态配置和 alias 迁移应保持一致。
+- 对 state/config update、重复 ID、重复 definition、apply 失败和滚动升级编写测试。
+
+## 发布前检查
+
+1. `pluginType:pluginName` 在目标集群中唯一。
+2. SPI 文件名和实现类全限定名正确，构造条件满足。
+3. definition 不包含 `enabled`，key/alias 无冲突。
+4. `applyConfig` 原子且可重复调用；same-map 重试安全。
+5. `RUNTIME` 字段真的支持在线替换，其他字段为 `RESTART`。
+6. 插件 disabled 时领域入口会检查统一状态。
+7. active critical provider 缺失或禁用时能明确失败。
+8. 文档列出所有 canonical key、alias、默认值、敏感性和生效模式。

--- a/src/content/docs/next/zh-cn/plugin/development.md
+++ b/src/content/docs/next/zh-cn/plugin/development.md
@@ -30,9 +30,9 @@ sidebar:
 
 ## 稳定身份和冲突
 
-插件名称必须非空、稳定，并在同一 `pluginType` 内唯一。统一注册采用 first-wins：后发现的重复 `pluginId` 会被忽略并记录包含两边实现类的 WARN。领域 provider 从多个 SPI 实现构造 map 时也必须先检查重复，不能用 `put` 静默覆盖。
+插件名称必须非空、稳定，并在同一 `pluginType` 内唯一。同类型 Provider 按 `PluginProvider.getOrder()` 升序处理（默认值为 `0`）；order 相同时保持 SPI 发现顺序。随后统一注册执行 first-wins，因此 order 较小的 Provider 先获得注册机会，后来出现的重复 `pluginId` 会被忽略并记录包含两边实现类的 WARN。Provider order 不替代 EXCLUSIVE 选择或领域路由。领域 provider 从多个 SPI 实现构造 map 时也必须先检查重复，不能用 `put` 静默覆盖。
 
-不要把 SPI 扫描顺序当成选择机制。需要选择实现时使用对应类型的静态 `type` key或领域路由字段。
+不要把相同 order 下的 SPI 扫描顺序当成选择机制。只有确实需要 Provider 优先级时才使用不同 order；选择实现仍应使用对应类型的静态 `type` key 或领域路由字段。
 
 ## 声明统一配置
 
@@ -74,6 +74,7 @@ public final class ExamplePlugin implements PluginConfigSpec {
 - `applyConfig` 接收 canonical item-key 的完整有效快照，应先校验并构建新不可变状态，再一次性发布，避免调用方观察到半更新。
 - `getCurrentConfig` 返回插件最后接受的快照，不要重新读取 Spring environment。
 - definition key 和 alias 也采用 first-wins；不要发布内部互相冲突的 definition。
+- 对 STATIC 输入，normalized 标准完整 key 只要存在就优先，即使值为空也不回退 alias。只有标准 key 不存在时才读取 alias；同时存在多个 alias 时按该 definition 的 `aliases` 声明顺序取第一个。
 
 只有 definition 非空时，默认 `isConfigurable()` 才返回 `true`。实现必须同时提供可靠的 `applyConfig` 和当前快照。
 

--- a/src/content/docs/next/zh-cn/plugin/migration.md
+++ b/src/content/docs/next/zh-cn/plugin/migration.md
@@ -20,7 +20,7 @@ sidebar:
 6. 先滚动部署新插件和静态配置，再通过插件详情检查 effective source。
 7. `RESTART` 字段必须随节点重启；不要用 PUT API 尝试修改。
 
-标准 key 与 alias 同时存在时，标准 key 优先。API 接受的 alias 会被归一化，`plugin-configs.json` 和 local-only map 只保存 canonical item key。
+对 STATIC `PluginConfigSpec` 配置项，标准完整 key 按“是否存在”取得优先级，而不是按值是否非空。空的标准值仍会屏蔽历史 alias，并可能触发 required 校验；只有彻底删除标准属性后才会回退 alias。同时存在多个 alias 时，按 definition 中的声明顺序取第一个。选择 key 仍遵循各插件族文档中的规则。API 接受的 alias 会被归一化，`plugin-configs.json` 和 local-only map 只保存 canonical item key。
 
 ## 实现选择 key
 
@@ -39,6 +39,8 @@ sidebar:
 - OIDC 从 `nacos.core.auth.plugin.oidc.*` 迁到 `nacos.plugin.auth.oidc.*`。当前全部字段为 `RESTART`。
 - `nacos.plugin.visibility.enabled` 仍是能力总开关；`nacos.plugin.visibility.type` 只用于历史初始选择。实现状态使用 `visibility:{name}` 的统一状态。
 - `nacos.plugin.ai-pipeline.enabled` 仍是 Pipeline 总开关；历史 `nacos.plugin.ai-pipeline.type` 只用于启动时初始 chain 状态。后续成员变更使用统一插件状态，节点参数使用各自 definition。
+
+目标发行包已经声明 `nacos.plugin.auth.type=nacos` 和 `auth:nacos` 的标准默认项。升级时应把保留的鉴权选择和实现配置复制到这些标准 key，不能让历史 alias 与目标默认值并存；否则标准 selector 会继续选择 `nacos`，标准 `PluginConfigSpec` key 即使为空也会屏蔽 alias。启动脚本只会特殊迁移 `application.properties` 中有效的旧 token secret，其他鉴权值都需要显式迁移。
 
 ## Config Change
 
@@ -68,6 +70,8 @@ nacos.plugin.ai-resource-import.enabled=true
 nacos.plugin.ai-resource-import.{pluginName}.enabled=true
 nacos.plugin.ai-resource-import.{pluginName}.{itemKey}=value
 ```
+
+标准 key 和历史 alias 都未配置时，family gate 仍默认开启；只有显式 `false` 才关闭。升级期间必须保持导入能力关闭的部署，应在发布前明确设置 `nacos.plugin.ai-resource-import.enabled=false`。
 
 需要删除或重写的旧模型：
 

--- a/src/content/docs/next/zh-cn/plugin/migration.md
+++ b/src/content/docs/next/zh-cn/plugin/migration.md
@@ -1,0 +1,104 @@
+---
+title: 插件迁移指南
+keywords: [插件迁移, 配置迁移, AI Resource Import, ConfigChangeConfigs, 兼容性]
+description: 从历史插件选择 key、私有配置和旧 AI Resource Import SPI 迁移到统一插件管理模型。
+sidebar:
+    order: 4
+---
+
+# 插件迁移指南
+
+统一插件管理把“模块是否进入插件能力”“选择哪个实现”“实现是否 enabled”“实现私有配置”拆成四个独立层次。升级前先按这个模型分类旧配置，避免把历史总开关直接迁成某个实现的配置或状态。
+
+## 通用迁移步骤
+
+1. 记录当前插件 JAR、实现名、模块开关、选择 key、实现 enabled key 和私有配置。
+2. 把实现身份映射为稳定的 `pluginType:pluginName`。
+3. 对 `EXCLUSIVE` 类型改用标准 `nacos.plugin.{pluginType}.type`。
+4. 对实现配置改用 `nacos.plugin.{pluginType}.{pluginName}.{itemKey}`。
+5. 保留 alias 只用于一个兼容窗口，观察迁移 WARN；确认新 key 生效后删除 alias。
+6. 先滚动部署新插件和静态配置，再通过插件详情检查 effective source。
+7. `RESTART` 字段必须随节点重启；不要用 PUT API 尝试修改。
+
+标准 key 与 alias 同时存在时，标准 key 优先。API 接受的 alias 会被归一化，`plugin-configs.json` 和 local-only map 只保存 canonical item key。
+
+## 实现选择 key
+
+| pluginType | 标准 key | 历史 alias | 默认/行为 |
+| --- | --- | --- | --- |
+| `auth` | `nacos.plugin.auth.type` | `nacos.core.auth.system.type` | 默认 `nacos`。 |
+| `datasource-dialect` | `nacos.plugin.datasource-dialect.type` | `spring.sql.init.platform` | standalone/embedded 默认 `derby`，普通 cluster 默认 `mysql`。`spring.datasource.platform` 已移除。 |
+| `control` | `nacos.plugin.control.type` | `nacos.plugin.control.manager.type` | 空表示 no-limit。 |
+
+这些选择都在启动时快照，变更需要重启。不要用 status API 切换 exclusive 实现。
+
+## Auth、Visibility 和 AI Pipeline
+
+- 默认鉴权实现配置从 `nacos.core.auth.plugin.nacos.*` 和 `nacos.core.auth.caching.enabled` 迁到 `nacos.plugin.auth.nacos.*`。
+- LDAP 从 `nacos.core.auth.ldap.*` 迁到 `nacos.plugin.auth.ldap.*`；未被生产代码消费的 `nacos.core.auth.ldap.userdn` 模板 key 不是有效 alias。
+- OIDC 从 `nacos.core.auth.plugin.oidc.*` 迁到 `nacos.plugin.auth.oidc.*`。当前全部字段为 `RESTART`。
+- `nacos.plugin.visibility.enabled` 仍是能力总开关；`nacos.plugin.visibility.type` 只用于历史初始选择。实现状态使用 `visibility:{name}` 的统一状态。
+- `nacos.plugin.ai-pipeline.enabled` 仍是 Pipeline 总开关；历史 `nacos.plugin.ai-pipeline.type` 只用于启动时初始 chain 状态。后续成员变更使用统一插件状态，节点参数使用各自 definition。
+
+## Config Change
+
+新 Config Change 实现应直接在 `ConfigChangePluginService` 上声明 `PluginConfigSpec`：
+
+```text
+nacos.plugin.config-change.{pluginName}.{itemKey}
+```
+
+历史 `nacos.core.config.plugin.{pluginName}.*` 仍会在兼容周期内提供给没有 definition 的旧实现；历史 `{name}.enabled` 只用于没有持久化状态时初始化 unified state。`ConfigChangeConfigs` 已废弃，新实现不要依赖它，也不要继续把 `PLUGIN_PROPERTIES` 当成第二套 enabled gate。
+
+旧二进制插件仍可加载，但显示 `configurable=false`。迁移版本应增加 definition、`applyConfig` 和当前配置快照。
+
+## AI Resource Import breaking change
+
+AI Resource Import 已从“Importer + 可复制 Source/preset”双层模型改为一个 Builder 对应一个确定来源：
+
+```text
+ai-resource-import:{pluginName}
+sourceId = managed pluginName
+```
+
+新开关和配置：
+
+```properties
+nacos.plugin.ai-resource-import.enabled=true
+nacos.plugin.ai-resource-import.{pluginName}.enabled=true
+nacos.plugin.ai-resource-import.{pluginName}.{itemKey}=value
+```
+
+需要删除或重写的旧模型：
+
+- `nacos.plugin.ai.importer.*`
+- `nacos.ai.resource.import.sources[N].*`
+- `AiResourceImportSource`
+- `AiResourceImportSourceProvider` / Source Provider SPI
+- preset 来源模型
+- 通过配置复制同一个 importer 到多个 endpoint
+
+原有 API 的 `sourceId` 现在等于 managed `pluginName`；API 字段 `pluginName` 仍表示 importer/protocol 类型，用于兼容控制台数据模型。一个 `pluginName` 只代表一个固定来源。需要第二个企业 endpoint 时，提供另一个具有不同 `pluginName` 的 `AiResourceImportServiceBuilder`，不能复制配置实例。
+
+新 Builder 自身实现 `PluginConfigSpec`，提供 `pluginName()`、`importerType()`、展示信息、支持的资源类型、definitions、`applyConfig`、当前快照和无参 `build()`。请求级 service 从已接受的不可变快照创建；请求不再携带 source 配置或任意 endpoint。
+
+四个内置来源：
+
+| pluginId | importer type | 默认实现状态 | endpoint |
+| --- | --- | --- | --- |
+| `ai-resource-import:mcp-official` | `mcp-registry` | enabled | 固定官方 MCP Registry |
+| `ai-resource-import:mcp-registry-protocol` | `mcp-registry` | disabled | 运维必须配置 |
+| `ai-resource-import:skills-sh` | `skills-sh` | enabled | 固定 `https://skills.sh` |
+| `ai-resource-import:skills-well-known` | `skills-well-known` | disabled | 运维必须配置 |
+
+`mcp-official` 和 `skills-sh` 继续使用原有 Console 展示名称，用户仍按来源搜索、选择、校验、导入。旧 `nacos.plugin.ai.importer.*` 中仍有效的展示、描述、限制、状态和可配置 endpoint key 只在一个迁移窗口作为 alias 读取；固定来源 endpoint override、`auth-ref`、来源/全局 timeout、`max-page-count`、`block-private-network`、全局默认值和任意 `properties.*` 已移除。
+
+旧 Importer/Source SPI 没有兼容适配器，外部实现必须重新编译并迁移。完整 definitions 和示例见 [AI 资源导入插件](./ai-resource-import-plugin.md)。
+
+## 上线和回滚
+
+- 先在单节点验证 plugin list/detail、effective source、敏感脱敏和 `RESTART` 提示。
+- 集群滚动升级期间，不要提交依赖新 definition 的 runtime config，直到所有节点都运行新插件。
+- 保留旧 alias 的第一个版本要持续监控 WARN；下一个维护窗口删除旧 key。
+- 回滚前清理只有新版本认识的 runtime override，避免旧版本忽略或误读配置。
+- AI Resource Import 旧 SPI 无兼容适配器；需要回滚时必须同时回滚插件 JAR、配置和调用方，不能混跑两种模型。

--- a/src/content/docs/next/zh-cn/plugin/operations.md
+++ b/src/content/docs/next/zh-cn/plugin/operations.md
@@ -55,6 +55,8 @@ nacos.plugin.{pluginType}.{pluginName}.{itemKey}
 | `sensitive` | 详情响应脱敏，日志不得输出值。 |
 | `effectMode` | `RUNTIME` 可运行时更新；`RESTART` 只能通过静态配置并重启生效。 |
 
+解析 `PluginConfigSpec` 配置项的 STATIC 来源时，normalized 标准完整 key 只要存在就具有优先级，即使值为空字符串也不回退 alias。只有标准 key 不存在时才检查 alias；同时存在多个 alias 时，按 definition 中的声明顺序取第一个，其余 alias 被忽略并记录 WARN。
+
 definition 归一化采用 first-wins。空 key、保留 key `enabled`、重复 key，以及与先前 key/alias 冲突的后来 definition 或 alias 都会被忽略并记录 WARN。
 
 ## 配置来源和优先级

--- a/src/content/docs/next/zh-cn/plugin/operations.md
+++ b/src/content/docs/next/zh-cn/plugin/operations.md
@@ -1,0 +1,152 @@
+---
+title: 插件运维与配置
+keywords: [插件管理, PluginConfigSpec, plugin-configs.json, 运行时配置, Console]
+description: 说明 Nacos 插件状态、配置来源、敏感值、运行时更新、持久化、控制台和排障方法。
+sidebar:
+    order: 2
+---
+
+# 插件运维与配置
+
+本文面向 Nacos 运维人员和平台管理员，说明如何读取插件清单、区分模块开关与插件状态，以及如何安全地更新实现配置。
+
+## 清单和详情
+
+新控制台的“平台管理 → 插件管理”按 `pluginType` 展示已加载插件。对应 Admin API 为：
+
+| 方法 | 路径 | 用途 |
+| --- | --- | --- |
+| `GET` | `/v3/admin/core/plugin/list` | 列出已加载插件，可按 `pluginType` 过滤。 |
+| `GET` | `/v3/admin/core/plugin/detail` | 查询一个插件的状态、definition、有效配置和值元数据。 |
+| `PUT` | `/v3/admin/core/plugin/status` | 更新实现状态。 |
+| `PUT` | `/v3/admin/core/plugin/config` | 替换一个配置来源的完整 override map。 |
+
+Console API 提供等价代理路径 `/v3/console/plugin/*`。详细参数见 [Admin API](../manual/admin/admin-api.md) 和 [Console API](../manual/admin/console-api.md)。
+
+列表和详情中的关键字段：
+
+| 字段 | 含义 |
+| --- | --- |
+| `pluginId` | `{pluginType}:{pluginName}`。 |
+| `enabled` | 当前节点上实现是否允许参与领域执行。 |
+| `executionMode` | `EXCLUSIVE`、`CHAIN`、`ROUTED` 或 `BROADCAST`。 |
+| `exclusive` | 为兼容保留，等价于 `executionMode=EXCLUSIVE`。 |
+| `typeCritical` | 该插件类型是否可能成为 critical。 |
+| `critical` | 当前状态下这个具体实现是否不能单独禁用。 |
+| `configurable` | 是否声明了至少一个有效 `ConfigItemDefinition`。 |
+| `config` | 已接受并实际生效的 item-key 配置快照；敏感值已脱敏。 |
+| `configDefinitions` | 配置定义，包括 alias、类型、默认值、必填、敏感和 effect mode。 |
+| `configValueMetas` | 每个 canonical item key 的 `source` 与 `overridden`。 |
+
+## 配置 definition
+
+`ConfigItemDefinition.key` 是实现内的 item key，不带完整前缀。静态配置使用：
+
+```text
+nacos.plugin.{pluginType}.{pluginName}.{itemKey}
+```
+
+| 元数据 | 运维含义 |
+| --- | --- |
+| `aliases` | 历史静态 key。读取或 API 输入时可兼容，但会记录迁移 WARN；持久化只保存 canonical item key。 |
+| `type` | `STRING`、`NUMBER`、`BOOLEAN` 或 `ENUM`。 |
+| `defaultValue` | 没有更高优先级来源时使用。 |
+| `required` | 最终值必须存在。 |
+| `sensitive` | 详情响应脱敏，日志不得输出值。 |
+| `effectMode` | `RUNTIME` 可运行时更新；`RESTART` 只能通过静态配置并重启生效。 |
+
+definition 归一化采用 first-wins。空 key、保留 key `enabled`、重复 key，以及与先前 key/alias 冲突的后来 definition 或 alias 都会被忽略并记录 WARN。
+
+## 配置来源和优先级
+
+对 `STANDARD` 插件，有效值按以下顺序解析：
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+| source | 含义 | 是否持久化/同步 |
+| --- | --- | --- |
+| `DEFAULT` | definition 默认值。 | 否 |
+| `STATIC` | `application.properties`、环境变量、JVM 或 Spring 参数。 | 由部署系统管理 |
+| `RUNTIME_PERSISTED` | 集群运行时 override。 | 是，进入插件配置持久化和集群同步 |
+| `LOCAL_ONLY` | 当前节点诊断或应急 override。 | 否 |
+
+`configValueMetas.source` 是当前有效值的来源。`overridden=true` 表示同一个 key 同时存在多个非默认来源；它不把 `DEFAULT` 计入覆盖判断。
+
+运行时持久化配置的落盘文件是 `${nacos.home}/data/plugin/plugin-configs.json`。该文件由 Nacos 管理，不要手工编辑。它只保存 `pluginId + itemKey + value`，不保存 alias、完整静态 key、source 或版本。插件 enabled 状态由独立的统一状态路径管理，不写入这个配置文件。
+
+## 更新语义
+
+`PUT .../plugin/config` 的 `config` 是目标来源的**完整 map**，不是 patch：
+
+- `localOnly=false` 替换 `RUNTIME_PERSISTED` 的完整 map。
+- `localOnly=true` 替换当前节点 `LOCAL_ONLY` 的完整 map。
+- 提交空 map 会清除该来源对这个插件的全部 override。
+- 省略某个现有 key 表示移除它；只有 `RUNTIME` 字段允许在运行时增加、修改或移除。
+- canonical item key、完整标准 key 和唯一匹配的 alias 都会先归一化成 item key。未声明或歧义 key 会返回参数校验错误。
+
+例如，只对当前节点覆盖默认鉴权 token 过期时间：
+
+```shell
+curl -X PUT 'http://127.0.0.1:8848/nacos/v3/admin/core/plugin/config' \
+  -d 'pluginType=auth' \
+  -d 'pluginName=nacos' \
+  -d 'config={"token.expire.seconds":"3600"}' \
+  -d 'localOnly=true'
+```
+
+同一个插件的更新会串行执行。持久化更新遵循“先持久化来源，再解析/校验，再 apply”。如果持久化失败，内存来源和插件都不改变；如果持久化成功但 `applyConfig` 失败，新来源仍被保留，API 返回明确错误。修复插件后可以重新提交同一个完整 map 触发人工重试。
+
+## `RUNTIME` 与 `RESTART`
+
+启动 apply 可以接收两种字段。运行时 PUT 只能改变 `RUNTIME` 字段；对 `RESTART` 字段的增加、修改或删除都会被拒绝。
+
+服务端静态配置刷新也会遵守相同边界：
+
+- `RUNTIME` 静态值变化会重新解析并按需调用 `applyConfig`。
+- `RESTART` 静态值变化只记录 WARN，当前进程继续使用启动时已接受的快照。
+- 详情返回已生效快照，不把尚未重启生效的新静态值误报为 effective。
+
+要修改 `RESTART` 字段，请更新所有节点的静态配置并按计划滚动重启。
+
+## 敏感值
+
+敏感字段在详情中使用包含 `******` 的脱敏值。提交更新时，任何包含标准 marker 的值（包括前后保留部分的形式）都表示“保留目标来源原值”：
+
+- 如果目标来源已有该 key，Nacos 保留同一来源中的原值。
+- 如果目标来源没有该 key，输入被忽略，不会把 `STATIC` 等其他来源的有效值复制成 runtime override。
+
+因此控制台编辑敏感值时可以原样提交脱敏展示值而不覆盖秘密。需要真的变更秘密时，提交不含 masked marker 的新值。日志只记录 `pluginId`、item key 和目标 source，不能记录秘密。
+
+## 状态更新和 critical 校验
+
+状态 API 支持集群持久化更新和 `localOnly=true` 的当前节点更新，但不是所有类型都能运行时切换：
+
+- `EXCLUSIVE` 类型由静态 `type` key 在启动时选择，状态 API 不用于切换实现。
+- active critical 类型必须保留策略要求的 enabled provider；违反要求的更新会在持久化和应用前被拒绝。
+- `environment` 是启动前插件，运行时状态更新被拒绝。
+- `control` 的 manager bundle 在启动阶段构建，当前也拒绝运行时选择变更。
+
+模块开关不会被状态 API 修改。例如关闭 `nacos.plugin.visibility.enabled` 会阻止可见性流程执行，即使 `visibility:nacos` 仍显示 loaded 和 enabled。
+
+## 新控制台行为
+
+Next Console 的插件详情以 detail API 为唯一事实源：
+
+- `RUNTIME` definition 可编辑；`RESTART` definition 只读，并提示修改静态配置后重启。
+- 显示每个值的 effective source 和 overridden 状态。
+- 将“集群运行时持久化”和“仅当前节点”作为两个明确模式。
+- 构造提交 map 时只保留属于目标 source 的 override，不会把 `STATIC`/`DEFAULT` 有效值复制进去。
+- 当前节点存在 `LOCAL_ONLY` override 时，控制台会阻止集群配置提交，避免覆盖被隐藏的较低优先级 persisted 值。先清空本地 override，再编辑集群配置。
+
+本文只描述 Next Console；Legacy Console 不提供这套统一配置编辑工作流。
+
+## 启动和排障检查
+
+1. 确保集群所有节点使用同版本插件 JAR 和依赖。
+2. 检查 plugin list 中目标 `pluginId` 是否在所有节点可用。
+3. 区分模块总开关、exclusive 选择 key、实现状态和实现配置。
+4. 查看详情中的 `source`，确认期望值是否被 `LOCAL_ONLY` 或 `RUNTIME_PERSISTED` 覆盖。
+5. 对 `RESTART` 配置确认节点已经重启。
+6. 出现重复 ID、definition key 或 alias WARN 时，移除冲突实现/定义，不要依赖 SPI 扫描顺序。

--- a/src/content/docs/next/zh-cn/plugin/overview.md
+++ b/src/content/docs/next/zh-cn/plugin/overview.md
@@ -1,70 +1,113 @@
 ---
-title: 插件化概览
-keywords: [插件, SPI, 扩展, Plugin]
-description: 本文介绍 Nacos 插件化体系的通用设计、加载方式、使用原则和各类插件入口。
+title: 插件体系概览
+keywords: [插件, PluginType, SPI, PluginConfigSpec, 插件管理]
+description: 了解 Nacos 统一插件身份、执行模式、状态、配置和生命周期，以及当前所有服务端插件类型。
 sidebar:
     order: 1
 ---
 
-# 插件化概览
+# 插件体系概览
 
-Nacos 的插件化体系用于把可替换、可扩展的能力从核心流程中解耦出来。用户可以按需选择官方默认实现、官方可选插件、社区插件，也可以根据企业内部的安全、数据库、审计、观测和治理要求开发自定义插件。
+Nacos 使用插件把鉴权、数据库方言、可见性、审计、流量防护和 AI 扩展等可替换能力与核心领域模型分离。服务端插件由领域 SPI 提供行为，并由统一插件管理体系提供清单、状态、配置和诊断能力。
 
-插件机制主要面向两类人：
+本文介绍服务端统一管理的插件。Java 客户端中的 `ClientAuthService`、`IConfigFilter`、`ServerListProvider` 等扩展运行在客户端进程中，不会出现在服务端插件管理 API 或控制台中。
 
-- 使用者和运维人员：需要知道某类能力是否可以通过插件启用，插件应该放在哪里，哪些配置需要保持集群一致。
-- 开发者和集成方：需要知道插件 SPI 的边界，如何声明实现类，如何避免插件影响 Nacos 主链路稳定性。
+## 插件身份
 
-## 插件加载方式
+每个服务端插件由类型和实现名唯一标识：
 
-Nacos 插件大多基于 Java SPI 加载。插件 JAR 中需要在 `META-INF/services` 下声明对应 SPI 接口的实现类。Nacos 启动时通过 `NacosServiceLoader` 发现实现，再由各插件类型的 `PluginProvider` 汇总成统一的插件信息。
+```text
+pluginId = pluginType:pluginName
+```
 
-在部署时，通常有两种方式让 Nacos 加载插件：
+例如，默认鉴权插件是 `auth:nacos`，LDAP 鉴权插件是 `auth:ldap`，AI 官方 MCP 导入来源是 `ai-resource-import:mcp-official`。
 
-1. 将插件 JAR 放入 `${nacos.home}/plugins`。
-2. 将插件 JAR 和所需依赖加入 Nacos Server 启动 classpath。
+- `pluginType` 表示扩展类别，由 Nacos 的 `PluginType` 注册表定义。
+- `pluginName` 是该类别下稳定且唯一的实现名。
+- `pluginId` 用于管理 API、插件状态、持久化配置和诊断日志。插件升级时不要随意修改它。
 
-生产集群中，所有 Nacos Server 节点应使用相同版本的插件 JAR、依赖 JAR 和插件配置。尤其是鉴权、数据源、可见性、配置变更、环境变量处理这类会影响请求结果或数据读写的插件，更需要先在测试环境完成验证。
+发现插件时采用确定性的 **first-wins** 规则。空实现、空名称和后到达的重复 `pluginId` 会被忽略并记录 WARN，已经注册的实现不会被覆盖。配置 definition 的 key 或 alias 冲突也采用 first-wins，并忽略后来冲突项。
 
-## 插件选择规则
+## 当前插件类型
 
-不同插件类型的启用方式并不完全相同。阅读子文档时，需要注意以下差异：
+| pluginType | 执行模式 | 类型级 critical | 初始化阶段 | 主要用途 |
+| --- | --- | --- | --- | --- |
+| `auth` | `EXCLUSIVE` | 是 | `STANDARD` | 选择一个鉴权实现。 |
+| `datasource-dialect` | `EXCLUSIVE` | 是 | `STANDARD` | 选择数据库 SQL 方言和 mapper 族。 |
+| `config-change` | `CHAIN` | 否 | `STANDARD` | 按 pointcut 和顺序执行配置变更插件。 |
+| `encryption` | `ROUTED` | 否 | `STANDARD` | 按密文 dataId 中的算法名路由。 |
+| `trace` | `BROADCAST` | 否 | `STANDARD` | 向所有匹配且启用的订阅者广播事件。 |
+| `environment` | `CHAIN` | 否 | `PRE_CONTEXT` | 在 Spring 上下文创建前按顺序转换环境配置。 |
+| `control` | `EXCLUSIVE` | 否 | `STANDARD` | 启动时选择一个流量防护 manager 实现。 |
+| `visibility` | `ROUTED` | 否 | `STANDARD` | 根据领域请求路由可见性实现。 |
+| `ai-pipeline` | `CHAIN` | 否 | `STANDARD` | 按顺序执行 AI 资源发布审核节点。 |
+| `ai-storage` | `ROUTED` | 是 | `STANDARD` | 按 `StorageKey.provider` 路由内容存储。 |
+| `ai-resource-import` | `ROUTED` | 否 | `STANDARD` | 按 `sourceId` 路由一个确定的外部来源。 |
 
-- **单选型插件**：同一时间通常只选择一个实现。例如鉴权插件通过 `nacos.core.auth.system.type` 选择实现，数据源方言插件通过 `spring.sql.init.platform` 选择数据库类型。
-- **多实现插件**：可以同时加载多个实现，并由插件内部顺序或订阅关系决定执行方式。例如配置变更插件、Trace 插件可以有多个实现。
-- **默认实现和可选实现**：Nacos 发行包中会包含部分默认实现；LDAP、OIDC/OAuth、社区数据源、加密等能力可能需要引入独立插件或扩展包。
-- **统一插件状态和业务配置不同**：Nacos 3.2 起有统一插件管理能力，但具体插件是否真正参与业务流程，仍需要按对应插件文档配置。例如配置变更插件、环境变量插件和流量防护插件都有自己的启用配置。
+`critical` 是类型能力，不表示该类型的每个实现永远都不能禁用。只有类型当前处于 active 状态时，`PluginTypePolicy` 才会校验领域实际要求的 provider。详情中的 `critical=true` 表示这个具体实现当前不能单独禁用；`typeCritical` 表示该类型具备 critical 能力。
 
-## 插件开发原则
+集群寻址文档仍放在插件目录中，但当前寻址实现使用 `MemberLookup`，不属于 `PluginType`，也不受统一插件管理 API 管理。参见[集群寻址](./address-plugin.md)。
 
-开发插件时，建议遵循以下原则：
+## 四种执行模式
 
-- **只扩展明确的 SPI 边界**：不要依赖 Nacos 内部非公开类作为长期稳定契约。确实需要参考实现时，以目标版本源码为准。
-- **插件名称稳定且唯一**：插件名称会用于配置选择、日志识别和插件状态管理。名称变更会影响升级和运维。
-- **避免阻塞主链路**：涉及网络、磁盘、审计系统、外部 KMS、Webhook 的插件应设置超时、失败降级和独立线程池。
-- **不在插件中硬编码敏感信息**：密钥、token、数据库密码等应来自安全配置、环境变量或企业密钥系统。
-- **版本严格匹配**：插件 API 可能随 Nacos 版本演进。升级 Nacos 前，请同时验证插件版本、依赖版本和配置兼容性。
-- **先验证再上线**：上线前至少验证插件加载日志、核心读写路径、异常降级、节点重启、滚动升级和回滚。
+- `EXCLUSIVE`：启动时选择一个实现。选择 key 为 `nacos.plugin.{pluginType}.type`，当前不支持通过运行时状态 API 切换。
+- `CHAIN`：所有符合领域条件且状态为 enabled 的实现按稳定顺序执行。
+- `ROUTED`：可以同时加载多个实现，领域根据算法名、provider、`sourceId` 或请求上下文选择一个 enabled 实现。
+- `BROADCAST`：所有订阅目标事件且状态为 enabled 的实现都会收到事件。
 
-## 插件文档入口
+统一插件管理负责 loaded/enabled/config；具体如何选择、排序、失败中止或降级，由对应领域 SPI 定义。
 
-| 插件 | 适用场景 |
-|-----|---------|
-| [鉴权插件](./auth-plugin.md) | 接入默认 RBAC、LDAP、OIDC/OAuth2 或自定义身份认证和权限校验。 |
-| [可见性插件](./visibility-plugin.md) | 控制 AI 资源等对象对当前调用者是否可见，常与鉴权插件配合使用。 |
-| [多数据源插件](./datasource-plugin.md) | 使用 MySQL、PostgreSQL、Oracle、Derby 或社区数据库方言插件。 |
-| [配置加密插件](./config-encryption-plugin.md) | 对敏感配置内容进行加密存储和读取解密。 |
-| [配置变更插件](./config-change-plugin.md) | 在配置发布、删除、导入等操作前后做校验、审计或 Webhook 通知。 |
-| [轨迹追踪插件](./trace-plugin.md) | 订阅 Nacos 内部操作事件，用于审计、排障和运维观测。 |
-| [自定义环境变量插件](./custom-environment-plugin.md) | 在 Nacos 读取配置项时做自定义转换，例如数据库密码解密。 |
-| [流量防护插件](./control-plugin.md) | 对连接数、TPS 等访问流量进行限制，保护服务端稳定性。 |
-| [集群寻址机制](./address-plugin.md) | 配置 Nacos Server 集群成员发现方式，例如 `file` 和 `address-server`。 |
-| [AI 发布 Pipeline 插件](./ai-pipeline-plugin.md) | 在 Skill、Prompt、MCP、AgentSpec 等 AI 资源发布前接入审核、扫描或拦截。 |
-| [AI 资源导入插件](./ai-resource-import-plugin.md) | 从 MCP registry、Skill 市场或企业内部资源库导入 AI 资源。 |
-| [AI 存储插件](./ai-storage-plugin.md) | 为 AI 资源版本内容接入自定义存储 provider。 |
+## 状态、模块开关和选择配置
 
-## 关联建议
+下列概念不能混用：
 
-如果你只是部署和运维 Nacos，建议优先阅读鉴权、可见性、多数据源、配置加密、流量防护、集群寻址机制和 AI 资源导入。它们直接影响生产环境的安全边界、数据存储、稳定性和资源来源。
+| 层次 | 职责 | 示例 |
+| --- | --- | --- |
+| 模块或能力总开关 | 决定核心流程是否进入某类插件能力，也可用于延迟加载整个类型。 | `nacos.extension.ai.enabled`、`nacos.plugin.visibility.enabled`、`nacos.plugin.ai-pipeline.enabled` |
+| 类型选择 key | 为 `EXCLUSIVE` 类型选择启动实现，变更后需要重启。 | `nacos.plugin.auth.type=nacos` |
+| 实现初始状态 | 为非单选实现提供未持久化状态覆盖时的启动默认值。 | `nacos.plugin.trace.audit.enabled=true` |
+| 统一插件状态 | 运行时决定已加载实现能否参与执行；可持久化到集群，也可只改当前节点。 | 插件状态 PUT API |
+| 实现配置 | 只包含该实现自己声明的 definition，不负责模块开关或实现选择。 | `nacos.plugin.auth.nacos.token.expire.seconds` |
 
-如果你需要开发插件，建议先读本页，再阅读目标插件的 SPI、加载方式和故障降级说明。不同插件接入点不同，不建议照搬另一个插件的配置项或生命周期。
+已加载不等于已启用；实现已启用也不能绕过模块总开关。类型级延迟加载只影响首次发现：一个非 critical 类型因总开关关闭而未加载时，开启总开关会触发一次发现、状态恢复和配置 apply；之后再次关闭总开关只停止领域执行，不会卸载实例。
+
+## 统一配置
+
+实现通过 `PluginConfigSpec` 声明 `ConfigItemDefinition`。标准静态 key 是：
+
+```text
+nacos.plugin.{pluginType}.{pluginName}.{itemKey}
+```
+
+definition 可声明 `key`、`aliases`、`type`、`defaultValue`、`required`、`sensitive` 和 `effectMode`。`enabled` 保留给插件状态，不能作为普通 definition key。
+
+`STANDARD` 插件的有效值优先级是：
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+`PRE_CONTEXT` 的 `environment` 插件只读取 `STATIC > DEFAULT`。它必须在 Spring 上下文创建前生效，因此所有配置和状态变更都要求重启，不能通过运行时 API 更新。
+
+完整的配置来源、敏感值、`RUNTIME`/`RESTART` 语义和管理 API 用法见[插件运维与配置](./operations.md)。
+
+## 加载和生命周期
+
+常规 `STANDARD` 插件在 Spring 上下文刷新后由统一管理器初始化。启动时会先加载运行时持久化配置，再对每个 configurable 实现计算完整有效配置并调用 `applyConfig`。实现即使没有 runtime override，也会收到启动配置。
+
+需要在配置完成后创建运行资源的适配器可以实现 `PluginStartupLifecycle`。统一管理器只对 enabled 实现调用幂等的 `initialize()`。这个回调不代表插件天然支持运行时资源替换；未定义替换和关闭生命周期的类型仍必须拒绝相关运行时切换。
+
+`environment` 在 `PRE_CONTEXT` 阶段发现、解析和 apply，后续统一管理器复用同一实例和已接受快照，不能再次加载。
+
+## 阅读路径
+
+- 运维人员：先读[插件运维与配置](./operations.md)，再读目标插件族页面。
+- 插件开发者：先读[插件开发指南](./development.md)，再核对目标领域 SPI。
+- 从旧 key 或旧 SPI 升级：阅读[插件迁移指南](./migration.md)。
+
+| 插件族 | 文档 |
+| --- | --- |
+| 鉴权与可见性 | [鉴权插件](./auth-plugin.md)、[可见性插件](./visibility-plugin.md) |
+| 数据与配置 | [多数据源](./datasource-plugin.md)、[配置加密](./config-encryption-plugin.md)、[配置变更](./config-change-plugin.md) |
+| 稳定性与观测 | [轨迹追踪](./trace-plugin.md)、[自定义环境变量](./custom-environment-plugin.md)、[流量防护](./control-plugin.md) |
+| AI 扩展 | [AI 发布 Pipeline](./ai-pipeline-plugin.md)、[AI 资源导入](./ai-resource-import-plugin.md)、[AI 存储](./ai-storage-plugin.md) |

--- a/src/content/docs/next/zh-cn/plugin/overview.md
+++ b/src/content/docs/next/zh-cn/plugin/overview.md
@@ -26,7 +26,7 @@ pluginId = pluginType:pluginName
 - `pluginName` 是该类别下稳定且唯一的实现名。
 - `pluginId` 用于管理 API、插件状态、持久化配置和诊断日志。插件升级时不要随意修改它。
 
-发现插件时采用确定性的 **first-wins** 规则。空实现、空名称和后到达的重复 `pluginId` 会被忽略并记录 WARN，已经注册的实现不会被覆盖。配置 definition 的 key 或 alias 冲突也采用 first-wins，并忽略后来冲突项。
+同一插件类型的 Provider 按 `PluginProvider.getOrder()` 升序处理；order 相同时保持 SPI 服务发现顺序，随后再执行确定性的 **first-wins** 注册。空实现、空名称和后到达的重复 `pluginId` 会被忽略并记录 WARN，已经注册的实现不会被覆盖。配置 definition 的 key 或 alias 冲突也采用 first-wins，并忽略后来冲突项。
 
 ## 当前插件类型
 

--- a/src/content/docs/next/zh-cn/plugin/trace-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/trace-plugin.md
@@ -3,7 +3,7 @@ title: 轨迹追踪
 keywords: [轨迹追踪, 操作审计, 诊断, Trace Plugin]
 description: 本文介绍 Nacos Trace 插件的事件模型、适用场景、开发方式和稳定性建议。
 sidebar:
-    order: 7
+    order: 10
 ---
 
 # 轨迹追踪插件
@@ -11,6 +11,8 @@ sidebar:
 Nacos Trace 插件用于订阅 Nacos 内部资源操作事件，帮助运维人员做审计、排障和诊断。它记录的是 Nacos 领域事件，例如服务注册、服务推送、实例健康状态变化、AI 资源操作等。
 
 它不是应用服务之间的分布式链路追踪。如果需要观察业务服务之间的调用链，请使用 OpenTelemetry、SkyWalking、Zipkin 等链路追踪体系。
+
+在统一插件管理中，本插件类型为 `trace`，执行模式为 `BROADCAST`，加载阶段为 `STANDARD`，类型非 critical。插件身份是 `trace:{getName()}`。同一事件可以广播给多个启用的订阅者；禁用状态会在每次分发前检查，无需重建订阅关系。
 
 ## 适用场景
 
@@ -60,7 +62,7 @@ AI 资源相关事件：
 
 `DeregisterInstanceTraceEvent` 会携带注销原因。常见值包括 `REQUEST`、`NATIVE_DISCONNECTED`、`SYNCED_DISCONNECTED` 和 `HEARTBEAT_EXPIRE`。
 
-Nacos 默认提供了 AI 资源 Trace 日志订阅者，会将 `AiResourceTraceEvent` 写入 `ai-resource-trace.log`，用于兼容 AI 资源审计日志。
+Nacos 默认提供 `trace:ai-resource-trace-log`，将 `AiResourceTraceEvent` 写入 `ai-resource-trace.log`，用于兼容 AI 资源审计日志。该实现默认启用、不声明配置 definitions，因此 `configurable=false`。
 
 ## 启用插件
 
@@ -90,10 +92,12 @@ Nacos 3.2 起，Trace 插件也会暴露给统一插件管理，插件类型为 
 
 | 方法 | 说明 |
 |-----|------|
-| `getName()` | 稳定订阅者名称。重复名称会被后加载的实现覆盖。 |
+| `getName()` | 稳定订阅者名称。重复身份按 first-wins 处理，后发现的实现被忽略并记录 WARN。 |
 | `subscribeTypes()` | 返回希望订阅的事件类列表。 |
 | `onEvent(event)` | 处理事件。 |
 | `executor()` | 可选执行器。涉及慢 IO 时建议返回独立线程池。 |
+
+`NacosTraceSubscriber` 继承 `PluginConfigSpec`。有私有配置的新实现应通过 definitions 声明元数据，使用 `nacos.plugin.trace.{pluginName}.{itemKey}` 标准键，并实现 `applyConfig` 与当前快照；未实现 definitions 的旧二进制订阅者仍可加载，但显示为不可配置。
 
 最小示例：
 
@@ -140,4 +144,4 @@ Trace Event Publish failed, event : ..., publish queue size : ...
 | 插件没有收到事件 | 检查 JAR、`META-INF/services`、`getName()` 和 `subscribeTypes()`。 |
 | 事件处理阻塞 | 检查是否在 `onEvent()` 中执行慢 IO，必要时实现 `executor()`。 |
 | 日志出现 Trace Event Publish failed | 说明 Trace 队列压力过大，检查订阅者处理速度和外部 sink。 |
-| 同名插件行为异常 | 检查是否有多个订阅者返回相同 `getName()`。 |
+| 同名插件行为异常 | 检查 WARN；first-wins 会保留先发现的订阅者并忽略后来项。 |

--- a/src/content/docs/next/zh-cn/plugin/visibility-plugin.md
+++ b/src/content/docs/next/zh-cn/plugin/visibility-plugin.md
@@ -3,7 +3,7 @@ title: 可见性插件
 keywords: [可见性, 插件, 鉴权, AI 管理中心]
 description: 本文介绍 Nacos 可见性插件的用途、默认实现、配置方式，以及它和鉴权插件的关系。
 sidebar:
-    order: 3
+    order: 6
 ---
 
 # 可见性插件
@@ -44,7 +44,7 @@ sidebar:
 
 ## 默认可见性实现
 
-Nacos 默认提供名为 `nacos` 的可见性实现。它由默认 Nacos 鉴权实现提供，当前主要服务于 AI 管理中心资源。
+Nacos 默认提供 `visibility:nacos`。`visibility` 是 `ROUTED`、非 critical、`STANDARD` 类型；默认实现没有私有 definitions，因此 `configurable=false`。
 
 默认行为如下：
 
@@ -64,33 +64,37 @@ Nacos 默认提供名为 `nacos` 的可见性实现。它由默认 Nacos 鉴权�
 
 ## 配置方式
 
-默认配置中已经包含可见性插件配置：
+需要区分能力总开关、历史选择和实现状态：
 
 ```properties
+# 能力总开关：关闭时不执行，并延迟首次加载
 nacos.plugin.visibility.enabled=true
+
+# 内置实现的初始统一状态
+nacos.plugin.visibility.nacos.enabled=true
+
+# 历史实现选择，只用于启动初始状态兼容
 nacos.plugin.visibility.type=nacos
 ```
 
-如果使用默认 `nacos` 可见性实现，请同时开启 Nacos 鉴权能力。默认实现会复用鉴权上下文中的用户信息。
+family gate 默认开启。关闭后即使实现仍显示 loaded/enabled 也不会执行；重新开启会在尚未加载时触发一次发现、状态恢复和配置 apply。持久化统一状态优先于 `type` 和静态 `{serviceName}.enabled`。
+
+如果使用默认实现，请同时开启 Nacos 鉴权。它复用鉴权上下文中的用户信息。
 
 ```properties
-nacos.core.auth.system.type=nacos
+nacos.plugin.auth.type=nacos
 nacos.core.auth.enabled=true
 nacos.core.auth.admin.enabled=true
 nacos.core.auth.console.enabled=true
 ```
 
-插件专属配置可以使用以下前缀：
+自定义实现只有声明 `PluginConfigSpec` definitions 后才可配置，canonical full key 为：
 
 ```properties
-nacos.plugin.visibility.{serviceName}.*
+nacos.plugin.visibility.{serviceName}.{itemKey}
 ```
 
-例如自定义插件名是 `example`，可以读取：
-
-```properties
-nacos.plugin.visibility.example.timeout=3000
-```
+不要把未声明的任意属性当作统一配置。旧二进制实现或零 definition 实现仍可加载，但显示 `configurable=false`。
 
 ## 可见性 SPI
 
@@ -98,11 +102,13 @@ nacos.plugin.visibility.example.timeout=3000
 
 | 方法 | 说明 |
 | --- | --- |
-| `getVisibilityServiceName()` | 返回插件名，需要和 `nacos.plugin.visibility.type` 对应。 |
-| `init(properties)` | 初始化插件专属配置。 |
+| `getVisibilityServiceName()` | 返回稳定 pluginName。 |
+| `init(properties)` | 已废弃的旧配置回调，只用于没有 definitions 的兼容实现。 |
 | `resolveDefaultScopeForCreate(identity, apiType, resourceType)` | 资源创建时，如果请求没有指定 `scope`，返回默认可见性。默认是 `PRIVATE`。 |
 | `validateVisibility(identity, action, apiType, resource)` | 判断单个资源是否对当前身份可见或可写。 |
 | `adviseQuery(identity, action, apiType, queryContext)` | 为列表和搜索生成可见性查询建议。 |
+
+`VisibilityService` 继承 `PluginConfigSpec`。新实现应声明 key/alias/type/default/required/sensitive/effectMode，实现原子 `applyConfig` 并返回当前快照。统一配置实现不会再调用旧 `init(Properties)`。运行时路由在调用前检查 `visibility:{serviceName}` 状态。
 
 ## 查询建议 QueryAdvisor
 

--- a/src/content/docs/next/zh-cn/quickstart/quick-start.mdx
+++ b/src/content/docs/next/zh-cn/quickstart/quick-start.mdx
@@ -110,8 +110,8 @@ nacos-setup --datasource-conf
 随后启动程序会提示您输入`3个`鉴权相关配置（Nacos从3.0.0版本开始默认启用控制台鉴权功能，因此如下3个鉴权相关配置必须填写）如下所示：
 
 ```
-`nacos.core.auth.plugin.nacos.token.secret.key` is missing, please set with Base64 string: ${your_input_token_secret_key}
-nacos.core.auth.plugin.nacos.token.secret.key` Updated:
+`nacos.plugin.auth.nacos.token.secret.key` is missing, please set with Base64 string: ${your_input_token_secret_key}
+nacos.plugin.auth.nacos.token.secret.key` Updated:
 ----------------------------------
 `nacos.core.auth.server.identity.key` is missing, please set: ${your_input_server_identity_key}
 `nacos.core.auth.server.identity.key` Updated:


### PR DESCRIPTION
## What changed

- align all next Chinese and English plugin documentation with the unified plugin identity, execution modes, state, configuration sources, and lifecycle
- add dedicated plugin operations, development, and migration guides
- document every current plugin family and built-in implementation, including exact configuration definitions, aliases, effect modes, gates, and routing or selection behavior
- replace the legacy AI Resource Import source/preset model with the four managed plugin sources and add the breaking-change migration guidance
- update the Next Console, Admin API, Maintainer SDK, system configuration, auth, deployment, upgrade, and cross-reference documentation

## Related issue

For alibaba/nacos#15475.

## Verification

- `git diff --check`
- bilingual plugin file and sidebar consistency check
- checked 568 relative links across the 76 changed next documents; no broken relative links found
- ran the full site build with the CI Node.js 18 runtime: all static routes and 1,491 search pages were generated; the command then hit the repository-wide existing `.html/` directory routing issue during Pagefind/Sitemap post-processing (`Cannot read properties of undefined (reading 'reduce')`)

Only `src/content/docs/next/{en,zh-cn}` is changed. Legacy and released-version documentation is untouched.
