### PR TITLE
Fix default value of nacos.core.auth.enabled in auth docs (zh-cn & en)

### DIFF
--- a/src/content/docs/latest/en/manual/admin/auth.mdx
+++ b/src/content/docs/latest/en/manual/admin/auth.mdx
@@ -33,7 +33,7 @@ For plugin boundaries and development details, see [Auth Plugin](../../plugin/au
 | Property | Default configuration | Description |
 | --- | --- | --- |
 | `nacos.core.auth.system.type` | `nacos` | Selected auth plugin type. Supports `nacos`, `ldap`, `oidc`, or a custom type. |
-| `nacos.core.auth.enabled` | `true` | Enables auth for Open API, SDK, and gRPC requests. |
+| `nacos.core.auth.enabled` | `false` | Enables auth for Open API, SDK, and gRPC requests. |
 | `nacos.core.auth.admin.enabled` | `true` | Enables auth for Admin API requests. |
 | `nacos.core.auth.console.enabled` | `true` | Enables auth for Console API and default console login. |
 | `nacos.core.auth.server.identity.key` | Empty | Server-to-server identity key. Required for auth-enabled clusters. |

--- a/src/content/docs/latest/zh-cn/manual/admin/auth.mdx
+++ b/src/content/docs/latest/zh-cn/manual/admin/auth.mdx
@@ -33,7 +33,7 @@ Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴
 | 配置项 | 默认配置 | 说明 |
 | --- | --- | --- |
 | `nacos.core.auth.system.type` | `nacos` | 当前使用的鉴权插件类型。支持 `nacos`、`ldap`、`oidc` 或自定义类型。 |
-| `nacos.core.auth.enabled` | `true` | 是否开启 Open API、SDK 和 gRPC 请求鉴权。 |
+| `nacos.core.auth.enabled` | `false` | 是否开启 Open API、SDK 和 gRPC 请求鉴权。 |
 | `nacos.core.auth.admin.enabled` | `true` | 是否开启 Admin API 鉴权。 |
 | `nacos.core.auth.console.enabled` | `true` | 是否开启 Console API 和默认控制台登录鉴权。 |
 | `nacos.core.auth.server.identity.key` | 空 | Nacos Server 节点间通信的身份 key。开启鉴权的集群部署必须配置。 |


### PR DESCRIPTION
## What

Fixes #1138.

The auth configuration table in both the zh-cn and en versions of the auth page lists `nacos.core.auth.enabled` as defaulting to `true`. The actual default in `alibaba/nacos` (`distribution/conf/application.properties`) is `false`:

```properties
### If turn on auth:
nacos.core.auth.enabled=false
```

## Changes

- `src/content/docs/latest/zh-cn/manual/admin/auth.mdx`: default `true` -> `false`
- `src/content/docs/latest/en/manual/admin/auth.mdx`: default `true` -> `false`

The other defaults in the same table (`auth.admin.enabled=true`, `auth.console.enabled=true`, empty identity key/value) were cross-checked against `application.properties` and are correct. The `nacos.core.auth.enabled=true` lines later in the page are configuration examples showing how to enable auth and are left unchanged.
