### PR TITLE
docs: fix bean name typo in MCP auto-register manual (#1128)

### DIFF
--- a/src/content/docs/latest/zh-cn/manual/user/ai/mcp-auto-register.md
+++ b/src/content/docs/latest/zh-cn/manual/user/ai/mcp-auto-register.md
@@ -199,7 +199,7 @@ or
 ```
 或者使用 提供的ToolCallbackProvider
 ```java
-@Qualifier("loadbalancedSyncMcpToolCallbacks") ToolCallbackProvider tools
+@Qualifier("loadbalancedMcpSyncToolCallbacks") ToolCallbackProvider tools
 ```
 or
 ```java

--- a/src/content/docs/next/zh-cn/manual/user/ai/mcp-auto-register.md
+++ b/src/content/docs/next/zh-cn/manual/user/ai/mcp-auto-register.md
@@ -199,7 +199,7 @@ or
 ```
 或者使用 提供的ToolCallbackProvider
 ```java
-@Qualifier("loadbalancedSyncMcpToolCallbacks") ToolCallbackProvider tools
+@Qualifier("loadbalancedMcpSyncToolCallbacks") ToolCallbackProvider tools
 ```
 or
 ```java

--- a/src/content/docs/v3.0/en/manual/user/ai/mcp-auto-register.md
+++ b/src/content/docs/v3.0/en/manual/user/ai/mcp-auto-register.md
@@ -204,7 +204,7 @@ private List<LoadbalancedMcpAsyncClient> loadbalancedMcpAsyncClients;
 ```
 Or Use ToolCallbackProvider
 ```java
-@Qualifier("loadbalancedSyncMcpToolCallbacks") ToolCallbackProvider tools
+@Qualifier("loadbalancedMcpSyncToolCallbacks") ToolCallbackProvider tools
 ```
 or
 ```java

--- a/src/content/docs/v3.0/zh-cn/manual/user/ai/mcp-auto-register.md
+++ b/src/content/docs/v3.0/zh-cn/manual/user/ai/mcp-auto-register.md
@@ -199,7 +199,7 @@ or
 ```
 或者使用 提供的ToolCallbackProvider
 ```java
-@Qualifier("loadbalancedSyncMcpToolCallbacks") ToolCallbackProvider tools
+@Qualifier("loadbalancedMcpSyncToolCallbacks") ToolCallbackProvider tools
 ```
 or
 ```java

--- a/src/content/docs/v3.1/zh-cn/manual/user/ai/mcp-auto-register.md
+++ b/src/content/docs/v3.1/zh-cn/manual/user/ai/mcp-auto-register.md
@@ -199,7 +199,7 @@ or
 ```
 或者使用 提供的ToolCallbackProvider
 ```java
-@Qualifier("loadbalancedSyncMcpToolCallbacks") ToolCallbackProvider tools
+@Qualifier("loadbalancedMcpSyncToolCallbacks") ToolCallbackProvider tools
 ```
 or
 ```java


### PR DESCRIPTION
## What
Fixes the bean name typo reported in #1128: `loadbalancedSyncMcpToolCallbacks` → `loadbalancedMcpSyncToolCallbacks`.

## Why
The SYNC `ToolCallbackProvider` bean is registered as `loadbalancedMcpSyncToolCallbacks` in spring-ai-alibaba (`Nacos2McpToolCallbackAutoConfiguration`, `@Bean(name = "loadbalancedMcpSyncToolCallbacks")`), and the ASYNC variant documented on the adjacent line (`loadbalancedMcpAsyncToolCallbacks`) already follows the correct word order. The transposed name in the manual breaks `@Qualifier` wiring for anyone who copies the snippet.

## Scope
The typo appears in five copies of the manual and is fixed in all of them:
- `latest/zh-cn`, `next/zh-cn`, `v3.0/zh-cn`, `v3.1/zh-cn`, `v3.0/en`

(`latest/en` / `next/en` do not carry this snippet.)

Fixes #1128