### PR TITLE
docs: Document nullable MCP Tool output schemas

### DIFF
--- a/src/content/docs/next/en/manual/user/ai/api-to-mcp.md
+++ b/src/content/docs/next/en/manual/user/ai/api-to-mcp.md
@@ -76,6 +76,16 @@ Then click an input parameter such as `NewArg1`, and edit its attributes in `Par
 | Description | Input parameter description for the MCP Tool. |
 | Protocol conversion configuration | Protocol conversion configuration for the AI gateway or protocol conversion proxy. It describes the existing service API that the Tool maps to, such as `url` and parameter mappings. For configuration details, see the [MCP Template Configuration Guide](./mcp-template.md). |
 
+In the Tool output configuration, each output field provides a `Nullable` option. When selected, the field is saved in the MCP Tool `outputSchema` as a union of its original type and `null`. For example, a nullable string field is saved as:
+
+```json
+{
+  "type": ["string", "null"]
+}
+```
+
+When importing an API from OpenAPI 3, `nullable: true` on a response field is automatically converted to the `outputSchema` union type shown above. This conversion applies only to the MCP Tool `outputSchema`, not to `inputSchema`.
+
 After all Tool input parameters are edited, click `OK` to save them. Add other Tools if needed, and then click `Publish as Latest Version` in the upper-right corner.
 
 > The `Save` button in the upper-right corner only saves the content. It does not mark the version as latest or publish the latest version, so AI gateways or protocol conversion proxies may not read the updated Tool information. Use it to save drafts during editing or for gray release scenarios.

--- a/src/content/docs/next/zh-cn/manual/user/ai/api-to-mcp.md
+++ b/src/content/docs/next/zh-cn/manual/user/ai/api-to-mcp.md
@@ -85,6 +85,16 @@ Nacos 能够通过和 [Higress](https://higress.ai) 等AI网关的结合，**0�
 | 描述     | MCP Tools的输入参数描述，自定义描述此MCP服务Tool参数描述信息                                                                                 |                                                                          |
 | 协议转化配置 | 提供给AI网关或协议转换代理的协议转化配置，用于提供给给AI网关或协议转化代理，此工具实际映射的存量服务的API信息，如`url`，`参数映射关系`等，具体配置细节，请参见[MCP模版配置手册](./mcp-template.md)。 |
 
+在 Tool 出参配置中，每个输出字段均提供 `Nullable` 勾选项。勾选后，该字段在 MCP Tool 的 `outputSchema` 中会保存为包含原类型和 `null` 的联合类型。例如，可空的字符串字段会保存为：
+
+```json
+{
+  "type": ["string", "null"]
+}
+```
+
+通过 OpenAPI 3 导入 API 时，响应字段中的 `nullable: true` 会自动转换为上述 `outputSchema` 联合类型。此转换仅适用于 MCP Tool 的 `outputSchema`，不适用于 `inputSchema`。
+
 所有Tool的输入参数编辑完成后， 点击`确定`进行保存，之后重复添加其他的Tool信息后，点击页面右上角`发布为最新版本`。
 
 > 页面右上角的`保存`仅会将内容进行保存，不会标记成最新版本，不进行发布最新版本，可能会导致AI网关或协议转换代理无法读取到新改动的工具信息。可用于编辑过程中保存记录以及灰度使用。


### PR DESCRIPTION
## What is the purpose of the change

Fixes #1140.

Update the next-version documentation for nullable fields in MCP Tool
`outputSchema`.

This documents the functionality introduced for
[alibaba/nacos#15675](https://github.com/alibaba/nacos/issues/15675) and
implemented by
[alibaba/nacos#15698](https://github.com/alibaba/nacos/pull/15698).

## Brief changelog

- Document the `Nullable` option for MCP Tool output fields.
- Explain that a nullable string field is saved as:

  ```json
  {
    "type": ["string", "null"]
  }

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/nacos-group/nacos-group.github.io/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `Fix UnknownException when host config not exist #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Test your code locally by running `npm run build`, and make sure it works as expected.
- [x] Make sure no files under build directory is added.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).