### PR TITLE
[ISSUE #15357] Document Nacos 3.3 default Client auth

### DIFF
--- a/src/content/docs/next/en/guide/user/auth.md
+++ b/src/content/docs/next/en/guide/user/auth.md
@@ -6,7 +6,7 @@ sidebar:
     order: 5
 ---
 
-> This document is kept for compatibility and will be deprecated. For server-side auth setup, see [Admin Manual - Authorization](../../manual/admin/auth.mdx). For SDK and OpenAPI credentials, see [User Manual - Configure Access Credentials](../../manual/user/auth.mdx).
+> This document is kept for compatibility and will be deprecated. Starting with Nacos 3.3, Client API authentication is enabled by default. For current server-side setup, see [Admin Manual - Authorization](../../manual/admin/auth.mdx). For SDK and OpenAPI credentials, see [User Manual - Configure Access Credentials](../../manual/user/auth.mdx).
 
 > Attention
 > - Nacos is an internal micro service component, which needs to run in a trusted internal network. It can not be exposed to the public network environment to prevent security risks.
@@ -20,7 +20,7 @@ sidebar:
 
 |Parameter|Default|Versions|Description|
 |-----|------|------|----|
-|nacos.core.auth.enabled|false|1.2.0 ~ latest|Whether to enable the authentication|
+|nacos.core.auth.enabled|true since 3.3; false before 3.3|1.2.0 ~ latest|Whether to enable Client/Open API, SDK, and gRPC authentication|
 |nacos.plugin.auth.type|nacos|3.3.0 ~ latest|Auth implementation selector|
 |nacos.plugin.auth.nacos.token.secret.key|No default|3.3.0 ~ latest|Default auth access-token signing key; sensitive and RESTART|
 |nacos.plugin.auth.nacos.token.expire.seconds|18000|3.3.0 ~ latest|Login access-token lifetime; RUNTIME|
@@ -35,9 +35,9 @@ sidebar:
 ## Use Authentication in Servers
 
 ### Without Docker
-By default, no login is required to start following the official document configuration, which can expose the configuration center directly to the outside world. However, if the authentication is enabled, one can use nacos only after he configures the user name and password.
+Starting with Nacos 3.3, Client API authentication is enabled by default. Callers must provide credentials supported by the selected auth plugin.
 
-Before enabling authentication, the configuration in application.properties is as follow:
+To retain the earlier unauthenticated Client API behavior temporarily during an upgrade, use this explicit compatibility override:
 ```java
 ### If turn on auth system:
 nacos.core.auth.enabled=false
@@ -60,15 +60,10 @@ After enabling authentication, you can customize the key used to generate JWT to
 > 3. The secret key needs to be consistent between nodes, and if it is inconsistent for a long time, it may cause 403 invalid token error.
 
 ```properties
-nacos.plugin.auth.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
+nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
 ```
 
-When customizing the key, it is recommended to set the configuration item to a **Base64 encoded** string,
-and **the decoded key must not be less than 32 bytes**. For example:
-
-```properties
-nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
-```
+Set the key to a **Base64 encoded** string whose decoded value is **at least 32 bytes**. Generate a deployment-specific secret and do not commit it to source control.
 
 The historical `nacos.core.auth.plugin.nacos.token.secret.key` remains an alias; use the standard key for new configuration.
 
@@ -78,7 +73,7 @@ The historical `nacos.core.auth.plugin.nacos.token.secret.key` remains an alias;
 
 #### Official images
 
-If you choose to use official images, please add the following environment parameter when you start a docker container.
+Nacos 3.3 and later official images enable Client API authentication when `NACOS_AUTH_ENABLE` is unset. You may set it explicitly for auditable deployment configuration:
 
 ```powershell
 NACOS_AUTH_ENABLE=true
@@ -90,26 +85,26 @@ For example, you can run this command to run a docker container with Authenticat
 docker run --env PREFER_HOST_MODE=hostname \
   --env MODE=standalone \
   --env NACOS_AUTH_ENABLE=true \
-  -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
-  -e NACOS_AUTH_IDENTITY_KEY=mpYGXyu7 \
-  -e NACOS_AUTH_IDENTITY_VALUE=mpYGXyu7 \
-  -p 8848:8848 nacos/nacos-server
+  -e NACOS_AUTH_TOKEN=${custom_base64_token_secret_key} \
+  -e NACOS_AUTH_IDENTITY_KEY=${custom_server_identity_key} \
+  -e NACOS_AUTH_IDENTITY_VALUE=${custom_server_identity_value} \
+  -p 8848:8848 nacos/nacos-server:${nacos_3_3_version}
 ```
 
 Besides, you can also add the other related enviroment parameters:
 
 | name                          | description                            | option                                 |
 | ----------------------------- | -------------------------------------- | -------------------------------------- |
-| NACOS_AUTH_ENABLE      |  If turn on auth system        | default :false                          |
+| NACOS_AUTH_ENABLE      |  Client API authentication override        | Unset inherits the image default (`true` for Nacos 3.3+)                          |
 | NACOS_AUTH_TOKEN_EXPIRE_SECONDS      |  The token expiration in seconds        | default :18000                          |
-| NACOS_AUTH_TOKEN      |  The default token        | default :SecretKey012345678901234567890123456789012345678901234567890123456789                          |
+| NACOS_AUTH_TOKEN      |  Base64-encoded token secret        | No default; use a unique production value                          |
 | NACOS_AUTH_CACHE_ENABLE      |  Turn on/off caching of auth information. By turning on this switch, the update of auth information would have a 15 seconds delay.        | default : false   |
 
 
 
 #### Custom images
 
-If you choose to use custom images, please modify the application.properties before you start nacos, change this line 
+If a custom image still carries an explicit compatibility override, change this line before enforcing Client API authentication:
 
 ```
 nacos.core.auth.enabled=false
@@ -138,8 +133,8 @@ try {
 	properties.put("serverAddr", serverAddr);
 
     // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
+        properties.put("username","${username}");
+        properties.put("password","${password}");
 
 	ConfigService configService = NacosFactory.createConfigService(properties);
 } catch (NacosException e) {
@@ -155,7 +150,7 @@ Pending...
 Firstly, the user name and password should be provided to login.
 
 ```plain
-curl -X POST '127.0.0.1:8848/nacos/v1/auth/login' -d 'username=nacos&password=nacos'
+curl -X POST '127.0.0.1:8848/nacos/v1/auth/login' -d 'username=${username}&password=${password}'
 ```
 
 If the user name and password are correct, the response will be:

--- a/src/content/docs/next/en/manual/admin/auth.mdx
+++ b/src/content/docs/next/en/manual/admin/auth.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 > - Nacos provides a simple auth implementation to prevent business misuse. It is a weak auth system, not a strong auth system designed to resist malicious attacks.
 > - If Nacos runs in an untrusted network or you require strong auth, use the official simple implementation as a reference to develop a [custom auth plugin](../../plugin/auth-plugin.md).
 
-Nacos auth is provided by auth plugins. Nacos 3.2 includes the default Nacos auth plugin, LDAP auth plugin, and OIDC/OAuth2 auth plugin. They share the same auth switches, but use different identity sources and permission models.
+Nacos auth is provided by auth plugins. Nacos 3.2 includes the default Nacos auth plugin, LDAP auth plugin, and OIDC/OAuth2 auth plugin. They share the same auth switches, but use different identity sources and permission models. Starting with Nacos 3.3, Client API authentication is also enabled by default; the Client, Admin, and Console API scopes still have independent switches.
 
 ## Choose An Auth Mode
 
@@ -30,26 +30,41 @@ For plugin boundaries and development details, see [Auth Plugin](../../plugin/au
 
 ## Core Configuration
 
-| Property | Default configuration | Description |
-| --- | --- | --- |
-| `nacos.plugin.auth.type` | `nacos` | Selects the auth plugin at startup; `nacos.core.auth.system.type` is a legacy alias. |
-| `nacos.core.auth.enabled` | `false` | Enables auth for Open API, SDK, and gRPC requests. |
-| `nacos.core.auth.admin.enabled` | `true` | Enables auth for Admin API requests. |
-| `nacos.core.auth.console.enabled` | `true` | Enables auth for Console API and default console login. |
-| `nacos.core.auth.server.identity.key` | Empty | Server-to-server identity key. Required for auth-enabled clusters. |
-| `nacos.core.auth.server.identity.value` | Empty | Server-to-server identity value. Required for auth-enabled clusters. |
-| `nacos.plugin.auth.nacos.caching.enabled` | `true` | Caches users, roles, and permissions; `nacos.core.auth.caching.enabled` is a historical alias. Permission changes may have about 15 seconds of delay. |
-| `nacos.plugin.auth.nacos.token.secret.key` | Empty | Default token signing key; sensitive and RESTART. `nacos.core.auth.plugin.nacos.token.secret.key` is a historical alias. |
-| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | Token lifetime; RUNTIME. `nacos.core.auth.plugin.nacos.token.expire.seconds` is a historical alias. |
-| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | Token cache switch; RUNTIME. `nacos.core.auth.plugin.nacos.token.cache.enable` is a historical alias. |
+| Property | Official Docker environment variable | Nacos 3.3 server default | Description |
+| --- | --- | --- | --- |
+| `nacos.plugin.auth.type` | `NACOS_AUTH_SYSTEM_TYPE` | `nacos` | Selects the auth plugin at startup. `nacos.core.auth.system.type` is a legacy alias, and the current image maps the environment variable through that alias. |
+| `nacos.core.auth.enabled` | `NACOS_AUTH_ENABLE` | `true` | Client/Open API auth switch. It covers SDK, Client HTTP API, and gRPC requests. |
+| `nacos.core.auth.admin.enabled` | `NACOS_AUTH_ADMIN_ENABLE` | `true` | Admin API auth switch. It covers `/v3/admin/*` and plugin-owned endpoints designated as `ADMIN_API`. |
+| `nacos.core.auth.console.enabled` | `NACOS_AUTH_CONSOLE_ENABLE` | `true` | Console API and default console login auth switch. It covers `/v3/console/*`, console login behavior, and plugin endpoints protected by Console-scoped auth resources. |
+| `nacos.core.auth.server.identity.key` | `NACOS_AUTH_IDENTITY_KEY` | Empty | Server-to-server identity key. It must be non-empty when Client API auth is enabled. |
+| `nacos.core.auth.server.identity.value` | `NACOS_AUTH_IDENTITY_VALUE` | Empty | Server-to-server identity value. It must be non-empty when Client API auth is enabled. |
+| `nacos.plugin.auth.nacos.caching.enabled` | `NACOS_AUTH_CACHE_ENABLE` | `true` | Caches users, roles, and permissions. `nacos.core.auth.caching.enabled` is a historical alias; the current image maps the environment variable through that alias and uses `false` when the variable is unset. Permission changes may have about 15 seconds of delay. |
+| `nacos.plugin.auth.nacos.token.secret.key` | `NACOS_AUTH_TOKEN` | Empty | Default Nacos token signing key; sensitive and RESTART. `nacos.core.auth.plugin.nacos.token.secret.key` is a historical alias, and the current image maps the environment variable through that alias. |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | `NACOS_AUTH_TOKEN_EXPIRE_SECONDS` | `18000` | Token lifetime; RUNTIME. `nacos.core.auth.plugin.nacos.token.expire.seconds` is a historical alias, and the current image maps the environment variable through that alias. |
+| `nacos.plugin.auth.nacos.token.cache.enable` | - | `false` | Token cache switch; RUNTIME. `nacos.core.auth.plugin.nacos.token.cache.enable` is a historical alias. |
+
+The Client, Admin, and Console API switches do not change one another. `/v3/auth/*` consists of plugin-provided APIs and must not be assigned to a scope from the URL alone: login is intentionally public; initial administrator bootstrap is available only while no global administrator exists; and user, role, and permission management endpoints are protected by their Console-scoped auth resources. Endpoints explicitly designated as public, bootstrap-only, or health checks also remain identity-free despite the default change.
 
 :::note
 After an upgrade, your cluster may keep old values. Always check the actual `application.properties`, environment variables, and startup parameters of the running cluster.
 :::
 
-## Enable Default Nacos Auth
+In the official Docker image, leaving `NACOS_AUTH_ENABLE` unset adds no JVM override, so the image's built-in value applies. Nacos 3.3 and later images enable Client API auth by default. An explicit `true` or `false` always overrides that default. Environment-variable mappings may differ between image versions, so check the target image documentation during an upgrade.
 
-Default Nacos auth uses local users, roles, permissions, and tokens. It provides the `/v3/auth/user`, `/v3/auth/role`, and `/v3/auth/permission` APIs. These APIs belong to the default auth plugin. Other auth plugins do not necessarily support them.
+### Credential Prerequisites For Default Nacos Auth
+
+- `nacos.plugin.auth.nacos.token.secret.key` must be valid Base64 whose decoded value is at least 32 bytes. Generate a strong, deployment-specific value for production.
+- When Client API auth is enabled, `nacos.core.auth.server.identity.key` and `nacos.core.auth.server.identity.value` must be non-empty. Use the same values on every member of one cluster, and do not reuse them across clusters.
+- The standard distribution startup script migrates a valid legacy token secret and interactively requests missing required values. Automated deployments should write these values before first startup instead of depending on interactive input.
+- The official Docker startup script requires non-empty `NACOS_AUTH_TOKEN`, `NACOS_AUTH_IDENTITY_KEY`, and `NACOS_AUTH_IDENTITY_VALUE`. Keep these credentials configured even while Client API auth is temporarily disabled so it can be re-enabled safely.
+
+:::caution
+Do not put token secrets, server identity values, or user passwords in images, public Compose or Helm files, or source control. Inject them through a secret manager or a controlled Secret in production, and restrict access to the configuration files and Secrets.
+:::
+
+## Configure Default Nacos Auth
+
+Default Nacos auth uses local users, roles, permissions, and tokens. It provides the `/v3/auth/user`, `/v3/auth/role`, and `/v3/auth/permission` APIs. These APIs belong to the default auth plugin. Other auth plugins do not necessarily support them. All three API scopes default to enabled in Nacos 3.3; the examples still set each switch explicitly so the complete deployment configuration is easy to audit.
 
 <Tabs>
   <TabItem label="Non-Docker deployment">
@@ -94,7 +109,7 @@ Default Nacos auth uses local users, roles, permissions, and tokens. It provides
       --env NACOS_AUTH_TOKEN=${custom_base64_token_secret_key} \
       --env NACOS_AUTH_IDENTITY_KEY=${custom_server_identity_key} \
       --env NACOS_AUTH_IDENTITY_VALUE=${custom_server_identity_value} \
-      -p 8848:8848 -p 9848:9848 nacos/nacos-server
+      -p 8848:8848 -p 9848:9848 nacos/nacos-server:${nacos_3_3_version}
     ```
 
   </TabItem>
@@ -249,20 +264,36 @@ Notes:
 - When a cached token is close to expiration, the login API issues a new token.
 - Check your current image version for Docker environment variable support.
 
-## Disable Console Auth
+## Enable Or Temporarily Disable An Auth Scope
 
-Since Nacos 3.0, console auth is enabled by default. For local development or a controlled temporary environment, you can disable it:
+The three scope switches are independent. Omitting a switch in Nacos 3.3 enables that scope; you may also set `true` explicitly. If client credential rollout is incomplete before an upgrade, use an explicit Client-scope opt-out only as a time-bounded compatibility measure:
 
 ```properties
+nacos.core.auth.enabled=false
+```
+
+For Docker deployments, use:
+
+```shell
+NACOS_AUTH_ENABLE=false
+```
+
+`nacos.core.auth.enabled` is runtime-refreshable, but a configuration-file refresh applies only to the current node. Apply and verify the same effective value on every cluster member. Changing an environment variable normally requires a rolling container replacement. After client credentials and permissions have been verified, change the value to `true`, or remove the explicit `false` from a Nacos 3.3 deployment to restore the enabled default.
+
+To disable Admin API or Console API auth temporarily in local development or a controlled environment, set the corresponding independent switch:
+
+```properties
+nacos.core.auth.admin.enabled=false
 nacos.core.auth.console.enabled=false
 ```
 
 :::caution
-After console auth is disabled, the console can be accessed without login. This can leak data and cause accidental changes. Do not disable it in production.
+Disabling any auth scope lets requests that would normally be protected in that scope bypass identity and permission checks. This may expose data, allow configuration changes, or permit unauthorized service registrations. Never disable Admin or Console API auth in production. If Client API auth must be disabled temporarily, restrict network access, record an owner and restoration deadline, and re-enable it as soon as client credentials are ready.
 :::
 
 ## Upgrade Notes
 
+- When upgrading from 3.0.x–3.2.x to 3.3.x, an absent `nacos.core.auth.enabled` changes from "Client API auth disabled" to "enabled." Older clients and direct OpenAPI calls without a username, password, or token will be rejected. Prepare users, roles, permissions, and client credentials before upgrading; see the [Upgrade Manual](./upgrading.mdx#212-prepare-for-default-client-api-authentication).
 - If an administrator user `nacos` already exists before upgrade, Nacos does not ask for administrator initialization again.
 - If the old cluster still uses a default or weak password, change it after upgrade.
 - When upgrading old LDAP deployments to 3.2, make sure the LDAP plugin jar and `spring-ldap-core` dependency are both available in `plugins/`.

--- a/src/content/docs/next/en/manual/admin/system-configurations.md
+++ b/src/content/docs/next/en/manual/admin/system-configurations.md
@@ -225,7 +225,7 @@ For auth setup, read [Authorization](./auth.mdx) and [OIDC/OAuth2 Authentication
 | Property | Description | Default |
 | --- | --- | --- |
 | `nacos.plugin.auth.type` | Select the auth implementation at startup; `nacos.core.auth.system.type` is a legacy alias. | `nacos` |
-| `nacos.core.auth.enabled` | Whether the general auth system and Open API authentication are enabled, including Client/Open HTTP APIs and SDK/gRPC requests. | `false` |
+| `nacos.core.auth.enabled` | Whether the general auth system and Open API authentication are enabled, including Client/Open HTTP APIs and SDK/gRPC requests. Enabled by default since Nacos 3.3; an explicit `false` remains a temporary compatibility override. | `true` |
 | `nacos.core.auth.admin.enabled` | Whether Admin API scope authentication is enabled, including plugin-owned endpoints marked `ADMIN_API` as well as `/v3/admin/*`. | `true` |
 | `nacos.core.auth.console.enabled` | Whether `/v3/console/*` Console API and login authentication are enabled. | `true` |
 | `nacos.plugin.auth.nacos.caching.enabled` | Whether auth information is cached; `nacos.core.auth.caching.enabled` is a historical alias. Permission updates may have a short delay when enabled. | `true` |

--- a/src/content/docs/next/en/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/en/manual/admin/upgrading.mdx
@@ -44,6 +44,7 @@ Complete these preparations before upgrading a production cluster:
 1. Confirm that the source cluster version is supported and that the database schema meets the requirements of the target 3.3.x release. See section 2.2 for database checks and changes.
 2. Back up the database, each node's `data`, `conf`, and `cluster.conf`, and any custom plugins and configuration.
 3. Rehearse the upgrade and rollback in staging with a copy of production data.
+4. Inventory Client API callers and complete the auth migration in section 2.1.2. Do not wait for the first 3.3 node to start before distributing client credentials.
 
 <a id="217-config-compatibility-migration-removal-nacos-330"></a>
 
@@ -52,6 +53,41 @@ Complete these preparations before upgrading a production cluster:
 Nacos 3.3 removes the Config compatibility migration and no longer supports a direct smooth upgrade from 2.x. After a direct upgrade from 2.x to 3.3.x, Config data previously stored in the default namespace will no longer be queryable.
 
 Before upgrading, confirm that the deployment has not used Config data in the default namespace. If it has, or if this cannot be confirmed, first upgrade to 3.0.x–3.2.x and verify that the default-namespace Config data remains queryable, then upgrade to 3.3.x.
+
+#### 2.1.2. Prepare For Default Client API Authentication
+
+Nacos 3.3 enables Client API authentication by default. Only the missing-value default for the Client scope changes; the three auth scopes remain independent:
+
+| Property | Request scope | 3.0.x–3.2.x missing-value default | 3.3.x missing-value default |
+| --- | --- | --- | --- |
+| `nacos.core.auth.enabled` | Client/Open APIs, Java SDK, and gRPC requests | `false` | `true` |
+| `nacos.core.auth.admin.enabled` | `/v3/admin/*` Admin APIs | `true` | `true` |
+| `nacos.core.auth.console.enabled` | `/v3/console/*` Console APIs and console login | `true` | `true` |
+
+After a cluster without an explicit `nacos.core.auth.enabled` value upgrades to 3.3, unauthenticated Config publish/query, service registration/discovery/subscription, and other protected Client HTTP, SDK, or gRPC requests are rejected. An older client is not necessarily incompatible by version; the risk is that the caller has no supported username, password, token, or other identity material required by the selected auth plugin. Admin and Console API defaults do not change. Endpoints explicitly designated as public, bootstrap-only, or health checks keep their own rules. `/v3/auth/*` consists of plugin APIs and must not be assigned to the Client scope from its URL alone.
+
+Complete these steps before a production upgrade:
+
+1. Inventory every direct OpenAPI caller, SDK, gateway, automation job, and side script, including the resources and read/write actions it needs.
+2. Confirm the auth plugin type. For the default `nacos` plugin, prepare a deployment-specific token secret and Server identity. The token secret must be valid Base64 whose decoded value is at least 32 bytes. Every member of one cluster must use the same token secret and identity.
+3. Use an existing protected management path to initialize or confirm the administrator, then create application-specific users, roles, and least-privilege permissions. Do not distribute global administrator credentials to business clients.
+4. Configure each caller with a username/password, token, or the identity material required by the selected plugin before the server upgrade. See [Client Authentication](../user/auth.mdx) for SDK examples.
+5. In staging, verify successful reads and writes plus anonymous, invalid-identity, no-permission, and resource-boundary cases. Confirm that every cluster member has the same effective value for all three switches.
+
+If all clients cannot be updated before the upgrade window, Client API auth may be disabled explicitly for a short compatibility period. Keep the token secret, Server identity, users, roles, and permissions configured so auth can be re-enabled later:
+
+| Deployment | Temporary explicit opt-out |
+| --- | --- |
+| Native distribution | Set `nacos.core.auth.enabled=false` in `conf/application.properties` on every member. The property is runtime-refreshable, but file refresh is node-local, so apply and verify it member by member. |
+| Docker | Set `NACOS_AUTH_ENABLE=false`. Leaving the variable unset in a 3.3 image inherits the enabled default; explicit `true` or `false` overrides the image default. |
+| Helm | Set `nacos.auth.enabled=false`, for example `helm upgrade ${release_name} ./ --reuse-values --set nacos.auth.enabled=false`. This field is tri-state `null`/`true`/`false`: `null` omits `NACOS_AUTH_ENABLE` and inherits the selected image's default. |
+| Operator | Set `spec.certification.enabled: false` in the Nacos custom resource. This field is also tri-state `null`/`true`/`false`: `null` or omission leaves out `NACOS_AUTH_ENABLE` and inherits the selected image's default. |
+
+The Helm and Operator fields control only Client API auth; neither changes Admin or Console API auth. With Helm, use `nacos.auth.existingSecret` for the token and Server identity in production. On the first upgrade from chart 1.0.0 or earlier, use `--reuse-values` if the release still depends on legacy inline credentials, or create an external Secret first. Do not put fixed production credentials in values, custom resources, Compose files, or source control.
+
+:::caution[Temporary opt-out expands unauthenticated access]
+Use explicit `false` only for a time-bounded upgrade compatibility window. Keep Nacos on a trusted network, restrict ingress and callers, and record an owner and restoration deadline. After client credentials and permissions are verified, set the value to `true` on every member. If the selected image is Nacos 3.3 or later, Docker, `nacos.auth.enabled`, or `spec.certification.enabled` may instead be restored to `null`/omitted so the deployment inherits the enabled default again.
+:::
 
 ### 2.2. Apply Database Changes
 
@@ -326,7 +362,7 @@ The initial migration does not automatically delete historical A2A Config or per
 At minimum, verify the following after the upgrade:
 
 1. Node versions, cluster membership, and health are correct, with no schema, plugin-loading, or configuration-alias errors in the logs.
-2. Config publish/query, service register/discover, Console login, Client API, and Admin API authentication match the pre-upgrade settings.
+2. Config publish/query, service register/discover, and Console login succeed, and the effective Client, Admin, and Console API auth switches match the rollout plan. When Client API auth is enabled, verify that valid clients succeed and anonymous, invalid-identity, and unauthorized requests fail. If it remains temporarily disabled, verify the network restriction and restoration deadline.
 3. Deployments upgraded from 2.x through an intermediate release can still query Config data in the default namespace.
 4. Plugin management reports the expected plugin IDs, states, configuration sources, and restart-required fields, with no implementation enabled unexpectedly.
 5. When AI Resource Search is enabled, all three relational tables exist and index tasks converge. When the PostgreSQL vector plugin is enabled, also verify the pgvector schema and datasource connectivity.

--- a/src/content/docs/next/zh-cn/guide/user/auth.md
+++ b/src/content/docs/next/zh-cn/guide/user/auth.md
@@ -6,7 +6,7 @@ sidebar:
     order: 5
 ---
 
-> 该文档即将废弃，若想查看服务端如何开启鉴权功能，推荐查看[运维手册-权限校验](../../manual/admin/auth.mdx)；若想查看客户端如何配置访问凭据，推荐查看[用户手册-配置访问凭据](../../manual/user/auth.mdx)。
+> 该文档即将废弃。Nacos 3.3 起 Client API 鉴权默认开启。若想查看当前服务端配置，推荐查看[运维手册-权限校验](../../manual/admin/auth.mdx)；若想查看客户端如何配置访问凭据，推荐查看[用户手册-配置访问凭据](../../manual/user/auth.mdx)。
 
 > 注意
 > - Nacos是一个内部微服务组件，需要在可信的内部网络中运行，不可暴露在公网环境，防止带来安全风险。
@@ -19,7 +19,7 @@ sidebar:
 
 |参数名|默认值|启止版本|说明|
 |-----|------|------|----|
-|nacos.core.auth.enabled|false|1.2.0 ~ latest|是否开启鉴权功能|
+|nacos.core.auth.enabled|3.3 起为 true；3.3 前为 false|1.2.0 ~ latest|是否开启 Client/Open API、SDK 和 gRPC 鉴权|
 |nacos.plugin.auth.type|nacos|3.3.0 ~ latest|鉴权实现选择|
 |nacos.plugin.auth.nacos.token.secret.key|无默认值|3.3.0 ~ latest|默认鉴权插件的 accessToken 签名密钥，敏感且 RESTART|
 |nacos.plugin.auth.nacos.token.expire.seconds|18000|3.3.0 ~ latest|用户登录 accessToken 过期时间，RUNTIME|
@@ -39,9 +39,9 @@ sidebar:
 
 ### 非Docker环境
 
-按照官方文档配置启动,默认是不需要登录的，这样会导致配置中心对外直接暴露。而启用鉴权之后，需要在使用用户名和密码登录之后，才能正常使用nacos。
+Nacos 3.3 起 Client API 鉴权默认开启，调用方必须提供所选鉴权插件支持的凭据。
 
-开启鉴权之前，application.properties中的配置信息为：
+升级期间如需临时维持早期版本的 Client API 无鉴权行为，可使用以下显式兼容配置：
 ```java
 ### If turn on auth system:
 nacos.core.auth.enabled=false
@@ -63,14 +63,10 @@ nacos.core.auth.enabled=true
 > 3. 密钥需要保持节点间一致，长时间不一致可能导致403 invalid token错误。
 
 ```properties
-nacos.plugin.auth.nacos.token.secret.key=SecretKey012345678901234567890123456789012345678901234567890123456789
+nacos.plugin.auth.nacos.token.secret.key=${custom_base64_token_secret_key}
 ```
 
-自定义密钥时，推荐将配置项设置为 **Base64 编码**的字符串，且**解码后的密钥不得少于 32 字节**。例如：
-
-```properties
-nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
-```
+请使用 **Base64 编码**且**解码后不少于 32 字节**的密钥。每个生产部署应生成独立值，不要提交到代码仓库。
 
 历史 `nacos.core.auth.plugin.nacos.token.secret.key` 仍作为 alias；新配置请使用标准 key。
 
@@ -80,7 +76,7 @@ nacos.plugin.auth.nacos.token.secret.key=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU
 
 #### 官方镜像
 
-如果使用官方镜像，请在启动docker容器时，添加如下环境变量
+Nacos 3.3 及以上官方镜像在未设置 `NACOS_AUTH_ENABLE` 时默认开启 Client API 鉴权。也可以显式设置，方便审计部署配置：
 
 ```powershell
 NACOS_AUTH_ENABLE=true
@@ -92,19 +88,19 @@ NACOS_AUTH_ENABLE=true
 docker run --env PREFER_HOST_MODE=hostname \
   --env MODE=standalone \
   --env NACOS_AUTH_ENABLE=true \
-  -e NACOS_AUTH_TOKEN=SecretKeyM1Z2WDc4dnVyZkQ3NmZMZjZ3RHRwZnJjNFROdkJOemEK \
-  -e NACOS_AUTH_IDENTITY_KEY=mpYGXyu7 \
-  -e NACOS_AUTH_IDENTITY_VALUE=mpYGXyu7 \
-  -p 8848:8848 nacos/nacos-server
+  -e NACOS_AUTH_TOKEN=${custom_base64_token_secret_key} \
+  -e NACOS_AUTH_IDENTITY_KEY=${custom_server_identity_key} \
+  -e NACOS_AUTH_IDENTITY_VALUE=${custom_server_identity_value} \
+  -p 8848:8848 nacos/nacos-server:${nacos_3_3_version}
 ```
 
 除此之外，还可以添加其他鉴权相关的环境变量信息：
 
 | name                          | description                            | option                                 |
 | ----------------------------- | -------------------------------------- | -------------------------------------- |
-| NACOS_AUTH_ENABLE      |  是否开启权限系统        | 默认:false|
+| NACOS_AUTH_ENABLE      |  Client API 鉴权覆盖值        | 未设置时继承镜像默认值（Nacos 3.3+ 为 `true`）|
 | NACOS_AUTH_TOKEN_EXPIRE_SECONDS      |  token 失效时间 | 默认:18000                          |
-| NACOS_AUTH_TOKEN      |  token        | 默认:SecretKey012345678901234567890123456789012345678901234567890123456789      |
+| NACOS_AUTH_TOKEN      |  Base64 编码的 token secret        | 无默认值；生产环境应使用独立值      |
 | NACOS_AUTH_CACHE_ENABLE      |  权限缓存开关 ,开启后权限缓存的更新默认有15秒的延迟       | 默认 : false   |
 
 
@@ -115,7 +111,7 @@ docker-compose -f example/standalone-derby.yaml up
 
 #### 自定义镜像
 
-如果选择自定义镜像，请在构建镜像之前，修改nacos工程中的application.properties文件，
+如果自定义镜像仍保留显式兼容配置，在正式启用 Client API 鉴权前修改 application.properties：
 
 将下面这一行配置信息
 ```
@@ -146,8 +142,8 @@ try {
 	properties.put("serverAddr", serverAddr);
 
     // if need username and password to login
-        properties.put("username","nacos");
-        properties.put("password","nacos");
+        properties.put("username","${username}");
+        properties.put("password","${password}");
 
 	ConfigService configService = NacosFactory.createConfigService(properties);
 } catch (NacosException e) {
@@ -163,7 +159,7 @@ try {
 首先需要使用用户名和密码登陆nacos。
 
 ```plain
-curl -X POST '127.0.0.1:8848/nacos/v1/auth/login' -d 'username=nacos&password=nacos'
+curl -X POST '127.0.0.1:8848/nacos/v1/auth/login' -d 'username=${username}&password=${password}'
 ```
 
 若用户名和密码正确,返回信息如下:

--- a/src/content/docs/next/zh-cn/manual/admin/auth.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/auth.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 > - Nacos提供简单的鉴权实现，为防止业务错用的弱鉴权体系，不是防止恶意攻击的强鉴权体系。
 > - 如果运行在不可信的网络环境或者有强鉴权诉求，请参考官方简单实现做进行[自定义插件开发](../../plugin/auth-plugin.md)。
 
-Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴权、LDAP 鉴权和 OIDC/OAuth2 鉴权。不同插件使用同一套开关，但身份来源和权限模型不同。
+Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴权、LDAP 鉴权和 OIDC/OAuth2 鉴权。不同插件使用同一套开关，但身份来源和权限模型不同。Nacos 3.3 起，Client API 鉴权也默认开启；Client API、Admin API 和 Console API 三个范围仍由独立开关控制。
 
 ## 选择鉴权模式
 
@@ -30,26 +30,41 @@ Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴
 
 ## 核心配置
 
-| 配置项 | 默认配置 | 说明 |
-| --- | --- | --- |
-| `nacos.plugin.auth.type` | `nacos` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias。 |
-| `nacos.core.auth.enabled` | `false` | 是否开启 Open API、SDK 和 gRPC 请求鉴权。 |
-| `nacos.core.auth.admin.enabled` | `true` | 是否开启 Admin API 鉴权。 |
-| `nacos.core.auth.console.enabled` | `true` | 是否开启 Console API 和默认控制台登录鉴权。 |
-| `nacos.core.auth.server.identity.key` | 空 | Nacos Server 节点间通信的身份 key。开启鉴权的集群部署必须配置。 |
-| `nacos.core.auth.server.identity.value` | 空 | Nacos Server 节点间通信的身份 value。开启鉴权的集群部署必须配置。 |
-| `nacos.plugin.auth.nacos.caching.enabled` | `true` | 是否缓存用户、角色、权限信息；`nacos.core.auth.caching.enabled` 是历史 alias。权限变更可能存在约 15 秒延迟。 |
-| `nacos.plugin.auth.nacos.token.secret.key` | 空 | 默认 Nacos token 签名密钥，敏感且 RESTART；`nacos.core.auth.plugin.nacos.token.secret.key` 是历史 alias。 |
-| `nacos.plugin.auth.nacos.token.expire.seconds` | `18000` | token 有效期，RUNTIME；`nacos.core.auth.plugin.nacos.token.expire.seconds` 是历史 alias。 |
-| `nacos.plugin.auth.nacos.token.cache.enable` | `false` | token 缓存开关，RUNTIME；`nacos.core.auth.plugin.nacos.token.cache.enable` 是历史 alias。 |
+| 配置项 | 官方 Docker 环境变量 | 3.3 服务端缺省值 | 说明 |
+| --- | --- | --- | --- |
+| `nacos.plugin.auth.type` | `NACOS_AUTH_SYSTEM_TYPE` | `nacos` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias，当前镜像通过该 alias 映射环境变量。 |
+| `nacos.core.auth.enabled` | `NACOS_AUTH_ENABLE` | `true` | Client/Open API 鉴权开关，覆盖 SDK、Client HTTP API 和 gRPC 请求。 |
+| `nacos.core.auth.admin.enabled` | `NACOS_AUTH_ADMIN_ENABLE` | `true` | Admin API 鉴权开关，覆盖 `/v3/admin/*` 以及标记为 `ADMIN_API` 的插件端点。 |
+| `nacos.core.auth.console.enabled` | `NACOS_AUTH_CONSOLE_ENABLE` | `true` | Console API 和默认控制台登录鉴权开关，覆盖 `/v3/console/*`、控制台登录行为以及受 Console scope 鉴权资源保护的插件端点。 |
+| `nacos.core.auth.server.identity.key` | `NACOS_AUTH_IDENTITY_KEY` | 空 | Nacos Server 节点间通信的身份 key。开启 Client API 鉴权时必须为非空。 |
+| `nacos.core.auth.server.identity.value` | `NACOS_AUTH_IDENTITY_VALUE` | 空 | Nacos Server 节点间通信的身份 value。开启 Client API 鉴权时必须为非空。 |
+| `nacos.plugin.auth.nacos.caching.enabled` | `NACOS_AUTH_CACHE_ENABLE` | `true` | 是否缓存用户、角色、权限信息；`nacos.core.auth.caching.enabled` 是历史 alias，当前镜像通过该 alias 映射环境变量且变量未设置时使用 `false`。权限变更可能存在约 15 秒延迟。 |
+| `nacos.plugin.auth.nacos.token.secret.key` | `NACOS_AUTH_TOKEN` | 空 | 默认 Nacos token 签名密钥，敏感且 RESTART；`nacos.core.auth.plugin.nacos.token.secret.key` 是历史 alias，当前镜像通过该 alias 映射环境变量。 |
+| `nacos.plugin.auth.nacos.token.expire.seconds` | `NACOS_AUTH_TOKEN_EXPIRE_SECONDS` | `18000` | token 有效期，RUNTIME；`nacos.core.auth.plugin.nacos.token.expire.seconds` 是历史 alias，当前镜像通过该 alias 映射环境变量。 |
+| `nacos.plugin.auth.nacos.token.cache.enable` | - | `false` | token 缓存开关，RUNTIME；`nacos.core.auth.plugin.nacos.token.cache.enable` 是历史 alias。 |
+
+Client API、Admin API 和 Console API 的开关互不联动。`/v3/auth/*` 是鉴权插件提供的 API，不应仅根据 URL 将它归入某个范围：登录接口有意保持公开；首次管理员初始化只在尚无全局管理员时开放；用户、角色和权限管理接口受各自的 Console 鉴权资源保护。明确标记为公开、首次初始化或健康检查的端点也不因默认值变化而改为需要身份。
 
 :::note
 如果你从旧版本升级，实际配置可能保留旧值。请以当前集群的 `application.properties`、环境变量和启动参数为准。
 :::
 
-## 开启默认 Nacos 鉴权
+官方 Docker 镜像中，`NACOS_AUTH_ENABLE` 未设置时不会添加 JVM 覆盖值，因此使用镜像内的默认值；Nacos 3.3 及以上镜像会启用 Client API 鉴权。显式 `true` 或 `false` 始终覆盖默认值。不同镜像版本的环境变量映射可能不同，升级时应以目标镜像说明为准。
 
-默认 Nacos 鉴权使用本地用户、角色、权限和 token。它提供 `/v3/auth/user`、`/v3/auth/role`、`/v3/auth/permission` 等 v3 Auth API。这些 API 属于默认鉴权插件，不是所有鉴权插件都支持。
+### 默认 Nacos 鉴权的凭据前置条件
+
+- `nacos.plugin.auth.nacos.token.secret.key` 必须是有效 Base64，解码后不少于 32 字节。每个生产部署应使用独立的强随机值。
+- 开启 Client API 鉴权时，`nacos.core.auth.server.identity.key` 和 `nacos.core.auth.server.identity.value` 必须非空；同一集群各节点使用相同值，不同集群不要复用。
+- 标准发行包的启动脚本会迁移有效的历史 token secret，并在必填值为空时交互提示输入。自动化部署应在首次启动前显式写入这些值，避免依赖交互输入。
+- 官方 Docker 启动脚本要求 `NACOS_AUTH_TOKEN`、`NACOS_AUTH_IDENTITY_KEY` 和 `NACOS_AUTH_IDENTITY_VALUE` 非空，即使临时显式关闭 Client API 鉴权也应保留这些凭据，以便后续安全地重新开启。
+
+:::caution
+不要把 token secret、节点身份值或用户密码写入镜像、公共 Compose/Helm 文件或代码仓库。生产环境应通过密钥管理系统或受控 Secret 注入，并限制配置文件和 Secret 的读取权限。
+:::
+
+## 配置默认 Nacos 鉴权
+
+默认 Nacos 鉴权使用本地用户、角色、权限和 token。它提供 `/v3/auth/user`、`/v3/auth/role`、`/v3/auth/permission` 等 v3 Auth API。这些 API 属于默认鉴权插件，不是所有鉴权插件都支持。Nacos 3.3 中三个 API 范围均默认开启，下面仍显式列出开关，便于核对完整部署配置。
 
 <Tabs>
   <TabItem label="非 Docker 部署">
@@ -94,7 +109,7 @@ Nacos 的鉴权能力由鉴权插件提供。Nacos 3.2 内置了默认 Nacos 鉴
       --env NACOS_AUTH_TOKEN=${custom_base64_token_secret_key} \
       --env NACOS_AUTH_IDENTITY_KEY=${custom_server_identity_key} \
       --env NACOS_AUTH_IDENTITY_VALUE=${custom_server_identity_value} \
-      -p 8848:8848 -p 9848:9848 nacos/nacos-server
+      -p 8848:8848 -p 9848:9848 nacos/nacos-server:${nacos_3_3_version}
     ```
 
   </TabItem>
@@ -249,20 +264,36 @@ nacos.plugin.auth.nacos.token.cache.enable=true
 - 当缓存中的 token 接近过期时，登录接口会重新签发 token。
 - Docker 镜像是否暴露对应环境变量，请以当前镜像版本说明为准。
 
-## 关闭控制台鉴权
+## 开启或临时关闭鉴权范围
 
-从 Nacos 3.0 起，控制台访问默认开启鉴权。如果只在本地开发或受控环境中临时关闭，可以设置：
+三个范围的开关相互独立。Nacos 3.3 中省略开关等同于启用；也可以显式设置 `true`。如果升级前尚未完成 Client 凭据改造，只能把显式关闭作为有明确期限的兼容措施：
 
 ```properties
+nacos.core.auth.enabled=false
+```
+
+Docker 部署使用：
+
+```shell
+NACOS_AUTH_ENABLE=false
+```
+
+`nacos.core.auth.enabled` 支持运行时刷新，但配置文件刷新只作用于当前节点。集群必须在每个节点应用并核对相同的有效值。环境变量变更通常需要滚动重建容器。客户端凭据和权限验证完成后，将该值改为 `true`，或在 3.3 部署中删除显式 `false` 以恢复默认开启状态。
+
+如需在本地开发或受控环境临时关闭 Admin API 或 Console API 鉴权，分别设置：
+
+```properties
+nacos.core.auth.admin.enabled=false
 nacos.core.auth.console.enabled=false
 ```
 
 :::caution
-关闭控制台鉴权后，访问控制台不再需要登录，存在数据泄露和误操作风险。生产环境不要关闭。
+关闭任一鉴权范围都会允许对应范围内原本受保护的请求绕过身份和权限校验，可能造成数据泄露、配置篡改或服务注册污染。生产环境不要关闭 Admin API 或 Console API 鉴权；临时关闭 Client API 鉴权时，应同时限制网络访问、记录责任人与恢复时间，并在客户端凭据就绪后尽快重新开启。
 :::
 
 ## 升级注意事项
 
+- 从 3.0.x～3.2.x 升级到 3.3.x 时，缺少 `nacos.core.auth.enabled` 的配置会从“Client API 鉴权关闭”变为“开启”。未携带用户名、密码或 token 的旧客户端和直接 OpenAPI 调用将被拒绝。升级前应完成用户、角色、权限和客户端凭据准备，详见[升级手册](./upgrading.mdx#212-准备-client-api-默认鉴权)。
 - 从旧版本升级时，如果已经存在管理员用户 `nacos`，Nacos 不会重新要求初始化管理员密码。
 - 如果旧集群仍使用默认或弱密码，升级后请尽快修改。
 - 如果从旧 LDAP 配置升级到 3.2，请确认 LDAP 插件 jar 和 `spring-ldap-core` 依赖都已放入 `plugins/`。

--- a/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
+++ b/src/content/docs/next/zh-cn/manual/admin/system-configurations.md
@@ -225,7 +225,7 @@ Raft 参数通过 `nacos.core.protocol.raft.data.*` 配置。`data` 是当前代
 | 参数名 | 说明 | 默认值 |
 | --- | --- | --- |
 | `nacos.plugin.auth.type` | 启动时选择鉴权插件；`nacos.core.auth.system.type` 是历史 alias。 | `nacos` |
-| `nacos.core.auth.enabled` | 是否开启通用鉴权系统和 Open API 鉴权，包括 Client/Open HTTP API 及 SDK/gRPC 请求。 | `false` |
+| `nacos.core.auth.enabled` | 是否开启通用鉴权系统和 Open API 鉴权，包括 Client/Open HTTP API 及 SDK/gRPC 请求。Nacos 3.3 起默认开启；显式 `false` 仅作为临时兼容覆盖。 | `true` |
 | `nacos.core.auth.admin.enabled` | 是否开启 Admin API scope 鉴权；除 `/v3/admin/*` 外，也包括标记为 `ADMIN_API` 的插件自有端点。 | `true` |
 | `nacos.core.auth.console.enabled` | 是否开启 `/v3/console/*` Console API 和登录鉴权。 | `true` |
 | `nacos.plugin.auth.nacos.caching.enabled` | 是否缓存鉴权信息；`nacos.core.auth.caching.enabled` 是历史 alias。开启后权限变更会有短暂延迟。 | `true` |

--- a/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
+++ b/src/content/docs/next/zh-cn/manual/admin/upgrading.mdx
@@ -44,6 +44,7 @@ Nacos 3.x 服务端与各版本客户端的兼容性如下：
 1. 确认源集群版本受支持，且数据库 schema 已满足目标 3.3.x 版本要求；具体数据库检查和变更见第 2.2 节。
 2. 备份数据库、各节点的 `data`、`conf`、`cluster.conf`，以及自定义插件和配置。
 3. 在预发环境使用生产数据副本演练升级和回滚。
+4. 按第 2.1.2 节盘点 Client API 调用方并完成鉴权迁移；不要等到首个 3.3 节点启动后才开始补客户端凭据。
 
 <a id="217-配置中心兼容迁移移除-nacos-330"></a>
 
@@ -52,6 +53,41 @@ Nacos 3.x 服务端与各版本客户端的兼容性如下：
 Nacos 3.3 已移除配置中心兼容迁移逻辑，不再支持从 2.x 直接平滑升级。若从 2.x 直接升级到 3.3.x，将无法查询之前保存在默认 namespace 中的配置。
 
 升级前请确认业务未使用默认 namespace 中的配置数据。若使用过或无法确认，请先升级到 3.0.x～3.2.x，确认默认 namespace 配置可正常查询后，再升级到 3.3.x。
+
+#### 2.1.2. 准备 Client API 默认鉴权
+
+Nacos 3.3 将 Client API 鉴权改为默认开启。只改变 Client 范围的缺省值，三个鉴权范围仍相互独立：
+
+| 配置项 | 请求范围 | 3.0.x～3.2.x 缺省值 | 3.3.x 缺省值 |
+| --- | --- | --- | --- |
+| `nacos.core.auth.enabled` | Client/Open API、Java SDK 和 gRPC 请求 | `false` | `true` |
+| `nacos.core.auth.admin.enabled` | `/v3/admin/*` Admin API | `true` | `true` |
+| `nacos.core.auth.console.enabled` | `/v3/console/*` Console API 和控制台登录 | `true` | `true` |
+
+因此，没有显式配置 `nacos.core.auth.enabled` 的集群升级到 3.3 后，原本未携带身份的配置发布/查询、服务注册/发现/订阅以及其他受保护的 Client HTTP、SDK 或 gRPC 请求会被拒绝。旧客户端本身不一定不兼容；风险来自调用方没有配置受支持的用户名、密码、token 或所选鉴权插件要求的其他身份材料。Admin API 和 Console API 的默认行为不因本次变更改变。明确标记为公开、首次初始化或健康检查的端点仍按各自规则处理；`/v3/auth/*` 是鉴权插件 API，也不能仅按 URL 归入 Client 范围。
+
+正式升级前应完成：
+
+1. 盘点所有直接 OpenAPI、SDK、网关、自动化任务和旁路脚本，确认它们访问的资源与所需读写动作。
+2. 确认鉴权插件类型。使用默认 `nacos` 插件时，准备部署独有的 token secret 和 Server identity；token secret 必须是有效 Base64，解码后不少于 32 字节，同一集群各节点的 token secret 与 identity 必须一致。
+3. 通过已有的受保护管理入口初始化或确认管理员，并为应用创建独立用户、角色和最小权限。不要把全局管理员凭据分发给业务客户端。
+4. 在升级前把用户名/密码、token 或所选插件要求的凭据配置到客户端。SDK 配置方式见[客户端鉴权](../user/auth.mdx)。
+5. 在预发环境同时验证正常读写、无身份、错误身份、无权限和资源边界场景，并确认每个集群节点的三个开关有效值一致。
+
+如果无法在升级窗口前完成全部客户端改造，可以临时显式关闭 Client API 鉴权，但必须保留 token secret、Server identity、用户、角色和权限，以便后续重新开启：
+
+| 部署方式 | 临时显式关闭方式 |
+| --- | --- |
+| 原生发行包 | 在每个节点的 `conf/application.properties` 设置 `nacos.core.auth.enabled=false`。该项支持运行时刷新，但文件刷新是节点本地行为，必须逐节点应用并核对。 |
+| Docker | 设置 `NACOS_AUTH_ENABLE=false`。未设置该变量时，3.3 镜像继承默认开启；显式 `true` 或 `false` 均会覆盖镜像默认值。 |
+| Helm | 设置 `nacos.auth.enabled=false`，例如 `helm upgrade ${release_name} ./ --reuse-values --set nacos.auth.enabled=false`。该字段为 `null`/`true`/`false` 三态：`null` 表示不写入 `NACOS_AUTH_ENABLE`，继承所选镜像默认值。 |
+| Operator | 在 Nacos CR 中设置 `spec.certification.enabled: false`。该字段同样为 `null`/`true`/`false` 三态：`null` 或省略表示不写入 `NACOS_AUTH_ENABLE`，继承所选镜像默认值。 |
+
+Helm 和 Operator 的该字段都只控制 Client API 鉴权，不改变 Admin API 或 Console API。使用 Helm 时，生产环境优先通过 `nacos.auth.existingSecret` 管理 token 和 Server identity；从 chart 1.0.0 或更早版本首次升级且仍使用旧内联凭据时，应使用 `--reuse-values` 保留凭据，或先创建外部 Secret。不要在 values、CR、Compose 文件或代码仓库中写入固定生产凭据。
+
+:::caution[临时关闭会扩大未授权访问面]
+显式 `false` 仅用于有明确期限的升级兼容窗口。期间应把 Nacos 限制在可信网络内，收紧入口和调用来源，并记录责任人与恢复时间。客户端凭据和权限验证完成后，在所有节点把值改为 `true`；也可以在确认使用 3.3 及以上镜像后，将 Docker 变量、`nacos.auth.enabled` 或 `spec.certification.enabled` 恢复为 `null`/省略，以重新继承默认开启行为。
+:::
 
 ### 2.2. 应用数据库变更
 
@@ -326,7 +362,7 @@ Nacos 使用 Namespace `_nacos_internal_`、group `nacos_internal` 保存迁移�
 升级完成后至少验证：
 
 1. 所有节点版本、集群成员列表和健康状态正确，日志中没有 schema、插件加载或配置 alias 错误。
-2. 配置发布/查询、服务注册/发现、控制台登录、Client API 和 Admin API 的鉴权行为符合升级前设置。
+2. 配置发布/查询、服务注册/发现和控制台登录正常；Client API、Admin API、Console API 的有效开关分别符合计划。若 Client API 已开启，验证合法客户端成功，无身份、错误身份和越权请求被拒绝；若仍临时关闭，确认网络限制和重新开启时间已落实。
 3. 从 2.x 经中间版本升级的部署，确认默认 namespace 配置仍可正常查询。
 4. 在插件管理页面或 API 中检查插件 ID、状态、配置来源及需要重启的字段；确认没有意外启用的实现。
 5. 开启 AI Resource Search 时，确认三张检索关系表已创建、索引任务能够收敛；启用 PostgreSQL 向量插件时还要确认 pgvector schema 和数据源连通性。


### PR DESCRIPTION
## What is the purpose of the change

Align the `next` operator and upgrade documentation with the Nacos 3.3 change that enables Client API authentication by default.

Related issue: https://github.com/alibaba/nacos/issues/15357

Implementation references:

- https://github.com/alibaba/nacos/pull/15824
- https://github.com/nacos-group/nacos-docker/pull/522
- https://github.com/nacos-group/nacos-k8s/pull/529
- https://github.com/nacos-group/nacos-k8s/pull/530

## Brief changelog

- Document the independent Client, Admin, and Console auth scopes and the Nacos 3.3 missing-value defaults.
- Add a production upgrade checklist covering caller inventory, credentials, least-privilege permissions, staged negative tests, and cluster-wide verification.
- Explain native, Docker, Helm, and Operator compatibility overrides, including tri-state inheritance and Secret migration behavior.
- Add default-plugin credential prerequisites and remove fixed token/default-password examples from the compatibility guide.
- Keep English and Chinese `next` documentation semantically aligned.

## Verification

- `npm run build` — passed; 3,794 pages generated.
- `git diff --check` — passed.
- Verified the rendered English and Chinese upgrade anchors and links, with one target per locale.
- Confirmed that no generated build or contributor-data files are included.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] The change is tracked by the cross-repository Nacos issue linked above.
- [x] The pull request and commit have meaningful subject lines.
- [x] The description explains what, how, and why.
- [x] Tested locally with `npm run build`.
- [x] No files under the build directory are added.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
