### PR TITLE
docs: restructure next upgrade guide

### DIFF
--- a/src/content/docs/next/en/manual/admin/system-configurations.md
+++ b/src/content/docs/next/en/manual/admin/system-configurations.md
@@ -225,8 +225,8 @@ For auth setup, read [Authorization](./auth.mdx) and [OIDC/OAuth2 Authentication
 | Property | Description | Default |
 | --- | --- | --- |
 | `nacos.plugin.auth.type` | Select the auth implementation at startup; `nacos.core.auth.system.type` is a legacy alias. | `nacos` |
-| `nacos.core.auth.enabled` | Whether SDK/gRPC request authentication is enabled. | `false` |
-| `nacos.core.auth.admin.enabled` | Whether `/v3/admin/*` Admin API authentication is enabled. | `true` |
+| `nacos.core.auth.enabled` | Whether the general auth system and Open API authentication are enabled, including Client/Open HTTP APIs and SDK/gRPC requests. | `false` |
+| `nacos.core.auth.admin.enabled` | Whether Admin API scope authentication is enabled, including plugin-owned endpoints marked `ADMIN_API` as well as `/v3/admin/*`. | `true` |
 | `nacos.core.auth.console.enabled` | Whether `/v3/console/*` Console API and login authentication are enabled. | `true` |
 | `nacos.plugin.auth.nacos.caching.enabled` | Whether auth information is cached; `nacos.core.auth.caching.enabled` is a historical alias. Permission updates may have a short delay when enabled. | `true` |
 | `nacos.core.auth.server.identity.key` | Server-to-server identity key. Required when auth is enabled. | empty |
@@ -235,9 +235,10 @@ For auth setup, read [Authorization](./auth.mdx) and [OIDC/OAuth2 Authentication
 | `nacos.plugin.auth.nacos.token.cache.enable` | Default auth token cache; `nacos.core.auth.plugin.nacos.token.cache.enable` is a historical alias. | `false` |
 | `nacos.plugin.auth.nacos.token.expire.seconds` | Default auth token expiration in seconds; `nacos.core.auth.plugin.nacos.token.expire.seconds` is a historical alias. | `18000` |
 | `nacos.plugin.auth.nacos.token.secret.key` | JWT signing secret; sensitive and RESTART. `nacos.core.auth.plugin.nacos.token.secret.key` is a historical alias. | empty |
-| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | Whether anonymous AI resource reads are allowed; `nacos.core.auth.nacos.anonymous.ai.enabled` is a historical alias. | `false` |
+| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | Whether explicitly opted-in AI endpoints accept anonymous reads; `nacos.core.auth.nacos.anonymous.ai.enabled` is a historical alias. Explicit empty or invalid credentials never fall back to anonymous access. | `false` |
 | `nacos.plugin.visibility.enabled` | Whether the visibility plugin is enabled. | `true` |
-| `nacos.plugin.visibility.type` | Visibility plugin type. The default `nacos` implementation reuses default auth plugin user information. | `nacos` |
+| `nacos.plugin.visibility.type` | Deprecated `RESTART` selector that still chooses the implementation requested by the AI domain and contributes to initial state when no persisted state exists. | `nacos` |
+| `nacos.plugin.visibility.{pluginName}.enabled` | Static initial implementation state; persisted plugin state wins. The default `nacos` implementation reuses default auth plugin user information. | `true` for `nacos` |
 
 ### LDAP, OIDC, and OAuth2
 
@@ -258,7 +259,7 @@ For the plugin system, see [Plugin Overview](../../plugin/overview.md).
 | `nacos.plugin.control.type` | Select the control implementation at startup; `nacos.plugin.control.manager.type` is a legacy alias. | empty (no-limit) |
 | `nacos.plugin.control.rule.local.basedir` | Local directory for traffic control rules. | `${nacos.home}` |
 | `nacos.plugin.control.rule.external.storage` | External rule storage type. Requires a custom implementation. | empty |
-| `nacos.plugin.{pluginType}.{pluginName}.enabled` | Implementation startup state; persisted or local state can override it. | Defined by implementation and type policy |
+| `nacos.plugin.{pluginType}.{pluginName}.enabled` | Initial state for non-exclusive implementations; persisted or local state can override it. Exclusive types such as `auth`, `datasource-dialect`, and `control` use selectors instead. | Defined by implementation and type policy |
 | `nacos.plugin.{pluginType}.{pluginName}.{itemKey}` | Canonical key for an implementation definition. | Defined by the definition |
 
 Historical `nacos.core.config.plugin.{pluginName}.*` properties exist only for old config-change binaries. Nacos Server does not bundle webhook, whitelist, or fileformatcheck implementations. New implementations use `nacos.plugin.config-change.{pluginName}.{itemKey}`.
@@ -289,7 +290,7 @@ For usage, see [AI Registry Overview](../user/ai/ai-registry-overview.md). The p
 | `nacos.ai.skill.registry.enabled` | Whether the Skill Registry protocol adapter is enabled. When enabled, it exposes an independent port through `nacos.ai.registry.port`. | `false` |
 | `nacos.ai.registry.port` | AI Registry protocol adapter port. | `9080` |
 | `nacos.ai.mcp.registry.port` | Legacy property name. Deprecated. Use `nacos.ai.registry.port` instead. | `9080` |
-| `nacos.plugin.ai-pipeline.enabled` | Dynamic AI Pipeline family gate; when false, type loading is deferred. | `false` |
+| `nacos.plugin.ai-pipeline.enabled` | Dynamic AI Pipeline family gate; when false, type loading is deferred. | `true` |
 | `nacos.plugin.ai-pipeline.type` | Legacy startup chain used only to initialize node state when no persisted state exists. | empty |
 | `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions; only `order` is RUNTIME. | See the [AI Pipeline Plugin](../../plugin/ai-pipeline-plugin.md) page |
 | `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions; only `order` is RUNTIME. | See the [AI Pipeline Plugin](../../plugin/ai-pipeline-plugin.md) page |

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -33,387 +33,210 @@ Compatibility between Nacos 3.x server and client versions is as follows:
 
 ## 2. Upgrade Steps
 
-### 2.1. Distribution Upgrade
+:::caution[3.0.x and 3.1.x can upgrade directly to 3.3.x]
+This procedure supports direct upgrades from Nacos 3.0.x, 3.1.x, or 3.2.x to 3.3.x. It does not require an intermediate server upgrade to 3.2.x. For a 3.0.x or 3.1.x deployment, or any deployment that has not applied every 3.2.x database change, first follow the [Nacos 3.2.x Upgrade Guide](/en/docs/latest/manual/admin/upgrading/) to apply the schema prerequisites for the current database. Verify that the actual schema contains the structures required by 3.2.x, and then apply the 3.3.x delta in this guide.
 
-#### 2.1.1 Verify Database Schema
+Only the database schema prerequisites are required; do not add an intermediate 3.2.x server upgrade. Decide whether each SQL statement is needed from the actual table definitions, do not repeat DDL that has already been applied, and never run a complete initialization script against an existing database.
+:::
 
-Compare the schema file of your currently deployed Nacos version with the schema file for the target version and target database.
+### 2.1. Pre-upgrade Checks
 
-If there are schema changes, apply the database alterations first. MySQL example:
+Complete these preparations before upgrading a production cluster:
 
-```SQL
--- When upgrading from 2.0.X, execute all SQL statements below. When upgrading from versions later than 2.1.X, execute only the last three lines.
-ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
-ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
-ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT 'secret key';
-ALTER TABLE `his_config_info` ADD COLUMN `publish_type` varchar(50)  DEFAULT 'formal' COMMENT 'publish type gray or formal';
-ALTER TABLE `his_config_info` ADD COLUMN `gray_name` varchar(50)  DEFAULT NULL COMMENT 'gray name';
-ALTER TABLE `his_config_info` ADD COLUMN `ext_info`  longtext DEFAULT NULL COMMENT 'ext info';
+1. Confirm that the source cluster runs a supported 3.0.x, 3.1.x, or 3.2.x release, and record the exact patch version, deployment mode, and database type. If the source version predates 3.2.x or its actual schema does not contain every 3.2.x change, list the database operations that must be applied from the 3.2.x upgrade guide.
+2. Back up the database and each node's `data`, `conf`, `cluster.conf`, custom plugins, and their configuration. Every deployment must retain plugin state and runtime configuration under `data/plugin`. With Derby or another embedded store, `data` also contains the primary database and must be preserved in full.
+3. Inventory plugin JARs, implementation names, states, selection properties, and private configuration. Distinguish built-in plugins from custom and third-party plugins.
+4. Rehearse database changes, authentication, plugin loading, rolling upgrade, and rollback in staging with a production-like data copy.
+5. Avoid plugin runtime configuration changes during the upgrade. Submit configuration that depends on 3.3 plugin definitions only after every node has been upgraded.
+
+<a id="217-config-compatibility-migration-removal-nacos-330"></a>
+
+#### 2.1.1. Verify Historical Config Migration Is Complete
+
+Nacos 3.3 removes the pre-3.0 Config storage migration compatibility. It no longer migrates or double-writes between the legacy empty tenant (`tenant_id = ''`) and the default namespace `public`, and it no longer migrates rows from `config_info_beta` or `config_info_tag` to `config_info_gray`.
+
+Before stopping the last source-version node:
+
+1. Check for default-namespace configuration rows with `tenant_id = ''`. If any exist, verify that they have been migrated to `tenant_id = 'public'`, resolving rows with the same `data_id` and `group_id` first.
+2. Check whether business data still depends on `config_info_beta` or `config_info_tag`. If so, complete its migration to `config_info_gray` and the current `GrayRule` model before upgrading to 3.3.x.
+3. Verify default-namespace reads, formal publishing, beta/tag gray queries, and stopping gray releases.
+
+No corresponding data migration is needed if the deployment never used the default namespace or beta/tag gray release. If the migration format is uncertain, keep the source cluster available while completing and verifying the migration; do not expect 3.3 startup to perform it.
+
+For PostgreSQL deployments upgrading directly from 3.0.x, 3.1.x, 3.2.0, or 3.2.1, or deployments that skipped the 3.2.2 schema normalization, first complete the `tenant_id` not-null migration documented in the [3.2.x Upgrade Guide](/en/docs/latest/manual/admin/upgrading/).
+
+:::caution[A2A upgrade limitation in 3.3.0-BETA]
+This guide currently applies to Nacos 3.3.0-BETA. This release introduces RAD (RemoteAgentDiscovery), a protocol-neutral capability for remote Agent registration and discovery, which will gradually replace the previous A2A capability in the GA release. However, the current BETA release does not yet support a lossless upgrade of A2A data. After a direct upgrade from 3.1.x or 3.2.x to 3.3.0-BETA, existing A2A content cannot be queried. Deployments with existing A2A content should assess this impact and retain a backup before upgrading.
+:::
+
+### 2.2. Apply Database Changes
+
+Before starting any 3.3.x node, first follow the [3.2.x Upgrade Guide](/en/docs/latest/manual/admin/upgrading/) to apply the database prerequisites needed to bring the current source schema up to the 3.2.x schema level; this does not require starting a 3.2.x server. Then compare the resulting actual schema with the complete matching schema in the target 3.3.x distribution and convert the remaining differences into reviewed incremental DDL. Never execute a complete initialization file containing `CREATE TABLE` or `DROP TABLE` statements directly against an existing database.
+
+The target distribution provides `mysql-schema.sql`, `pg-schema.sql`, `oracle-schema.sql`, and `derby-schema.sql` under `conf`. After applying the 3.2.x schema prerequisites, pay particular attention to these additional 3.3.x changes:
+
+| Change | Scope and action |
+| --- | --- |
+| `permissions.resource` expands to 512 characters | The default auth and visibility plugins need a longer column for canonical resource identifiers. If the current column is shorter than 512 and explicit visibility grants will be used, run the matching `*-upgrade-visibility-permission-resource.sql` from the target distribution. Before running the MySQL script, verify that the InnoDB page size, row format, and unique-index length support `VARCHAR(512) utf8mb4`. |
+| New AI resource search relational tables | Nacos 3.3 adds `ai_resource_search_document`, `ai_resource_search_chunk`, and `ai_resource_task`. Before enabling `nacos.ai.ard.enabled`, extract and review only the required `CREATE TABLE` and index statements for these tables from the target main-datasource schema; never copy adjacent `DROP` statements. If any table already exists, prepare an `ALTER` or data-migration plan instead of dropping and recreating it. ARD is disabled by default, so these tables and vector storage are not startup requirements while it remains disabled. Creating them proactively during a planned maintenance window is recommended. |
+| PostgreSQL pgvector storage (optional) | Only when enabling the default PostgreSQL vector plugin, initialize pgvector objects and `ai_resource_search_embedding_pg` in the PostgreSQL datasource that stores embeddings. `conf/pg-ai-vector-schema.sql` is separate from the main `pg-schema.sql`, contains `CREATE EXTENSION` and destructive initialization statements, and requires the pgvector extension and sufficient database privileges. Only a fresh vector store may run it unchanged after review; existing tables require a backup and an incremental migration instead of rerunning the file. |
+| AI resource description column expansion | In PostgreSQL, Oracle, and Derby, expand `ai_resource.c_desc` and `ai_resource_version.c_desc` to 2048 when their current length is smaller. Generate reviewed `ALTER` statements from the actual table definition and target schema instead of assuming the default length from a particular 3.2.x patch. |
+| MySQL collation for fresh schemas | Fresh 3.3 MySQL schemas use the case-sensitive `utf8mb4_bin` collation for existing core tables. No general in-place collation migration is currently provided for existing databases. Do not bulk-alter production tables from the full schema; review case-sensitive identity requirements and use a separately validated migration plan if alignment is required. |
+
+:::note
+The three ARD-related relational tables use protocol-neutral AI resource search names. Do not rename them to ARD-specific tables even though ARD is currently their only consumer. PostgreSQL deployments that do not enable the default vector plugin do not need pgvector or the vector schema.
+:::
+
+:::caution[Check case conflicts before enabling ARD on MySQL]
+In the current target schema, existing AI resource tables use the case-sensitive `utf8mb4_bin` collation, while the new search tables still use `utf8mb4_unicode_ci`. Resource names or versions that differ only by case within the same namespace may therefore collide on search-table unique keys. Detect and resolve such data before enabling ARD. If conflicts exist, keep ARD disabled until the target schema and migration plan are aligned.
+:::
+
+### 2.3. Migrate Configuration and Plugins
+
+Nacos 3.3 unifies server-plugin identity, state, implementation selection, and private configuration. Use the target distribution's `conf/application.properties` as the migration template instead of overwriting it with the source-version file. See [System Configurations](./system-configurations.md) for commonly used parameters and [Plugin Migration Guide](../../plugin/migration.md) for migration semantics. The target distribution template remains the final parameter baseline for that release.
+
+#### 2.3.1. Default Auth Plugin
+
+The default implementation remains `nacos`, but it is managed as `auth:nacos` in the unified plugin system. Its selector and private properties move to the canonical `nacos.plugin.auth.*` namespace.
+
+| 3.0.x–3.2.x legacy property | 3.3 canonical property |
+| --- | --- |
+| `nacos.core.auth.system.type` | `nacos.plugin.auth.type` |
+| `nacos.core.auth.caching.enabled` | `nacos.plugin.auth.nacos.caching.enabled` |
+| `nacos.core.auth.plugin.nacos.token.*` | `nacos.plugin.auth.nacos.token.*` |
+| `nacos.core.auth.nacos.anonymous.ai.enabled` | `nacos.plugin.auth.nacos.anonymous.ai.enabled` |
+| `nacos.core.auth.ldap.*` | `nacos.plugin.auth.ldap.*`, using canonical kebab-case item names from the plugin definitions |
+| `nacos.core.auth.plugin.oidc.*` | `nacos.plugin.auth.oidc.*` |
+
+`nacos.core.auth.enabled`, `nacos.core.auth.admin.enabled`, `nacos.core.auth.console.enabled`, and `nacos.core.auth.server.identity.*` remain core auth gates or server identity properties. Do not move them into a plugin-private namespace.
+
+When a canonical property and a legacy alias are both present, the canonical property wins. An empty canonical value still suppresses the alias. The target template already contains `nacos.plugin.auth.type=nacos` and canonical defaults for `auth:nacos`. Explicitly copy retained values to canonical properties instead of keeping old and new properties side by side. The startup script specially migrates only a valid legacy token secret in `application.properties`; migrate all other auth values explicitly. LDAP, OIDC, and custom auth deployments should also review the [Auth Plugin](../../plugin/auth-plugin.md) page item by item.
+
+If anonymous AI access is enabled, an explicit empty or invalid `Authorization`, `accessToken`, username, or password is rejected instead of falling back to anonymous access. Anonymous callers must omit credentials completely; authenticated callers must send valid credentials.
+
+#### 2.3.2. Other Plugin Configuration
+
+| Domain | 3.0.x–3.2.x legacy configuration | 3.3 canonical model |
+| --- | --- | --- |
+| Datasource dialect | `spring.sql.init.platform`; the older `spring.datasource.platform` has been removed | `nacos.plugin.datasource-dialect.type` |
+| Datasource connection | `db.*` and JVM property `QUERYTIMEOUT` | `nacos.plugin.datasource.db.*` |
+| Traffic control | `nacos.plugin.control.manager.type` | `nacos.plugin.control.type` |
+| Config Change | `nacos.core.config.plugin.{pluginName}.*` | `nacos.plugin.config-change.{pluginName}.{itemKey}` and unified implementation state |
+| Visibility | `nacos.plugin.visibility.type` | This deprecated `RESTART` selector still chooses the implementation requested by the AI domain and contributes to initial state; `nacos.plugin.visibility.{pluginName}.enabled` or persisted state determines availability, while `nacos.plugin.visibility.enabled` remains the capability gate |
+| AI Pipeline | Comma-separated `nacos.plugin.ai-pipeline.type` and legacy camel-case items | Per-implementation `nacos.plugin.ai-pipeline.{pluginName}.enabled`, canonical kebab-case items, and unified state |
+| AI Resource Import | `nacos.ai.resource.import.enabled`, `nacos.plugin.ai.importer.*`, and Source/preset/list models | `nacos.plugin.ai-resource-import.enabled`, `nacos.plugin.ai-resource-import.{pluginName}.*`, and fixed managed sources |
+
+Legacy properties may remain readable as aliases during the compatibility window and produce migration warnings, but a present canonical property has higher priority. Persisted implementation state also overrides static `.enabled` initial values. Dialect and exclusive implementation selectors, and every field marked `RESTART`, must be changed through static configuration followed by a restart, not through the plugin configuration API.
+
+AI Resource Import now defaults to enabled when neither its canonical gate nor the legacy alias is configured. To keep it disabled after the upgrade, set this before rollout:
+
+```properties
+nacos.plugin.ai-resource-import.enabled=false
 ```
 
-Version 3.2.0 introduces new AI-related tables. The following tables must be created when upgrading to 3.3.X from any previous version:
+The legacy Importer/Source SPI, clonable Source/preset model, and configuration-based cloning of one importer to multiple endpoints have been removed. External implementations must migrate to `AiResourceImportServiceBuilder`. See [AI Resource Import migration](../../plugin/migration.md#ai-resource-import-breaking-change) for the detailed mapping and built-in sources.
 
-```SQL
-CREATE TABLE IF NOT EXISTS `pipeline_execution` (
-    `execution_id`  varchar(64)  NOT NULL COMMENT 'execution ID',
-    `resource_type` varchar(32)  NOT NULL COMMENT 'resource type',
-    `resource_name` varchar(256) NOT NULL COMMENT 'resource name',
-    `namespace_id`  varchar(128) DEFAULT NULL COMMENT 'namespace ID',
-    `version`       varchar(64)  DEFAULT NULL COMMENT 'version',
-    `status`        varchar(32)  NOT NULL COMMENT 'execution status',
-    `pipeline`      longtext     NOT NULL COMMENT 'pipeline node result JSON',
-    `create_time`   bigint(20)   NOT NULL COMMENT 'creation time',
-    `update_time`   bigint(20)   NOT NULL COMMENT 'update time',
-    PRIMARY KEY (`execution_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource publish review pipeline execution record';
+#### 2.3.3. Custom and Third-party Plugins
 
-CREATE TABLE IF NOT EXISTS `ai_resource` (
-    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'creation time',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'modification time',
-    `name` varchar(256) NOT NULL COMMENT 'resource name',
-    `type` varchar(32) NOT NULL COMMENT 'resource type',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT 'resource description',
-    `status` varchar(32) DEFAULT NULL COMMENT 'resource status',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'namespace ID',
-    `biz_tags` varchar(1024) DEFAULT NULL COMMENT 'business tags',
-    `ext` longtext DEFAULT NULL COMMENT 'extension information (JSON)',
-    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT 'source identifier (import/sync source)',
-    `version_info` longtext DEFAULT NULL COMMENT 'version information (JSON)',
-    `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT 'metadata version (optimistic lock)',
-    `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT 'visibility: PUBLIC/PRIVATE',
-    `owner` varchar(128) NOT NULL DEFAULT '' COMMENT 'creator username',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT 'download count',
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
-    KEY `idx_ai_resource_name` (`name`),
-    KEY `idx_ai_resource_type` (`type`),
-    KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource metadata table';
+- Record each implementation by its stable `pluginType:pluginName`, remove duplicate identities, and confirm that the target release discovers the intended JAR. Duplicate identities now resolve deterministically with the first implementation winning.
+- Older zero-configuration plugins usually remain binary-loadable, but they appear configurable only after implementing `PluginConfigSpec` definitions, a current configuration snapshot, and apply callbacks.
+- Older Config Change binaries remain loadable during the compatibility window but show `configurable=false`; migrate them to definitions and callbacks.
+- AI Pipeline no longer loads `PublishPipelineServiceBuilder`. Recompile pipeline plugins, register `PublishPipelineService` directly with a public no-argument constructor, and implement the unified configuration contract.
+- Third-party datasource plugins that implement or register the removed `ConfigInfoBetaMapper`, `ConfigInfoTagMapper`, or `ConfigMigrateMapper` SPIs must be rebuilt without those interfaces. Complete pre-3.0 data migration before upgrading.
+- The legacy AI Resource Import SPI has no adapter. Recompile the plugin and update its configuration and callers together; do not mix the two models.
+- Critical plugin types such as auth, datasource dialect, and AI storage can block startup when their selected implementation is missing, disabled, or fails initialization. Validate selection, state, and initialization in staging.
+- On one node, verify plugin list/detail, effective sources, masking, and `RESTART` guidance. Do not submit runtime configuration understood only by 3.3 nodes during a rolling upgrade.
 
-CREATE TABLE IF NOT EXISTS `ai_resource_version` (
-    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'creation time',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'modification time',
-    `type` varchar(32) NOT NULL COMMENT 'resource type',
-    `author` varchar(128) DEFAULT NULL COMMENT 'author',
-    `name` varchar(256) NOT NULL COMMENT 'resource name',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT 'version description',
-    `status` varchar(32) NOT NULL COMMENT 'version status',
-    `version` varchar(64) NOT NULL COMMENT 'version number',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'namespace ID',
-    `storage` longtext DEFAULT NULL COMMENT 'storage information (JSON)',
-    `publish_pipeline_info` longtext DEFAULT NULL COMMENT 'publish pipeline information (JSON)',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT 'download count',
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
-    KEY `idx_ai_resource_ver_name` (`name`),
-    KEY `idx_ai_resource_ver_status` (`status`),
-    KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI resource version table';
-```
+### 2.4. Distribution Upgrade
 
-If you use PostgreSQL and upgrade from 3.2.1 or earlier to 3.2.2, check whether `tenant_id` in the config-related tables is already `NOT NULL DEFAULT ''` before the upgrade. Nacos 3.2.2 validates the PostgreSQL schema during startup. If older tables still allow `tenant_id` to be null, the server may fail to start. See [alibaba/nacos#15275](https://github.com/alibaba/nacos/issues/15275) for the related discussion.
-
-Before running the migration, check whether `config_info` contains duplicate logical config rows. If multiple rows with the same `data_id` and `group_id` have `tenant_id IS NULL`, clean the conflict first, then run the migration SQL.
-
-```SQL
-SELECT data_id, group_id, COUNT(*)
-FROM config_info
-WHERE tenant_id IS NULL
-GROUP BY data_id, group_id
-HAVING COUNT(*) > 1;
-```
-
-After confirming there is no conflict, run `pg-upgrade-null-tenant-id.sql` from the target Nacos source. The SQL is:
-
-```SQL
-ALTER TABLE config_info ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE config_info SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE config_info ALTER COLUMN tenant_id SET NOT NULL;
-
-ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE config_info_gray SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET NOT NULL;
-
-ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE config_tags_relation SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET NOT NULL;
-
-ALTER TABLE his_config_info ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE his_config_info SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE his_config_info ALTER COLUMN tenant_id SET NOT NULL;
-```
-
-#### 2.1.2. Download the New Version
+#### 2.4.1. Download the Target Version
 
 <Tabs>
   <TabItem label="Official Website">
-    Go to the Nacos official [download page](/download/nacos-server/), select the [stable version](/download/nacos-server/#stable-version), and click the `${nacos.version}.zip` link in the `Binary Package` column to download.
+    Go to the Nacos [download page](/en/download/nacos-server/), choose a [stable version](/en/download/nacos-server/#stable-versions), and click `${nacos.version}.zip` in the `Binary Package` column.
 
-    > Note: During peak download times, you may encounter rate limiting. If the download fails, please wait and retry, or use the `GitHub download` method instead.
+    > If the download is rate-limited, retry later or use GitHub instead.
   </TabItem>
-  <TabItem label="Github">
-    Go to the Nacos GitHub [latest stable release](https://github.com/alibaba/nacos/releases), select the desired Nacos version, and download the `nacos-server-$version.zip` package from the `Assets` section.
+  <TabItem label="GitHub">
+    Go to the Nacos GitHub [releases page](https://github.com/alibaba/nacos/releases), select the target release, and download `nacos-server-${target_version}.zip` or the corresponding tar.gz asset.
   </TabItem>
 </Tabs>
 
-#### 2.1.3. Replace the Binary JAR
+#### 2.4.2. Prepare a New Installation Directory
 
-Extract the newly downloaded distribution package:
-
-```bash
-  unzip nacos-server-$version.zip
-  # or tar -xvf nacos-server-$version.tar.gz
-```
-
-Then locate `nacos/target/nacos-server.jar` and replace the JAR in the old distribution. For example:
+Extract the target distribution into a new directory:
 
 ```bash
-cp nacos/target/nacos-server.jar ${old.nacos.home}/target/
+unzip nacos-server-${target_version}.zip -d ${INSTALL_PARENT}
+# or tar -xvf nacos-server-${target_version}.tar.gz -C ${INSTALL_PARENT}
 ```
 
-#### 2.1.4. Update Configuration Files
+The 3.3 distribution contains a coordinated server JAR, default plugins, schemas, startup scripts, and configuration templates. Do not replace only `target/nacos-server.jar`, and do not overwrite the new `bin`, `conf`, or complete `plugins` directory with files from the source version.
 
-Nacos 3.0.X has significant configuration changes compared to Nacos 2.X, including many new server and console related settings, as well as parameter reordering. Please carefully compare the configuration files between the new and old versions and reconfigure accordingly.
+Migrate deployment-specific data as follows:
 
-Key parameter changes:
+- Start from the new `application.properties` and move the properties verified in section 2.3 one by one.
+- Compare and recreate `cluster.conf`, JVM options, log paths, certificates, and other deployment-specific files.
+- Copy only custom or third-party plugin JARs that passed 3.3 compatibility verification.
+- Every deployment must migrate or restore that node's existing `data/plugin` so `plugin-states.json` and `plugin-configs.json` are retained. With Derby or embedded storage, migrate the complete `data` only after shutdown and a full backup. An external-database cluster must not blindly copy active Raft data between nodes; reuse that node's own persistent volume or follow the rehearsed node-recovery procedure. Never let old and new processes use the same data directory concurrently.
 
-`server.port` --> `nacos.server.main.port`
+#### 2.4.3. Restart or Roll Through the Cluster
 
-`server.servlet.contextPath` --> `nacos.server.contextPath`
-
-#### 2.1.5. Update Startup Parameters (Optional)
-
-Compare the startup scripts (`bin/startup.sh` or `bin/startup.cmd`) between the old and new versions to check for new or modified parameters, and apply them to the old startup scripts. For example:
+For a standalone deployment, stop the old instance and start with the new distribution scripts:
 
 ```bash
-diff nacos/bin/startup.sh ${old.nacos.home}/bin/startup.sh
+${OLD_NACOS_HOME}/bin/shutdown.sh
+${NEW_NACOS_HOME}/bin/startup.sh -m standalone
 ```
 
-#### 2.1.6. Restart Nacos Server
+For a cluster, upgrade one node at a time. Stop one source-version node, start it with its 3.3 configuration and the new distribution, and wait until it rejoins the cluster and core behavior is healthy before proceeding to the next node. Do not change unified plugin runtime state or configuration until all nodes run 3.3.
 
-After all replacements are complete, restart Nacos Server:
+On Windows, use `shutdown.cmd` and `startup.cmd` from the new distribution rather than reusing the old scripts.
 
-```
-# Cluster mode example
-## Linux
-${nacos.home}/bin/shutdown.sh
-${nacos.home}/bin/startup.sh
+### 2.5. Docker/Kubernetes Upgrade
 
-## Windows
-${nacos.home}/bin/shutdown.cmd
-${nacos.home}/bin/startup.cmd
-```
-
-#### 2.1.7. Config Compatibility Migration Removal (Nacos 3.3.0+)
-
-:::caution[Pre-upgrade check for 3.3]
-Starting from Nacos 3.3.0, the server no longer keeps Config migration compatibility logic from versions before 3.0. It no longer automatically migrates or double-writes storage between legacy empty tenant values (`tenant_id = ''`) and the default namespace `public`, and it no longer automatically migrates gray data from the legacy `config_info_beta` and `config_info_tag` tables into the current `config_info_gray` model.
-:::
-
-This removal only affects historical storage migration compatibility. It does not change current Config semantics:
-
-- Blank or omitted namespace requests are still normalized to the default namespace. The current default namespace ID is `public`.
-- Current beta/tag gray release APIs remain available and are backed by the `config_info_gray` and `GrayRule` model.
-
-When upgrading from versions before 3.0 to 3.3.x, if the old deployment did not use the default namespace and did not use beta gray release, this compatibility removal does not affect smooth upgrade for this compatibility area. If the old deployment used the default namespace or beta gray release, a fully smooth upgrade is no longer guaranteed. Operators must migrate and verify the affected data before upgrading to 3.3.x.
-
-Affected deployments must complete at least these actions:
-
-1. Check whether the old database has default-namespace config data with `tenant_id = ''`.
-2. Before upgrading to 3.3.x, migrate default-namespace data from the empty tenant to `tenant_id = 'public'`. If rows with the same `data_id` and `group_id` exist under both the empty tenant and `public`, decide which business data to keep before migrating to avoid conflicts.
-3. Check whether the old database has gray data in `config_info_beta` or `config_info_tag`.
-4. Before upgrading to 3.3.x, migrate legacy beta/tag gray data into the current `config_info_gray` model and store the corresponding `grayName` and `GrayRule` metadata according to the current gray rule model.
-5. After migration, use current clients or APIs to verify default-namespace config reads, formal publish, beta gray query, tag gray query, and stopping gray release.
-
-If you cannot directly confirm the migration format in your own tooling, you can first upgrade to a 3.0.x-3.2.x version that still contains this compatibility migration capability, complete the migration, run stably, verify the data, and then upgrade to 3.3.x.
-
-#### 2.1.8. Migrate MCP Services (Optional)
-
-If you are upgrading from version 3.0.0 and your cluster has MCP services, note that due to changes in the official MCP Registry API standard, the MCP Server metadata structure has changed. This incompatibility means that after upgrading from 3.0.0 to 3.0.1 or later, the console will be unable to read legacy MCP Server data. You need to use the [MCP Migration Tool](https://download.nacos.io/nacos-server/mcp-migration-tool.jar) to migrate the existing MCP service data from version 3.0.0.
-
-```shell
-# java -jar ./mcp-migration-tool.jar ${nacos-server-host}:${nacos-server-port} ${username} ${password}
-# Example
-java -jar ./mcp-migration-tool.jar localhost:8848 nacos ${your_password}
-```
-
-#### 2.1.9. Migrate Unified Plugin Configuration (Nacos 3.3.0+)
-
-If the deployment does not use custom server plugins, compare its current `application.properties` with the target distribution, then migrate retained legacy properties to the canonical keys documented in [System Configurations](./system-configurations.md). AI Resource Import now defaults to enabled when its gate is absent, so set `nacos.plugin.ai-resource-import.enabled=false` before rollout if it must remain disabled. A deployment that used the old Source/preset/list configuration must also follow the [AI Resource Import migration](../../plugin/migration.md#ai-resource-import-breaking-change).
-
-If the deployment uses self-developed or third-party server plugins, complete the same configuration comparison and review the plugin compatibility changes before rollout. In particular, the legacy Importer/Source SPI for AI Resource Import has been removed, while Config Change's `ConfigChangeConfigs` is deprecated and retained only for compatibility. Follow the [Plugin Migration Guide](../../plugin/migration.md), then check the relevant [AI Resource Import](../../plugin/ai-resource-import-plugin.md), [Config Change](../../plugin/config-change-plugin.md), and [Plugin Development](../../plugin/development.md) pages.
-
-### 2.2. Docker/Kubernetes Upgrade
-
-#### 2.2.1 Verify Database Schema
-
-Please refer to [2.1.1 Verify Database Schema](#211-verify-database-schema) to compare and apply database schema changes.
-
-#### 2.2.2. Verify Environment Variables
-
-Compare the environment variables of your current deployment with [System Parameters - Image Environment Variables](./system-configurations/#2-image-environment-variables) to check for changes. If there are any, update the Docker environment variable file or Kubernetes configmap/secret accordingly.
-
-For example, add the following environment variables:
-
-```
-NACOS_AUTH_TOKEN=${Base64-encoded token from a custom string of 32+ characters}
-NACOS_AUTH_IDENTITY_KEY=${any string}
-NACOS_AUTH_IDENTITY_VALUE=${any string}
-```
-
-#### 2.2.3. Update Image Version
+Container deployments must also complete the database, historical migration, and plugin checks in sections 2.1 through 2.3 before changing images. Compare the target image's environment-variable conversion rules and the mounted `application.properties`; do not assume that every old environment variable maps to a canonical plugin property. See [System Configurations - Startup Script and Image Variables](./system-configurations.md#startup-script-and-image-variables).
 
 <Tabs>
-  <TabItem label="Docker">
-    First, update the Nacos version in your docker compose file. For example, in the `standalone-mysql-8.yaml` from the [Nacos Docker](https://github.com/nacos-group/nacos-docker) project:
+  <TabItem label="Docker Compose">
+    Update the image version in the Compose file:
+
     ```yaml
     services:
-    nacos:
-    image:
-    nacos/nacos-server:${target_version}
+      nacos:
+        image: nacos/nacos-server:${target_version}
     ```
-    Then run the following commands to upgrade:
+
+    Pull the target image. For a standalone service named `nacos`, rebuild only that service:
+
     ```bash
-    docker-compose pull
-    docker-compose up -d --remove-orphans
+    docker compose pull
+    docker compose up -d --no-deps nacos
     ```
+
+    When Compose manages a multi-node cluster, do not run one `up` operation that recreates every Nacos service. Run `docker compose up -d --no-deps ${nacos_service_name}` for one service at a time, verify that the node has rejoined and is healthy, and then continue with the next service.
   </TabItem>
   <TabItem label="Kubernetes">
-    Update the version using the kubectl set image command:
+    Update the workload image, for example:
+
     ```bash
-    kubectl set image deployment/nacos-deployment ${container_name}=nacos/nacos-server:${target_version}
+    kubectl set image deployment/nacos-deployment \
+      ${container_name}=nacos/nacos-server:${target_version}
+    kubectl rollout status deployment/nacos-deployment
     ```
+
+    Set a rolling strategy appropriate for the cluster size. Wait for each Pod to become ready and rejoin the Nacos cluster before replacing more Pods.
   </TabItem>
 </Tabs>
 
-## 3. Legacy HTTP API Removal (Nacos 3.2.0+)
+### 2.6. Post-upgrade Verification and Rollback Preparation
 
-### 3.1 API Removal Notice
+At minimum, verify the following after the upgrade:
 
-:::caution[Breaking Change]
-Starting from **Nacos 3.2.0**, the legacy v1 and v2 HTTP APIs have been **removed** from the main Nacos repository.
-:::
+1. Node versions, cluster membership, and health are correct, with no schema, plugin-loading, or configuration-alias errors in the logs.
+2. Config publish/query, service register/discover, Console login, Client API, and Admin API authentication match the pre-upgrade settings.
+3. Deployments that used the default namespace or gray release recheck the paths listed in section 2.1.1.
+4. Plugin management reports the expected plugin IDs, states, configuration sources, and restart-required fields, with no implementation enabled unexpectedly.
+5. When ARD is enabled, all three relational tables exist and index tasks converge. When the PostgreSQL vector plugin is enabled, also verify the pgvector schema and datasource connectivity.
 
-The old v1 and v2 HTTP APIs are no longer included in the default Nacos server distribution. These APIs have been migrated to a separate legacy adapter module.
-
-**Affected APIs:**
-- All v1 REST APIs (e.g., `/nacos/v1/ns/instance`, `/nacos/v1/cs/configs`)
-- All v2 REST APIs
-
-### 3.2 Migration Options
-
-You have two options:
-
-#### Option 1: Migrate to New APIs and Clients (Recommended)
-- Use the new v3 APIs
-  - [v3 Admin API Documentation](./admin-api)
-  - [v3 Console API Documentation](./console-api)
-- Upgrade to the latest Nacos client SDK
-  - [Nacos Client Documentation](../user/overview/other-language)
-
-#### Option 2: Use Legacy API Adapter (Temporary Solution)
-If you need time to migrate, you can temporarily restore the old APIs using the legacy adapter.
-
-### 3.3 Installing the Legacy API Adapter
-
-:::danger[Important Warnings]
-- The legacy adapter is **NOT guaranteed** to be supported in future Nacos versions
-- This module is **NOT actively maintained** by the community
-- This is a **temporary solution** only for urgent migration scenarios
-- **We strongly recommend migrating to v3 APIs and new clients as soon as possible**
-:::
-
-#### Step 1: Build or Download the Adapter
-
-**Option A: Download from Release**
-```bash
-# Download from GitHub releases
-wget https://github.com/nacos-group/nacos-api-legacy-adapter/releases/download/v${version}/nacos-api-legacy-adapter-${version}.jar
-```
-
-**Option B: Build from Source**
-```bash
-git clone https://github.com/nacos-group/nacos-api-legacy-adapter.git
-cd nacos-api-legacy-adapter
-mvn clean install
-# Output: target/nacos-api-legacy-adapter-${version}.jar
-```
-
-**Requirements:**
-- JDK 17+
-- Maven 3.6+
-- The `nacos.version` in `pom.xml` must match the target Nacos server version
-
-#### Step 2: Install the Adapter
-
-**For Nacos Server Deployment:**
-
-1. Place the JAR file in the Nacos `plugins` directory:
-```bash
-cp nacos-api-legacy-adapter-${version}.jar ${NACOS_HOME}/plugins/
-```
-
-2. Restart Nacos server:
-```bash
-sh ${NACOS_HOME}/bin/shutdown.sh
-sh ${NACOS_HOME}/bin/startup.sh -m standalone  # Standalone mode
-# or
-sh ${NACOS_HOME}/bin/startup.sh                # Cluster mode
-```
-
-3. The adapter will automatically load when the JAR is in the classpath.
-
-**For Embedded/Custom Applications:**
-
-Add the Maven dependency:
-```xml
-<dependency>
-    <groupId>com.alibaba.nacos</groupId>
-    <artifactId>nacos-api-legacy-adapter</artifactId>
-    <version>${nacos.version}</version>
-</dependency>
-```
-
-#### Step 3: Verify Installation
-
-Check Nacos server logs for confirmation:
-```bash
-tail -f ${NACOS_HOME}/logs/nacos.log
-```
-
-Look for log messages indicating the legacy adapter has loaded.
-
-#### Step 4: Test Legacy APIs
-
-Test that your old v1/v2 API calls work again:
-```bash
-curl -X GET "http://localhost:8848/nacos/v1/ns/instance/list?serviceName=test"
-```
-
-### 3.4 Version Compatibility
-
-| Nacos Version | Legacy Adapter Version | Compatibility |
-|--------------|----------------------|---------------|
-| 3.2.0        | 3.2.0               | ✅ Compatible  |
-| 3.3.0+       | Match Nacos version | ⚠️ Check compatibility |
-
-**Important:** The adapter version must match your Nacos server version.
-
-### 3.5 Planning Your Migration
-
-While using the legacy adapter, plan your migration:
-
-1. **Audit your API usage** - Identify all v1/v2 API calls
-2. **Review new v3 APIs** - Understand the new API structure
-3. **Update clients** - Upgrade to latest Nacos client SDKs
-4. **Test thoroughly** - Test in staging environment
-5. **Migrate gradually** - Use feature flags or canary deployments
-6. **Remove adapter** - Once migration is complete, remove the adapter JAR
-
-### 3.6 Getting Help
-
-- Legacy Adapter Repository: https://github.com/nacos-group/nacos-api-legacy-adapter
-- Nacos Main Repository: https://github.com/alibaba/nacos
-- Community Support: [Nacos Community](https://nacos.io/community/)
+Keep the old distribution, configuration, plugin JARs, and database backup until the observation period ends. Before rollback, remove runtime plugin overrides understood only by 3.3. Roll back AI Resource Import plugin JARs, configuration, and callers together. Do not reverse new tables or widened columns during an emergency rollback; use the database rollback procedure validated before rollout.

--- a/src/content/docs/next/en/plugin/migration.md
+++ b/src/content/docs/next/en/plugin/migration.md
@@ -22,6 +22,18 @@ Unified plugin management separates four layers: module entry, implementation se
 
 For STATIC `PluginConfigSpec` items, canonical full keys win by presence, not by a non-blank value. An empty canonical value still suppresses legacy aliases and may fail required-value validation; remove the canonical property entirely only when fallback to an alias is intended. If several aliases are present, the first one in the definition's declaration order wins. Selection keys continue to follow their plugin family's documented rules. API aliases are normalized, and `plugin-configs.json` and local-only maps store only canonical item keys.
 
+Persisted implementation state overrides static `.enabled` initial values. Export existing plugin state and runtime configuration as well as static files before upgrading. Otherwise an implementation may remain enabled or disabled by persisted state even after `application.properties` is changed.
+
+## SPI and loading compatibility
+
+Default methods in the unified configuration contract let most older zero-configuration plugins remain binary-loadable, although they appear as `configurable=false`. Plugin authors must explicitly handle these changes before upgrading:
+
+- The legacy Importer/Source SPI for AI Resource Import has no adapter. Migrate to `AiResourceImportServiceBuilder` and update service registration, configuration, and callers together. See the detailed model below.
+- AI Pipeline no longer loads `PublishPipelineServiceBuilder`. Register `PublishPipelineService` directly with a public no-argument constructor and implement configuration definitions, a current snapshot, and apply callbacks.
+- A third-party datasource plugin that implements or registers the removed `ConfigInfoBetaMapper`, `ConfigInfoTagMapper`, or `ConfigMigrateMapper` must remove those SPI dependencies and be rebuilt. Complete pre-3.0 Config data migration before upgrading.
+- Duplicate implementations with the same `pluginType:pluginName` now resolve deterministically using first-wins. Remove duplicate IDs before upgrading instead of relying on an earlier undefined override order.
+- Critical plugin types such as `auth`, `datasource-dialect`, and `ai-storage` can block startup when the selected implementation is missing, disabled, or fails initialization. Validate selection, state, and initialization in staging before a rolling upgrade.
+
 ## Implementation selection
 
 | pluginType | Standard key | Historical alias | Default/behavior |
@@ -32,12 +44,14 @@ For STATIC `PluginConfigSpec` items, canonical full keys win by presence, not by
 
 All selections are snapshotted at startup. Do not use the status API to switch an exclusive implementation.
 
+Datasource connection properties also move to the unified namespace. Migrate `db.num`, `db.url.{index}`, `db.user[.{index}]`, `db.password[.{index}]`, `db.pool.config.*`, and the JVM property `QUERYTIMEOUT` to `nacos.plugin.datasource.db.*`. Pool items use canonical kebab-case. These settings remain restart-only and are not changed dynamically through the plugin configuration API.
+
 ## Auth, Visibility, and AI Pipeline
 
 - Move default auth settings from `nacos.core.auth.plugin.nacos.*` and `nacos.core.auth.caching.enabled` to `nacos.plugin.auth.nacos.*`.
 - Move LDAP from `nacos.core.auth.ldap.*` to `nacos.plugin.auth.ldap.*`. The unused `nacos.core.auth.ldap.userdn` template key is not a valid alias.
 - Move OIDC from `nacos.core.auth.plugin.oidc.*` to `nacos.plugin.auth.oidc.*`. All current fields are `RESTART`.
-- `nacos.plugin.visibility.enabled` remains the capability gate; `nacos.plugin.visibility.type` is only historical initial selection. Implementation state belongs to unified `visibility:{name}` state.
+- `nacos.plugin.visibility.enabled` remains the capability gate. The deprecated `nacos.plugin.visibility.type` is a `RESTART` selector that still chooses the implementation requested by the AI domain and contributes to initial state. `nacos.plugin.visibility.{name}.enabled` and persisted unified `visibility:{name}` state determine whether that implementation is available.
 - `nacos.plugin.ai-pipeline.enabled` remains the Pipeline gate. Historical `nacos.plugin.ai-pipeline.type` supplies only initial chain state at startup. Use unified state for later membership and per-node definitions for configuration.
 
 The target distribution already declares `nacos.plugin.auth.type=nacos` and the canonical defaults for `auth:nacos`. Copy retained auth selection and implementation values into those canonical keys instead of leaving legacy aliases beside the target defaults. Otherwise the canonical selector keeps `nacos`, and a canonical `PluginConfigSpec` key suppresses its alias even when the canonical value is empty. The startup script specially migrates only a valid legacy token secret found in `application.properties`; migrate all other auth values explicitly.

--- a/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
@@ -225,8 +225,8 @@ Raft 参数通过 `nacos.core.protocol.raft.data.*` 配置。`data` 是当前代
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
 | `nacos.plugin.auth.type` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias。 | `nacos` |
-| `nacos.core.auth.enabled` | 是否开启 SDK/gRPC 请求鉴权。 | `false` |
-| `nacos.core.auth.admin.enabled` | 是否开启 `/v3/admin/*` Admin API 鉴权。 | `true` |
+| `nacos.core.auth.enabled` | 是否开启通用鉴权系统和 Open API 鉴权，包括 Client/Open HTTP API 及 SDK/gRPC 请求。 | `false` |
+| `nacos.core.auth.admin.enabled` | 是否开启 Admin API scope 鉴权；除 `/v3/admin/*` 外，也包括标记为 `ADMIN_API` 的插件自有端点。 | `true` |
 | `nacos.core.auth.console.enabled` | 是否开启 `/v3/console/*` Console API 和登录鉴权。 | `true` |
 | `nacos.plugin.auth.nacos.caching.enabled` | 是否缓存鉴权信息；`nacos.core.auth.caching.enabled` 是历史 alias。开启后权限变更会有短暂延迟。 | `true` |
 | `nacos.core.auth.server.identity.key` | Server 间请求身份标识 key。开启鉴权时必须设置。 | 空 |
@@ -235,9 +235,10 @@ Raft 参数通过 `nacos.core.protocol.raft.data.*` 配置。`data` 是当前代
 | `nacos.plugin.auth.nacos.token.cache.enable` | 默认鉴权插件 token 缓存；旧 `nacos.core.auth.plugin.nacos.token.cache.enable` 是 alias。 | `false` |
 | `nacos.plugin.auth.nacos.token.expire.seconds` | 默认鉴权插件 token 过期秒数；`nacos.core.auth.plugin.nacos.token.expire.seconds` 是历史 alias。 | `18000` |
 | `nacos.plugin.auth.nacos.token.secret.key` | JWT 签名密钥，敏感且 RESTART；`nacos.core.auth.plugin.nacos.token.secret.key` 是历史 alias。 | 空 |
-| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | 是否允许 AI 资源匿名读取；`nacos.core.auth.nacos.anonymous.ai.enabled` 是历史 alias。 | `false` |
+| `nacos.plugin.auth.nacos.anonymous.ai.enabled` | 是否允许显式 opt-in 的 AI 端点接受匿名读取；`nacos.core.auth.nacos.anonymous.ai.enabled` 是历史 alias。显式携带空或无效凭据不会回退为匿名。 | `false` |
 | `nacos.plugin.visibility.enabled` | 是否开启可见性插件。 | `true` |
-| `nacos.plugin.visibility.type` | 可见性插件类型。默认 `nacos` 实现会复用默认鉴权插件用户信息。 | `nacos` |
+| `nacos.plugin.visibility.type` | 废弃的 `RESTART` selector，仍决定 AI 领域请求的实现，并在没有持久化状态时参与初始化实现状态。 | `nacos` |
+| `nacos.plugin.visibility.{pluginName}.enabled` | 实现的静态初始状态；持久化插件状态优先。默认 `nacos` 实现会复用默认鉴权插件用户信息。 | `nacos` 为 `true` |
 
 ### LDAP、OIDC 与 OAuth2
 
@@ -258,7 +259,7 @@ LDAP 与 OIDC/OAuth2 是可选插件。下表列出标准前缀，具体 definit
 | `nacos.plugin.control.type` | 启动时选择流量防护实现；`nacos.plugin.control.manager.type` 是历史 alias。 | 空（no-limit） |
 | `nacos.plugin.control.rule.local.basedir` | 本地流量防护规则目录。 | `${nacos.home}` |
 | `nacos.plugin.control.rule.external.storage` | 外部规则存储类型，需要自行实现。 | 空 |
-| `nacos.plugin.{pluginType}.{pluginName}.enabled` | 实现级启动初始状态；持久化/本地 state 可覆盖。 | 由实现和类型策略决定 |
+| `nacos.plugin.{pluginType}.{pluginName}.enabled` | 非互斥实现的启动初始状态；持久化/本地 state 可覆盖。`auth`、`datasource-dialect`、`control` 等互斥类型应使用 selector 选择实现。 | 由实现和类型策略决定 |
 | `nacos.plugin.{pluginType}.{pluginName}.{itemKey}` | 实现 definitions 的标准配置键。 | 由 definition 决定 |
 
 配置变更插件的历史 `nacos.core.config.plugin.{pluginName}.*` 只用于旧二进制兼容；Nacos Server 不内置 webhook、whitelist 或 fileformatcheck 实现。新实现使用 `nacos.plugin.config-change.{pluginName}.{itemKey}`。
@@ -289,7 +290,7 @@ AI 管理中心的使用方式见[AI 管理中心概述](../user/ai/ai-registry-
 | `nacos.ai.skill.registry.enabled` | 是否启用 Skill Registry 协议适配。开启后会使用 `nacos.ai.registry.port` 暴露独立端口。 | `false` |
 | `nacos.ai.registry.port` | AI Registry 协议适配端口。 | `9080` |
 | `nacos.ai.mcp.registry.port` | 旧参数名，已废弃。请改用 `nacos.ai.registry.port`。 | `9080` |
-| `nacos.plugin.ai-pipeline.enabled` | AI Pipeline 动态模块总开关；关闭时延迟加载类型。 | `false` |
+| `nacos.plugin.ai-pipeline.enabled` | AI Pipeline 动态模块总开关；关闭时延迟加载类型。 | `true` |
 | `nacos.plugin.ai-pipeline.type` | 历史启动链，仅用于没有持久化状态时初始化节点状态。 | 空 |
 | `nacos.plugin.ai-pipeline.skill-scanner.{itemKey}` | `skill-scanner` definitions；只有 `order` 为 RUNTIME。 | 见 [AI Pipeline 插件文档](../../plugin/ai-pipeline-plugin.md) |
 | `nacos.plugin.ai-pipeline.skill-spector.{itemKey}` | `skill-spector` definitions；只有 `order` 为 RUNTIME。 | 见 [AI Pipeline 插件文档](../../plugin/ai-pipeline-plugin.md) |

--- a/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
@@ -33,387 +33,210 @@ Nacos 3.x 服务端与各版本客户端的兼容性如下：
 
 ## 2. 升级步骤
 
-### 2.1. 发行版升级
+:::caution[3.0.x、3.1.x 可以直接升级到 3.3.x]
+本文适用于从 Nacos 3.0.x、3.1.x 或 3.2.x 直接升级到 3.3.x，不要求先将服务端升级到 3.2.x。对于 3.0.x、3.1.x，或尚未完整执行 3.2.x 数据库变更的部署，应先按照 [Nacos 3.2.x 升级手册](/docs/latest/manual/admin/upgrading/) 补齐适用于当前数据库的 schema 前置操作，确认实际 schema 已具备 3.2.x 所要求的结构，再继续执行本文的 3.3.x 增量操作。
 
-#### 2.1.1 确认表结构
+这里只要求补齐数据库 schema，不需要增加一次 3.2.x 服务端中转升级。所有 SQL 都应根据当前实际表结构判断是否需要执行，不要重复执行已完成的 DDL，也不要对已有数据库直接运行完整初始化脚本。
+:::
 
-先对比部署的旧版本 Nacos schema 文件和目标版本对应数据库的 schema 文件，确认表结构是否有变化。
+### 2.1. 升级前检查
 
-若文件中表结构存在变化，请先进行数据库变更。以 MySQL 为例：
+升级生产集群前，请完成以下准备：
 
-```SQL
--- 从 2.0.X 升级时需要执行下列所有SQL, 从2.1.X之后版本升级仅需执行最后三行。
-ALTER TABLE `config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `config_info_gray` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `his_config_info` ADD COLUMN `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥';
-ALTER TABLE `his_config_info` ADD COLUMN `publish_type` varchar(50)  DEFAULT 'formal' COMMENT 'publish type gray or formal';
-ALTER TABLE `his_config_info` ADD COLUMN `gray_name` varchar(50)  DEFAULT NULL COMMENT 'gray name';
-ALTER TABLE `his_config_info` ADD COLUMN `ext_info`  longtext DEFAULT NULL COMMENT 'ext info';
+1. 确认源集群运行受支持的 3.0.x、3.1.x 或 3.2.x 版本，并记录具体补丁版本、部署模式和数据库类型。若源版本早于 3.2.x，或实际 schema 尚未包含 3.2.x 的全部变更，请列出需要从 3.2.x 升级手册补齐的数据库操作。
+2. 备份数据库、每个节点的 `data`、`conf`、`cluster.conf`、自定义插件及其配置。所有部署都要保留 `data/plugin` 中的插件状态和运行时配置；使用 Derby 或其他嵌入式存储时，`data` 中还包含主数据库，必须完整保留。
+3. 记录现有插件 JAR、实现名、启停状态、选择 key 和私有配置，区分社区内置插件与自研、第三方插件。
+4. 在预发环境使用生产数据副本演练数据库变更、鉴权、插件加载、滚动升级和回滚。
+5. 升级期间避免修改插件运行时配置；集群全部升级完成后再提交依赖 3.3 插件定义的配置。
+
+<a id="217-配置中心兼容迁移移除-nacos-330"></a>
+
+#### 2.1.1. 确认历史配置迁移已完成
+
+Nacos 3.3 不再保留 3.0 之前的配置存储兼容迁移逻辑，不再自动在 legacy 空 tenant（`tenant_id = ''`）与默认 namespace `public` 之间迁移或双写，也不再自动把 `config_info_beta`、`config_info_tag` 中的数据迁移到 `config_info_gray`。
+
+在停止最后一个源版本节点前，请完成以下检查：
+
+1. 检查是否存在 `tenant_id = ''` 的默认 namespace 配置；若存在，确认这些数据已经迁移到 `tenant_id = 'public'`，并先处理同一 `data_id`、`group_id` 下的冲突记录。
+2. 检查是否仍有业务数据依赖 `config_info_beta` 或 `config_info_tag`；若存在，在升级到 3.3.x 前完成向 `config_info_gray` 和当前 `GrayRule` 模型的迁移。
+3. 验证默认 namespace 配置读取、正式发布、beta/tag 灰度查询和停止灰度等关键路径。
+
+若部署从未使用默认 namespace，也未使用 beta/tag 灰度发布，则不需要执行对应数据迁移。无法确认迁移格式时，应保留源集群并先完成迁移和验证，不要依赖 3.3 启动过程补做迁移。
+
+对于 PostgreSQL 部署，如果从 3.0.x、3.1.x、3.2.0 或 3.2.1 直接升级，或者曾跳过 3.2.2 的 schema 规范化，请先完成 [3.2.x 升级手册](/docs/latest/manual/admin/upgrading/) 中的 `tenant_id` 非空迁移。
+
+:::caution[3.3.0-BETA 的 A2A 升级限制]
+当前文档适用于 Nacos 3.3.0-BETA。该版本新增了协议无关的远程 Agent 注册与发现能力 RAD（RemoteAgentDiscovery），它将在正式版中逐步替代之前的 A2A 功能。但当前 BETA 版本尚未支持 A2A 功能的无损升级；从 3.1.x 或 3.2.x 直接升级到 3.3.0-BETA 后，原有的 A2A 内容将无法查询。已有 A2A 内容的部署应在升级前评估影响并保留备份。
+:::
+
+### 2.2. 应用数据库变更
+
+在启动任何 3.3.x 节点前，先按 [3.2.x 升级手册](/docs/latest/manual/admin/upgrading/) 完成从当前源版本到 3.2.x schema 所需的前置数据库操作；这一步不要求启动 3.2.x 服务端。然后比较完成前置操作后的实际 schema 与目标 3.3.x 发行包中对应数据库的完整 schema，并把剩余差异转换为经过评审的增量 DDL。不要在已有数据库上直接执行包含 `CREATE TABLE` 或 `DROP TABLE` 的完整初始化文件。
+
+目标发行包在 `conf` 目录提供 `mysql-schema.sql`、`pg-schema.sql`、`oracle-schema.sql` 和 `derby-schema.sql`。完成 3.2.x schema 前置操作后，还需要重点处理以下 3.3.x 变化：
+
+| 变化 | 影响与操作 |
+| --- | --- |
+| `permissions.resource` 扩展到 512 字符 | 默认鉴权与可见性插件保存完整资源标识需要更长字段。若当前字段短于 512 且计划使用显式可见性授权，请执行目标发行包中与数据库匹配的 `*-upgrade-visibility-permission-resource.sql`。MySQL 执行前必须确认 InnoDB 页大小、行格式和唯一索引长度支持脚本中的 `VARCHAR(512) utf8mb4`。 |
+| 新增 AI 资源检索关系表 | 3.3 新增 `ai_resource_search_document`、`ai_resource_search_chunk` 和 `ai_resource_task`。在开启 `nacos.ai.ard.enabled` 前，必须从目标主数据源 schema 中提取并评审这三张表所需的 `CREATE TABLE` 和索引语句，严禁复制相邻的 `DROP`。若任一表已经存在，应生成 `ALTER` 或数据迁移方案，不得删表重建。ARD 默认关闭；不启用时不会要求检索表和向量存储，但建议在计划内维护窗口提前完成建表。 |
+| PostgreSQL pgvector 存储（可选） | 只有启用默认 PostgreSQL 向量插件时，才需要在实际存储 embedding 的 PostgreSQL 数据源初始化 pgvector 对象和 `ai_resource_search_embedding_pg`。`conf/pg-ai-vector-schema.sql` 不属于主 `pg-schema.sql`，包含 `CREATE EXTENSION` 和破坏性的初始化语句，需要数据库具备 pgvector 扩展及相应权限。只有全新的向量库才能在评审后原样执行；已有表必须备份并制定增量迁移，不能直接重跑。 |
+| AI 资源描述字段扩容 | PostgreSQL、Oracle 和 Derby 的 `ai_resource.c_desc`、`ai_resource_version.c_desc` 当前长度小于 2048 时需要扩展到 2048。请按实际表结构和目标 schema 生成经过评审的 `ALTER`，不要依据某个 3.2.x 补丁的默认长度作假设。 |
+| 新建 MySQL schema 的字符序 | 3.3 新建 MySQL 数据库时，既有核心表使用区分大小写的 `utf8mb4_bin`。当前没有面向已有数据库的通用字符序迁移脚本，不要根据完整 schema 批量修改生产表；如需对齐，应先核对大小写敏感的资源身份要求并单独验证迁移方案。 |
+
+:::note
+ARD 的三张关系表是协议无关的 AI 资源检索表。即使当前只有 ARD 使用该能力，也不要自行改名为 ARD 专属表。如果使用 PostgreSQL 但不开启默认向量插件，则无需安装 pgvector 或执行向量 schema。
+:::
+
+:::caution[MySQL 开启 ARD 前检查大小写冲突]
+当前目标 schema 中，既有 AI 资源表使用区分大小写的 `utf8mb4_bin`，而新增检索表仍使用 `utf8mb4_unicode_ci`。如果同一 namespace 下存在仅大小写不同的资源名称或版本，写入检索表时可能发生唯一键冲突。启用 ARD 前必须排查并处理此类数据；存在冲突时，应等待目标 schema 和迁移方案对齐后再开启 ARD。
+:::
+
+### 2.3. 迁移配置与插件
+
+3.3 对服务端插件的身份、状态、实现选择和私有配置进行了统一管理。请以目标发行包的 `conf/application.properties` 为模板迁移实际配置，不要直接用源版本文件覆盖目标文件。常用参数见[系统参数](./system-configurations.md)，插件迁移规则见[插件迁移指南](../../plugin/migration.md)；发行包模板仍是目标版本参数的最终核对基线。
+
+#### 2.3.1. 默认鉴权插件
+
+默认鉴权实现仍然是 `nacos`，但在统一插件体系中的身份为 `auth:nacos`，实现选择与私有配置迁移到了标准 `nacos.plugin.auth.*` 命名空间。
+
+| 3.0.x～3.2.x 历史配置 | 3.3 标准配置 |
+| --- | --- |
+| `nacos.core.auth.system.type` | `nacos.plugin.auth.type` |
+| `nacos.core.auth.caching.enabled` | `nacos.plugin.auth.nacos.caching.enabled` |
+| `nacos.core.auth.plugin.nacos.token.*` | `nacos.plugin.auth.nacos.token.*` |
+| `nacos.core.auth.nacos.anonymous.ai.enabled` | `nacos.plugin.auth.nacos.anonymous.ai.enabled` |
+| `nacos.core.auth.ldap.*` | `nacos.plugin.auth.ldap.*`，item key 使用插件定义中的 kebab-case 名称 |
+| `nacos.core.auth.plugin.oidc.*` | `nacos.plugin.auth.oidc.*` |
+
+`nacos.core.auth.enabled`、`nacos.core.auth.admin.enabled`、`nacos.core.auth.console.enabled` 和 `nacos.core.auth.server.identity.*` 仍是核心鉴权开关或节点身份配置，不要迁移到插件私有命名空间。
+
+标准 key 与历史 alias 同时存在时，标准 key 优先；即使标准值为空，也会屏蔽历史 alias。目标发行包已经包含 `nacos.plugin.auth.type=nacos` 和 `auth:nacos` 的标准默认项，因此应把保留的值显式写入标准 key，而不是把新旧配置并列保留。启动脚本只会特殊迁移 `application.properties` 中有效的旧 token secret，其他鉴权参数都需要显式迁移。LDAP、OIDC 和自定义鉴权插件还应按照[鉴权插件文档](../../plugin/auth-plugin.md)逐项核对。
+
+开启 AI 匿名访问时，显式携带但为空或无效的 `Authorization`、`accessToken`、用户名或密码不再降级为匿名访问，而会被拒绝。匿名调用方应完全不携带凭据，鉴权调用方则必须提供有效凭据。
+
+#### 2.3.2. 其他插件配置
+
+| 领域 | 3.0.x～3.2.x 历史配置 | 3.3 标准模型 |
+| --- | --- | --- |
+| 数据库方言 | `spring.sql.init.platform`；更早的 `spring.datasource.platform` 已移除 | `nacos.plugin.datasource-dialect.type` |
+| 数据库连接 | `db.*`、JVM 参数 `QUERYTIMEOUT` | `nacos.plugin.datasource.db.*` |
+| 流量防护 | `nacos.plugin.control.manager.type` | `nacos.plugin.control.type` |
+| Config Change | `nacos.core.config.plugin.{pluginName}.*` | `nacos.plugin.config-change.{pluginName}.{itemKey}` 和统一实现状态 |
+| Visibility | `nacos.plugin.visibility.type` | 该废弃的 `RESTART` selector 仍决定 AI 领域请求的实现并参与初始状态计算；`nacos.plugin.visibility.{pluginName}.enabled` 或持久化状态决定实现是否可用，`nacos.plugin.visibility.enabled` 仍是能力总开关 |
+| AI Pipeline | `nacos.plugin.ai-pipeline.type` 逗号分隔链及历史 camel-case item | 每个 `nacos.plugin.ai-pipeline.{pluginName}.enabled`、canonical kebab-case item 和统一状态 |
+| AI Resource Import | `nacos.ai.resource.import.enabled`、`nacos.plugin.ai.importer.*`、Source/preset/list 模型 | `nacos.plugin.ai-resource-import.enabled`、`nacos.plugin.ai-resource-import.{pluginName}.*` 和固定受管来源 |
+
+历史 key 在兼容窗口内仍可能作为 alias 被读取并输出迁移 WARN，但新 key 只要存在就具有更高优先级。持久化实现状态也会覆盖静态 `.enabled` 初始值。方言、互斥实现选择和标记为 `RESTART` 的字段必须通过静态配置修改并重启，不能通过插件配置 API 动态切换。
+
+AI Resource Import 在新旧模块开关均未配置时默认开启；如果升级后仍需关闭，必须在发布前显式设置：
+
+```properties
+nacos.plugin.ai-resource-import.enabled=false
 ```
 
-3.2.0 版本新增了AI相关的表，所有版本升级到 3.3.X 均需创建以下表：
+旧 Importer/Source SPI、可复制 Source/preset 和通过配置复制同一 importer 到多个 endpoint 的模型已经移除，外部实现必须迁移到新的 `AiResourceImportServiceBuilder`。详细映射及内置来源见 [AI Resource Import 迁移说明](../../plugin/migration.md#ai-resource-import-breaking-change)。
 
-```SQL
-CREATE TABLE IF NOT EXISTS `pipeline_execution` (
-    `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
-    `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
-    `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
-    `namespace_id`  varchar(128) DEFAULT NULL COMMENT '命名空间ID',
-    `version`       varchar(64)  DEFAULT NULL COMMENT '版本',
-    `status`        varchar(32)  NOT NULL COMMENT '执行状态',
-    `pipeline`      longtext     NOT NULL COMMENT 'pipeline节点结果JSON',
-    `create_time`   bigint(20)   NOT NULL COMMENT '创建时间',
-    `update_time`   bigint(20)   NOT NULL COMMENT '修改时间',
-    PRIMARY KEY (`execution_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源发布审核Pipeline执行记录';
+#### 2.3.3. 自研与第三方插件
 
-CREATE TABLE IF NOT EXISTS `ai_resource` (
-    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
-    `name` varchar(256) NOT NULL COMMENT '资源名称',
-    `type` varchar(32) NOT NULL COMMENT '资源类型',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT '资源描述',
-    `status` varchar(32) DEFAULT NULL COMMENT '资源状态',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
-    `biz_tags` varchar(1024) DEFAULT NULL COMMENT '业务标签',
-    `ext` longtext DEFAULT NULL COMMENT '扩展信息(JSON)',
-    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT '来源标识(导入/同步来源)',
-    `version_info` longtext DEFAULT NULL COMMENT '版本信息(JSON)',
-    `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT '元数据版本(乐观锁)',
-    `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT '可见性: PUBLIC/PRIVATE',
-    `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
-    KEY `idx_ai_resource_name` (`name`),
-    KEY `idx_ai_resource_type` (`type`),
-    KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
+- 按稳定的 `pluginType:pluginName` 记录每个实现，消除重复身份，并确认目标版本能够发现预期 JAR。重复身份现在按 first-wins 确定实际实现。
+- 旧版零配置插件通常仍能加载，但只有实现 `PluginConfigSpec` definitions、当前配置快照和 apply 回调后才会显示为可配置。
+- 旧 Config Change 二进制插件在兼容窗口内仍可加载，但会显示 `configurable=false`；应尽快迁移到新的 definitions 和 callbacks。
+- AI Pipeline 不再加载 `PublishPipelineServiceBuilder`。第三方 Pipeline 插件需要重新编译，以 public 无参构造直接注册 `PublishPipelineService`，并实现统一配置契约。
+- 实现或注册了已移除 `ConfigInfoBetaMapper`、`ConfigInfoTagMapper`、`ConfigMigrateMapper` SPI 的第三方数据源插件必须移除这些接口并重新编译；3.0 之前的数据迁移应在升级前完成。
+- 旧 AI Resource Import SPI 没有兼容适配器，必须重新编译并同步修改配置与调用方，不能与新模型混跑。
+- `auth`、`datasource-dialect`、`ai-storage` 等关键插件在选中的实现缺失、被禁用或初始化失败时可能阻止服务启动，应在预发环境验证选择、状态和初始化过程。
+- 先在单节点核对插件列表、详情、effective source、脱敏结果和 `RESTART` 提示；滚动升级期间不要下发只有 3.3 节点才能理解的运行时配置。
 
-CREATE TABLE IF NOT EXISTS `ai_resource_version` (
-    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
-    `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
-    `type` varchar(32) NOT NULL COMMENT '资源类型',
-    `author` varchar(128) DEFAULT NULL COMMENT '作者',
-    `name` varchar(256) NOT NULL COMMENT '资源名称',
-    `c_desc` varchar(2048) DEFAULT NULL COMMENT '版本描述',
-    `status` varchar(32) NOT NULL COMMENT '版本状态',
-    `version` varchar(64) NOT NULL COMMENT '版本号',
-    `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
-    `storage` longtext DEFAULT NULL COMMENT '存储信息(JSON)',
-    `publish_pipeline_info` longtext DEFAULT NULL COMMENT '发布流水线信息(JSON)',
-    `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ver_ns_name_type_ver` (`namespace_id`,`name`,`type`,`version`),
-    KEY `idx_ai_resource_ver_name` (`name`),
-    KEY `idx_ai_resource_ver_status` (`status`),
-    KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';
-```
+### 2.4. 发行版升级
 
-如果使用 PostgreSQL，并且从 3.2.1 或更早版本升级到 3.2.2，请在升级前确认配置相关表的 `tenant_id` 字段是否已经是 `NOT NULL DEFAULT ''`。3.2.2 会在启动时校验 PostgreSQL schema；如果旧数据表中仍允许 `tenant_id` 为空，服务端可能会启动失败。相关讨论见 [alibaba/nacos#15275](https://github.com/alibaba/nacos/issues/15275)。
-
-执行迁移前，建议先检查 `config_info` 中是否存在重复的逻辑配置。若同一 `data_id` 和 `group_id` 下存在多条 `tenant_id IS NULL` 记录，请先清理冲突数据，再执行迁移 SQL。
-
-```SQL
-SELECT data_id, group_id, COUNT(*)
-FROM config_info
-WHERE tenant_id IS NULL
-GROUP BY data_id, group_id
-HAVING COUNT(*) > 1;
-```
-
-确认没有冲突后，执行目标版本源码中的 `pg-upgrade-null-tenant-id.sql`。SQL 内容如下：
-
-```SQL
-ALTER TABLE config_info ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE config_info SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE config_info ALTER COLUMN tenant_id SET NOT NULL;
-
-ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE config_info_gray SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET NOT NULL;
-
-ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE config_tags_relation SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET NOT NULL;
-
-ALTER TABLE his_config_info ALTER COLUMN tenant_id SET DEFAULT '';
-UPDATE his_config_info SET tenant_id = '' WHERE tenant_id IS NULL;
-ALTER TABLE his_config_info ALTER COLUMN tenant_id SET NOT NULL;
-```
-
-#### 2.1.2. 下载新版本
+#### 2.4.1. 下载目标版本
 
 <Tabs>
   <TabItem label="官网">
-    进入Nacos官网[版本下载页面](/download/nacos-server/)，选择 [稳定版本](/download/nacos-server/#稳定版本)， 然后点击`二进制包下载`列中的`${nacos.version}.zip`进行下载。
+    进入 Nacos 官网[版本下载页面](/download/nacos-server/)，选择[稳定版本](/download/nacos-server/#稳定版本)，然后点击`二进制包下载`列中的`${nacos.version}.zip`。
 
-    > 注意：有时大量用户同时进行下载时，可能会遇到下载限流失败的情况，若出现下载限流失败，请稍等后重试，或采用`从 Github 下载方式`。
+    > 若下载受到限流，请稍后重试，或改用 GitHub 下载。
   </TabItem>
-  <TabItem label="Github">
-    进入Nacos Github 的 [最新稳定版本](https://github.com/alibaba/nacos/releases) ，选择需要下载的Nacos版本，在`Assets`中点击下载 `nacos-server-$version.zip` 包。
+  <TabItem label="GitHub">
+    进入 Nacos GitHub 的[版本发布页面](https://github.com/alibaba/nacos/releases)，选择目标版本，在 `Assets` 中下载 `nacos-server-${target_version}.zip` 或对应的 tar.gz 包。
   </TabItem>
 </Tabs>
 
-#### 2.1.3. 替换二进制jar包
+#### 2.4.2. 准备新的安装目录
 
-解压新下载的发行版压缩包
-
-```bash
-  unzip nacos-server-$version.zip
-  # 或者 tar -xvf nacos-server-$version.tar.gz
-```
-
-然后 找到`nacos/target/nacos-server.jar` 将该jar包替换到旧的发行版中，例如：
+解压目标发行包到新的目录：
 
 ```bash
-cp nacos/target/nacos-server.jar ${old.nacos.home}/target/
+unzip nacos-server-${target_version}.zip -d ${INSTALL_PARENT}
+# 或 tar -xvf nacos-server-${target_version}.tar.gz -C ${INSTALL_PARENT}
 ```
 
-#### 2.1.4. 修改配置文件
+3.3 的发行包同时包含新的服务端 JAR、默认插件、schema、启动脚本和配置模板。不要只替换 `target/nacos-server.jar`，也不要用源版本的 `bin`、`conf` 或整个 `plugins` 目录覆盖新发行包。
 
-Nacos 3.0.X 版本相比Nacos 2.X版本有较大的配置文件内容改动，除了新增大量关于server和console的相关配置，还对参数的顺序进行了改动，因此请务必仔细对比新版本和旧版本的配置文件，并重新设置Nacos的配置文件。
+请按以下原则迁移部署数据：
 
-主要的参数改动如下：
+- 以新 `application.properties` 为基础，逐项迁移第 2.3 节确认的配置。
+- 对比后重新设置 `cluster.conf`、JVM 参数、日志目录、证书和其他部署专属文件。
+- 只复制已经完成 3.3 兼容验证的自研或第三方插件 JAR。
+- 所有部署都要迁移或恢复该节点原有的 `data/plugin`，以保留 `plugin-states.json` 和 `plugin-configs.json`。Derby 或嵌入式存储还必须在停机和完整备份后迁移整个 `data`。外置数据库集群不要在节点间盲目复制仍活跃的 Raft 数据，应复用该节点自己的持久卷或遵循已演练的节点恢复方案；任何新旧进程都不能同时使用同一数据目录。
 
-`server.port` --> `nacos.server.main.port`
+#### 2.4.3. 重启或滚动升级
 
-`server.servlet.contextPath` --> `nacos.server.contextPath`
-
-#### 2.1.5. 修改启动参数（可选）
-
-对比部署的旧版本的启动脚本和新版本的启动脚本`bin/startup.sh`或`bin/startup.cmd`，确认是否有新增或修改的配置项，将这些配置项添加到旧的启动脚本件中，例如：
+单机部署先停止旧实例，再使用新发行包的启动脚本启动：
 
 ```bash
-diff nacos/bin/startup.sh ${old.nacos.home}/bin/startup.sh
+${OLD_NACOS_HOME}/bin/shutdown.sh
+${NEW_NACOS_HOME}/bin/startup.sh -m standalone
 ```
 
-#### 2.1.6. 重启Nacos Server
+集群部署建议逐节点升级。每次只停止一个源版本节点，使用该节点对应的 3.3 配置和新发行包启动，确认节点重新加入集群且核心功能正常后再处理下一个节点。全部节点升级完成前，不要修改统一插件运行时状态或配置。
 
-均替换完成后，重启Nacos Server:
+Windows 部署使用新发行包中的 `shutdown.cmd` 和 `startup.cmd`，不要复用旧版脚本。
 
-```
-# 以集群模式为例
-## Linux
-${nacos.home}/bin/shutdown.sh
-${nacos.home}/bin/startup.sh
+### 2.5. Docker/Kubernetes 升级
 
-## Windows
-${nacos.home}/bin/shutdown.cmd
-${nacos.home}/bin/startup.cmd
-```
-
-#### 2.1.7. 配置中心兼容迁移移除 (Nacos 3.3.0+)
-
-:::caution[3.3 升级前置检查]
-从 Nacos 3.3.0 起，服务端不再保留 Config 3.0 之前兼容迁移逻辑，不再自动在 legacy 空 tenant（`tenant_id = ''`）与默认 namespace `public` 之间做存储迁移或双写，也不再自动将旧 `config_info_beta`、`config_info_tag` 表中的灰度数据迁移到当前 `config_info_gray` 模型。
-:::
-
-这项移除只影响历史存储兼容迁移，不改变当前配置中心语义：
-
-- 空或省略的 namespace 请求仍会归一化为默认 namespace，当前默认 namespace ID 为 `public`。
-- 当前 beta/tag 灰度发布 API 仍可使用，实际由 `config_info_gray` 和 `GrayRule` 模型支撑。
-
-从 3.0 之前版本升级到 3.3.x 时，如果旧部署未使用默认 namespace，且未使用 beta 灰度发布，则本次兼容迁移移除不影响该兼容领域的平滑升级。如果旧部署使用过默认 namespace 或 beta 灰度发布，则不再保证完全平滑升级，需要在升级到 3.3.x 前自行完成数据迁移和验证。
-
-受影响部署至少需要完成以下操作：
-
-1. 检查旧数据库中是否存在 `tenant_id = ''` 的默认 namespace 配置数据。
-2. 在升级到 3.3.x 前，将默认 namespace 数据从空 tenant 迁移到 `tenant_id = 'public'`。如果同一 `data_id`、`group_id` 下同时存在空 tenant 和 `public` 记录，请先确认保留哪一份业务数据，避免迁移后产生冲突。
-3. 检查旧数据库中是否存在 `config_info_beta` 或 `config_info_tag` 灰度数据。
-4. 在升级到 3.3.x 前，将旧 beta/tag 灰度数据迁移到当前 `config_info_gray` 模型，并按当前灰度规则保存对应 `grayName` 和 `GrayRule` 元数据。
-5. 迁移后使用当前客户端或 API 验证默认 namespace 配置读取、正式发布、beta 灰度查询、tag 灰度查询和停止灰度等关键路径。
-
-如果无法在业务侧直接确认迁移格式，可以先升级到仍包含该兼容迁移能力的 3.0.x～3.2.x 版本，完成迁移、稳定运行并验证数据后，再升级到 3.3.x。
-
-#### 2.1.8. 迁移MCP服务（可选）
-
-若您是从3.0.0版本进行升级，且您的集群中存在MCP服务，由于官方社区MCP Registry API标准的改动， MCP Server定义的元数据存在一定的变化， 这部分变化将会导致一定的数据结构不兼容，从3.0.0版本升级到3.0.1及以上版本之后会导致控制台无法读取到旧版本MCP Server数据，因此需要使用[MCP迁移工具](https://download.nacos.io/nacos-server/mcp-migration-tool.jar) 对3.0.0版本的存量MCP服务数据进行迁移。
-
-```shell
-# java -jar ./mcp-migration-tool.jar ${nacos-server-host}:${nacos-server-port} ${username} ${password}
-# 示例
-java -jar ./mcp-migration-tool.jar localhost:8848 nacos ${your_password}
-```
-
-#### 2.1.9. 迁移统一插件配置（Nacos 3.3.0+）
-
-没有使用自定义服务端插件的用户，只需对比当前部署与目标发行包的 `application.properties`，再参考[系统参数](./system-configurations.md)把保留的旧配置迁移到标准 key。AI Resource Import 的模块开关未配置时现在默认开启；如果升级后仍需保持关闭，应在发布前明确设置 `nacos.plugin.ai-resource-import.enabled=false`。使用过旧 Source/preset/list 配置的部署还需按 [AI Resource Import 迁移说明](../../plugin/migration.md#ai-resource-import-breaking-change)处理。
-
-使用自研或第三方服务端插件的用户，除完成上述配置对比外，还需要在升级前检查插件兼容性变化。其中，AI Resource Import 的旧 Importer/Source SPI 已移除，Config Change 的 `ConfigChangeConfigs` 已废弃且只在兼容周期内保留。请先阅读[插件迁移指南](../../plugin/migration.md)，再按使用情况查看 [AI 资源导入插件](../../plugin/ai-resource-import-plugin.md)、[Config Change 插件](../../plugin/config-change-plugin.md)和[插件开发指南](../../plugin/development.md)。
-
-###  2.2. Docker/Kubernetes升级
-
-#### 2.2.1 确认表结构
-
-请参考 [2.1.1 确认表结构](#211-确认表结构)，对比并应用数据库表结构变更。
-
-#### 2.2.2. 确认环境变量
-
-可以对比当前部署版本的环境变量与[系统参数-镜像环境变量](./system-configurations/#2-镜像环境变量)中的环境变量是否有变化，如有，需要修改Docker的环境变量文件或Kubernetes的regcenter中的环境变量。
-
-例如, 添加如下环境变量：
-
-```
-NACOS_AUTH_TOKEN=${长度32位以上的自定义字符串，进行base64编码后的token}
-NACOS_AUTH_IDENTITY_KEY=${任意字符串}
-NACOS_AUTH_IDENTITY_VALUE=${任意字符串}
-```
-
-#### 2.2.3. 修改镜像版本
+容器部署同样需要先完成第 2.1～2.3 节的数据库、历史配置和插件检查。对比目标镜像的环境变量转换规则与挂载的 `application.properties`，不要假设旧环境变量一定能够映射到新的标准插件 key。常用参数见[系统参数 - 启动脚本和镜像变量](./system-configurations.md#启动脚本和镜像变量)。
 
 <Tabs>
-  <TabItem label="Docker">
-    首先修改docker compose所对应的文件中的Nacos版本，例如[Nacos Docker](https://github.com/nacos-group/nacos-docker)项目下的standalone-mysql-8.yaml中的
+  <TabItem label="Docker Compose">
+    更新 Compose 文件中的镜像版本：
+
     ```yaml
     services:
-        nacos:
-            image:
-                nacos/nacos-server:${target_version}
+      nacos:
+        image: nacos/nacos-server:${target_version}
     ```
-    然后执行如下命令进行升级
+
+    先拉取目标镜像。单节点且服务名为 `nacos` 时，可以只重建该服务：
+
     ```bash
-      docker-compose pull
-      docker-compose up -d --remove-orphans
+    docker compose pull
+    docker compose up -d --no-deps nacos
     ```
+
+    Compose 管理多节点集群时，不要用一次 `up` 同时重建所有 Nacos 服务。按服务逐个执行 `docker compose up -d --no-deps ${nacos_service_name}`，确认当前节点重新加入集群且健康后再更新下一个服务。
   </TabItem>
   <TabItem label="Kubernetes">
-    通过kubectl set image 命令更新版本，如：
+    更新工作负载的镜像版本，例如：
+
     ```bash
-        kubectl set image deployment/nacos-deployment ${container_name}=nacos/nacos-server:${target_version}
+    kubectl set image deployment/nacos-deployment \
+      ${container_name}=nacos/nacos-server:${target_version}
+    kubectl rollout status deployment/nacos-deployment
     ```
+
+    根据集群规模设置滚动策略，确认一个 Pod 就绪并重新加入 Nacos 集群后再继续替换。
   </TabItem>
 </Tabs>
 
-## 3. 旧版HTTP API移除说明 (Nacos 3.2.0+)
+### 2.6. 升级后验证与回滚准备
 
-### 3.1 API移除通知
+升级完成后至少验证：
 
-:::caution[重大变更]
-从 **Nacos 3.2.0** 开始,旧版 v1 和 v2 HTTP API 已从 Nacos 主仓库中**移除**。
-:::
+1. 所有节点版本、集群成员列表和健康状态正确，日志中没有 schema、插件加载或配置 alias 错误。
+2. 配置发布/查询、服务注册/发现、控制台登录、Client API 和 Admin API 的鉴权行为符合升级前设置。
+3. 使用过默认 namespace 或灰度发布的部署，重新验证第 2.1.1 节列出的路径。
+4. 在插件管理页面或 API 中检查插件 ID、状态、配置来源及需要重启的字段；确认没有意外启用的实现。
+5. 开启 ARD 时，确认三张检索关系表已创建、索引任务能够收敛；启用 PostgreSQL 向量插件时还要确认 pgvector schema 和数据源连通性。
 
-旧版的 v1 和 v2 HTTP API 不再包含在默认的 Nacos server 发行版中。这些 API 已迁移到单独的旧版适配器模块中。
-
-**受影响的API:**
-- 所有 v1 REST APIs (例如: `/nacos/v1/ns/instance`, `/nacos/v1/cs/configs`)
-- 所有 v2 REST APIs
-
-### 3.2 迁移选项
-
-您有两个选择:
-
-#### 选项 1: 迁移到新API和客户端 (推荐)
-- 使用新的 v3 API
-  - [v3 Admin API 文档](./admin-api)
-  - [v3 Console API 文档](./console-api)
-- 升级到最新的 Nacos 客户端 SDK
-  - [Nacos 客户端文档](../user/overview/other-language)
-
-#### 选项 2: 使用旧版API适配器 (临时方案)
-如果您需要时间进行迁移,可以临时使用旧版适配器恢复旧API。
-
-### 3.3 安装旧版API适配器
-
-:::danger[重要警告]
-- 旧版API适配器**不保证**在未来的Nacos版本中继续支持
-- 该模块**没有社区长期维护计划**
-- 这只是**临时解决方案**,仅用于紧急迁移场景
-- **强烈建议尽快迁移到 v3 API 和新客户端**
-:::
-
-#### 步骤 1: 构建或下载适配器
-
-**方式 A: 从 Release 下载**
-```bash
-# 从 GitHub releases 下载
-wget https://github.com/nacos-group/nacos-api-legacy-adapter/releases/download/v${version}/nacos-api-legacy-adapter-${version}.jar
-```
-
-**方式 B: 从源码构建**
-```bash
-git clone https://github.com/nacos-group/nacos-api-legacy-adapter.git
-cd nacos-api-legacy-adapter
-mvn clean install
-# 输出: target/nacos-api-legacy-adapter-${version}.jar
-```
-
-**环境要求:**
-- JDK 17+
-- Maven 3.6+
-- `nacos.version` 必须与目标 Nacos server 版本匹配
-
-#### 步骤 2: 安装适配器
-
-**对于 Nacos Server 部署:**
-
-1. 将 JAR 文件放入 Nacos `plugins` 目录:
-```bash
-cp nacos-api-legacy-adapter-${version}.jar ${NACOS_HOME}/plugins/
-```
-
-2. 重启 Nacos server:
-```bash
-sh ${NACOS_HOME}/bin/shutdown.sh
-sh ${NACOS_HOME}/bin/startup.sh -m standalone  # 单机模式
-# 或
-sh ${NACOS_HOME}/bin/startup.sh                # 集群模式
-```
-
-3. 当 JAR 文件在 classpath 中时,适配器将自动加载。
-
-**对于嵌入式/自定义应用:**
-
-添加 Maven 依赖:
-```xml
-<dependency>
-    <groupId>com.alibaba.nacos</groupId>
-    <artifactId>nacos-api-legacy-adapter</artifactId>
-    <version>${nacos.version}</version>
-</dependency>
-```
-
-#### 步骤 3: 验证安装
-
-检查 Nacos server 日志以确认:
-```bash
-tail -f ${NACOS_HOME}/logs/nacos.log
-```
-
-查找表明旧版适配器已加载的日志消息。
-
-#### 步骤 4: 测试旧版API
-
-测试您的旧 v1/v2 API 调用是否再次工作:
-```bash
-curl -X GET "http://localhost:8848/nacos/v1/ns/instance/list?serviceName=test"
-```
-
-### 3.4 版本兼容性
-
-| Nacos版本 | 适配器版本 | 兼容性 |
-|----------|----------|--------|
-| 3.2.0    | 3.2.0    | ✅ 兼容 |
-| 3.3.0+   | 匹配Nacos版本 | ⚠️ 请检查兼容性 |
-
-**重要提示:** 适配器版本必须与您的 Nacos server 版本匹配。
-
-### 3.5 规划您的迁移
-
-在使用旧版适配器的同时,请规划您的迁移:
-
-1. **审计您的API使用** - 识别所有 v1/v2 API 调用
-2. **查看新的 v3 API** - 了解新的 API 结构
-3. **更新客户端** - 升级到最新的 Nacos 客户端 SDK
-4. **充分测试** - 在预发环境中测试
-5. **逐步迁移** - 使用功能开关或金丝雀部署
-6. **移除适配器** - 迁移完成后,移除适配器 JAR
-
-### 3.6 获取帮助
-
-- 旧版适配器仓库: https://github.com/nacos-group/nacos-api-legacy-adapter
-- Nacos 主仓库: https://github.com/alibaba/nacos
-- 社区支持: [Nacos 社区](https://nacos.io/community/)
+保留旧发行包、旧配置、插件 JAR 和数据库备份直到观察期结束。回滚前先清理只有 3.3 能识别的插件运行时 override；AI Resource Import 需要将插件 JAR、配置和调用方一起回滚。数据库扩容和新增表不要在紧急回滚时直接反向删除，应使用预先验证的数据库回滚方案。

--- a/src/content/docs/next/zh-cn/plugin/migration.md
+++ b/src/content/docs/next/zh-cn/plugin/migration.md
@@ -22,6 +22,18 @@ sidebar:
 
 对 STATIC `PluginConfigSpec` 配置项，标准完整 key 按“是否存在”取得优先级，而不是按值是否非空。空的标准值仍会屏蔽历史 alias，并可能触发 required 校验；只有彻底删除标准属性后才会回退 alias。同时存在多个 alias 时，按 definition 中的声明顺序取第一个。选择 key 仍遵循各插件族文档中的规则。API 接受的 alias 会被归一化，`plugin-configs.json` 和 local-only map 只保存 canonical item key。
 
+持久化实现状态会覆盖静态 `.enabled` 初始值。升级前除静态文件外，还要导出现有插件状态和运行时配置；否则即使修改了 `application.properties`，已有持久化状态仍可能保持实现启用或禁用。
+
+## SPI 与加载兼容性
+
+统一配置契约为多数旧版零配置插件提供 default 方法，因此它们通常仍能二进制加载，但会显示 `configurable=false`。以下变化需要插件作者在升级前明确处理：
+
+- AI Resource Import 的旧 Importer/Source SPI 没有兼容适配器，必须迁移到 `AiResourceImportServiceBuilder`，并同步更新服务注册、配置和调用方。详细模型见下文。
+- AI Pipeline 不再加载 `PublishPipelineServiceBuilder`。插件应以 public 无参构造直接注册 `PublishPipelineService`，并实现配置 definitions、当前快照和 apply 回调。
+- 第三方数据源插件如果实现或注册了已移除的 `ConfigInfoBetaMapper`、`ConfigInfoTagMapper` 或 `ConfigMigrateMapper`，必须删除这些 SPI 依赖并重新编译。3.0 之前的配置数据迁移应在升级前完成。
+- 相同 `pluginType:pluginName` 的重复实现现在按确定性的 first-wins 规则处理。升级前应消除重复 ID，不能依赖旧版不确定的覆盖顺序。
+- `auth`、`datasource-dialect`、`ai-storage` 等关键插件类型在选中实现缺失、被禁用或初始化失败时可能阻止服务启动。滚动升级前应在预发环境验证实现选择、状态和初始化结果。
+
 ## 实现选择 key
 
 | pluginType | 标准 key | 历史 alias | 默认/行为 |
@@ -32,12 +44,14 @@ sidebar:
 
 这些选择都在启动时快照，变更需要重启。不要用 status API 切换 exclusive 实现。
 
+数据源连接参数也已迁移到统一命名空间：`db.num`、`db.url.{index}`、`db.user[.{index}]`、`db.password[.{index}]`、`db.pool.config.*` 和 JVM 参数 `QUERYTIMEOUT` 应迁移到 `nacos.plugin.datasource.db.*`。连接池 item 使用 canonical kebab-case。这些参数仍只在重启后生效，不通过插件配置 API 动态修改。
+
 ## Auth、Visibility 和 AI Pipeline
 
 - 默认鉴权实现配置从 `nacos.core.auth.plugin.nacos.*` 和 `nacos.core.auth.caching.enabled` 迁到 `nacos.plugin.auth.nacos.*`。
 - LDAP 从 `nacos.core.auth.ldap.*` 迁到 `nacos.plugin.auth.ldap.*`；未被生产代码消费的 `nacos.core.auth.ldap.userdn` 模板 key 不是有效 alias。
 - OIDC 从 `nacos.core.auth.plugin.oidc.*` 迁到 `nacos.plugin.auth.oidc.*`。当前全部字段为 `RESTART`。
-- `nacos.plugin.visibility.enabled` 仍是能力总开关；`nacos.plugin.visibility.type` 只用于历史初始选择。实现状态使用 `visibility:{name}` 的统一状态。
+- `nacos.plugin.visibility.enabled` 仍是能力总开关；废弃的 `nacos.plugin.visibility.type` 是 `RESTART` selector，仍决定 AI 领域请求的实现并参与初始状态计算。`nacos.plugin.visibility.{name}.enabled` 和 `visibility:{name}` 的持久化统一状态决定该实现是否可用。
 - `nacos.plugin.ai-pipeline.enabled` 仍是 Pipeline 总开关；历史 `nacos.plugin.ai-pipeline.type` 只用于启动时初始 chain 状态。后续成员变更使用统一插件状态，节点参数使用各自 definition。
 
 目标发行包已经声明 `nacos.plugin.auth.type=nacos` 和 `auth:nacos` 的标准默认项。升级时应把保留的鉴权选择和实现配置复制到这些标准 key，不能让历史 alias 与目标默认值并存；否则标准 selector 会继续选择 `nacos`，标准 `PluginConfigSpec` key 即使为空也会屏蔽 alias。启动脚本只会特殊迁移 `application.properties` 中有效的旧 token secret，其他鉴权值都需要显式迁移。


### PR DESCRIPTION
## What is the purpose of the change

Restructure the bilingual `next` upgrade guide for Nacos 3.3.0-BETA so that users can identify the required database, authentication, plugin, deployment, and rollback work before upgrading from Nacos 3.0.x, 3.1.x, or 3.2.x.

## Brief changelog

- Clarify that Nacos 3.0.x, 3.1.x, and 3.2.x can upgrade directly to 3.3.x; older source versions only need to apply the database prerequisites documented by the 3.2.x guide.
- Document the 3.3 database changes, including ARD tables, optional PostgreSQL vector storage, permission column expansion, description column expansion, and schema review precautions.
- Document the unified plugin configuration and state model, default auth migration, datasource property migration, removed plugin SPIs, and third-party plugin compatibility checks.
- Replace the old distribution and container instructions with fresh-directory, rolling-upgrade, validation, and rollback guidance.
- Add a 3.3.0-BETA warning that RAD will gradually replace A2A and that existing A2A content is not yet queryable after a direct BETA upgrade.
- Keep the Chinese and English upgrade, plugin migration, and system configuration pages aligned.

## Verification

- `git diff --check`
- Rendered all six changed Chinese and English documentation routes successfully; the linked Chinese and English 3.2.x upgrade routes also returned HTTP 200.
- Dependency installation completed with Node.js 18.
- The full local build reached Astro static entrypoint compilation, then the local x86_64 Node.js 18 process running under Rosetta on an arm64 host aborted with a V8 `BasicBlock` assertion. This is a local runtime failure rather than an MDX diagnostic; native Linux CI remains the authoritative full-build check.

No generated build files are included.
