### PR TITLE
docs: add Nacos 3.3.0-BETA download

### DIFF
--- a/src/content/download/en/nacos-server.mdx
+++ b/src/content/download/en/nacos-server.mdx
@@ -11,6 +11,10 @@ Nacos Server **3.2.3** and **2.5.3** have been released. 3.2.3 improves AI Regis
 
 Feel free to [download and try it out](#stable-versions).
 
+The Nacos Server **3.3.0-BETA** snapshot has also been released, adding protocol-neutral Agent registration, intelligent AI resource discovery, dynamic plugin configuration, and distributed locks, along with Spring Boot 4 and Jackson 3 compatibility.
+
+Feel free to also [download and try the snapshot](#snapshot-versions).
+
 :::
 ## System Requirements
 :::note
@@ -63,3 +67,4 @@ Nacos will be automatically deployed after installation. For more usage, refer t
 Snapshot versions are still in development. We encourage you to try them out and provide feedback, but it is not recommended for production use.
 | Version | Binary Package Download                                                | Docker Image                                                 | MD5                         | Release Notes                                     | Reference Documentation                                  |
 | ---- | ---- | ---- | ---- | ---- | ---- |
+| 3.3.0-BETA | [3.3.0-BETA.zip](https://github.com/alibaba/nacos/releases/download/3.3.0-BETA/nacos-server-3.3.0-BETA.zip) | Snapshots do not provide images. Use [nacos/nacos-server\:latest](https://hub.docker.com/r/nacos/nacos-server/tags?page=1&name=latest) | e443a321af16d6f42d7da5e23e192a2e | [Release Notes](https://github.com/alibaba/nacos/releases/tag/3.3.0-BETA) | [Quick Start](/docs/next/quickstart/quick-start/) |

--- a/src/content/download/zh-cn/nacos-server.mdx
+++ b/src/content/download/zh-cn/nacos-server.mdx
@@ -13,6 +13,10 @@ Nacos Server **3.2.3** 和 **2.5.3** 已发布。3.2.3 聚焦 AI Registry、Skil
 
 欢迎[下载和试用](#稳定版本)。
 
+Nacos Server **3.3.0-BETA** 快照版本也已发布，新增协议无关的 Agent 注册、AI 资源智能发现、动态插件配置和分布式锁，并带来 Spring Boot 4 与 Jackson 3 兼容性。
+
+同时欢迎[下载和试用快照版本](#快照版本)。
+
 :::
 
 
@@ -74,3 +78,4 @@ Nacos Server **3.2.3** 和 **2.5.3** 已发布。3.2.3 聚焦 AI Registry、Skil
 
 | 版本 | 二进制包下载                                                | Docker 镜像                                                 | MD5                         | 发布说明                                     | 参考文档                                  |
 | ---- | ---- | ---- | ---- | ---- | ---- |
+| 3.3.0-BETA | [3.3.0-BETA.zip](https://github.com/alibaba/nacos/releases/download/3.3.0-BETA/nacos-server-3.3.0-BETA.zip) | 快照版本不提供镜像，请使用 [nacos/nacos-server\:latest](https://hub.docker.com/r/nacos/nacos-server/tags?page=1&name=latest) | e443a321af16d6f42d7da5e23e192a2e | [发布说明](https://github.com/alibaba/nacos/releases/tag/3.3.0-BETA) | [快速开始](/docs/next/quickstart/quick-start/) |


### PR DESCRIPTION
## What changed

- add the Nacos Server 3.3.0-BETA snapshot release summary to the Chinese and English download pages
- add the snapshot ZIP download, MD5, release notes, and next-version documentation links
- keep the existing 3.2.3 and 2.5.3 stable release content and download links unchanged

## Verification

- `git diff --check`
- Astro generated both `/download/nacos-server/` and `/en/download/nacos-server/` successfully
- the local full-site build later stopped while rendering the homepage because the sandbox could not resolve `api.github.com`; no download-page build errors were reported
